### PR TITLE
Adds a reserved byte between UUID and TLV

### DIFF
--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -125,6 +125,7 @@ struct _h26x_nalu_t {
   bool is_hashable;  // Should be hashed
   const uint8_t *payload;  // Points to the payload (including UUID for SEI-nalus)
   size_t payload_size;  // Parsed payload size
+  uint8_t reserved_byte;  // First byte of SEI payload
   const uint8_t *tlv_start_in_nalu_data;  // Points to beginning of the TLV data in the |nalu_data|
   const uint8_t *tlv_data;  // Points to the TLV data after removing emulation prevention bytes
   size_t tlv_size;  // Total size of the |tlv_data|

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -157,6 +157,7 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload)
 
     payload_size = document_size + gop_info_size;
     payload_size += UUID_LEN;  // UUID
+    payload_size += 1;  // One byte for reserved data.
     // Compute total SEI NALU data size.
     sei_buffer_size += self->codec == SV_CODEC_H264 ? 6 : 7;  // NALU header
     sei_buffer_size += payload_size / 256 + 1;  // Size field
@@ -202,6 +203,9 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload)
 
     // User data unregistered UUID field
     h26x_set_nal_uuid_type(self, &payload_ptr, UUID_TYPE_SIGNED_VIDEO);
+
+    // Add reserved byte(s).
+    *payload_ptr++ = SV_RESERVED_BYTE;
 
     size_t written_size =
         tlv_list_encode_or_get_size(self, document_encoders, num_doc_encoders, payload_ptr);

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -60,6 +60,7 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 #endif
 
 #define UUID_LEN 16
+#define SV_RESERVED_BYTE 0x80  // First bit should be marked as 1
 #define MAX_NALUS_TO_PREPEND 5  // This means that there is room to prepend 4 additional nalus.
 #define LAST_TWO_BYTES_INIT_VALUE 0x0101  // Anything but 0x00 are proper inits
 #define STOP_BYTE_VALUE 0x80


### PR DESCRIPTION
The reserved byte has a starting bit, which is checked when parsing
the SEI.
