### PR TITLE
Adds set_hash_list_size(...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ meson install -C build
 ```
 
 ## Configure, build and run unittests
-To run the tests, compile the library with the meson option `test-settings` set to `true`. This will apply some settings needed for the tests to run properly. Hence, to build and run the unittests call
+Nothing extra is needed. Hence, to build and run the unittests call
 ```
-meson -Dtest-settings=true . build
+meson . build
 ninja -C build test
 ```
 Alternatively, you can run the script [tests/test_checks.sh](./tests/test_checks.sh) and the unittests will run both with and without debug prints.

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -190,6 +190,7 @@ struct _gop_info_t {
   uint8_t *gop_hash;  // Pointing to the memory slot of the gop_hash in |hashes|.
   uint8_t hash_list[HASH_LIST_SIZE];  // Pointer to the list of hashes used for
   // SV_AUTHENTICITY_LEVEL_FRAME.
+  size_t hash_list_size;  // The allowed size of the |hash_list|. This can be less than allocated.
   int list_idx;  // Pointing to next available slot in the |hash_list|. If something has gone wrong,
   // like exceeding available memory, |list_idx| = -1.
   uint8_t gop_hash_init;  // The initialization value for the |gop_hash|.
@@ -226,6 +227,11 @@ struct_member_memory_allocated_and_copy(void **member_ptr,
 
 void
 gop_info_reset(gop_info_t *gop_info);
+
+/* Sets the allowed size of |hash_list|.
+ * Note that this can be different from what is allocated. */
+svi_rc
+set_hash_list_size(gop_info_t *gop_info, size_t hash_list_size);
 
 /* Resets the gop_hash. */
 svi_rc

--- a/meson.build
+++ b/meson.build
@@ -9,13 +9,6 @@ cc = meson.get_compiler('c')
 
 check_dep = dependency('check', required : false)
 
-if get_option('test-settings')
-  if not check_dep.found()
-    message('libcheck is not installed')
-  endif
-  # Set MAX_GOP_LENGTH to 10 in tests to avoid long streams
-  add_global_arguments('-DMAX_GOP_LENGTH=10', language : 'c')
-endif
 if get_option('debugprints')
   add_global_arguments('-DSIGNED_VIDEO_DEBUG', language : 'c')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,3 @@ option('debugprints',
   type : 'boolean',
   value : false,
   description : 'Run with SIGNED_VIDEO_DEBUG flag')
-option('test-settings',
-  type : 'boolean',
-  value : false,
-  description : 'Apply settings for check tests')

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ The check tests are built with the unthreaded signing plugin.
 ## Build and run check tests
 The tests can be built with meson/ninja from the top-level as
 ```
-meson -Dtest-settings=true . build
+meson . build
 ninja -C build test
 ```
 Alternatively, you can run the script `test_checks.sh` from either this folder or the top-level. The script builds and runs the tests both with and without debug prints.

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -85,7 +85,7 @@ pull_nalus(signed_video_t *sv, nalu_list_item_t *item)
  * Takes a string of NALU characters ('I', 'i', 'P', 'p', 'S', 'X') as input and generates NALU
  * data for these. Then adds these NALUs to the input session. The generated sei-nalus are added to
  * the stream. */
-static nalu_list_t *
+nalu_list_t *
 create_signed_nalus_with_sv(signed_video_t *sv, const char *str)
 {
   SignedVideoReturnCode rc = SV_OK;

--- a/tests/check/signed_video_helpers.h
+++ b/tests/check/signed_video_helpers.h
@@ -78,6 +78,14 @@ nalu_list_t *
 create_signed_nalus_recurrence(const char *str, struct sv_setting settings,
     int recurrence);
 
+/* Generates a signed video stream of NALUs for a user-owned signed_video_t session.
+ *
+ * Takes a string of NALU characters ('I', 'i', 'P', 'p', 'S', 'X') as input and generates NALU
+ * data for these. Then adds these NALUs to the input session. The generated sei-nalus are added to
+ * the stream. */
+nalu_list_t *
+create_signed_nalus_with_sv(signed_video_t *sv, const char *str);
+
 /* Removes the NALU list items with position |item_number| from the |list|. The item is, after a
  * check against the expected |str|, then freed. */
 void

--- a/tests/test_checks.sh
+++ b/tests/test_checks.sh
@@ -7,12 +7,12 @@ fi
 
 # Remove any existing build directory
 rm -rf build
-meson -Dtest-settings=true -Dbuildtype=debug . build
+meson -Dbuildtype=debug . build
 ninja -C build test
 
 echo ""
 echo "=== Now Runs check tests with SIGNED_VIDEO_DEBUG ==="
 echo ""
 
-meson -Ddebugprints=true -Dtest-settings=true -Dbuildtype=debug --reconfigure . build
+meson -Ddebugprints=true -Dbuildtype=debug --reconfigure . build
 ninja -C build test


### PR DESCRIPTION
This internal function is used to set the size of the |hash_list|.
This comes in handy for check tests to test what happens when the
limit is hit.

Further, by setting the size of the |hash_list| in the tests, the
test-settings meson option is removed since there is no longer a need
to pass in MAX_GOP_LENGTH as define at compile time.

The test_checks.sh script and READMEs have been updated accordingly.
