### PR TITLE
Detect change of public key

### DIFF
--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -22,24 +22,27 @@ signedvideoframework_sources = files(
   'signed_video_tlv.h',
 )
 
-# Until plugin management in place the plugin file(s) are added to the sources.
+# Until plugin management is in place the plugin file(s) are added to the sources.
 signedvideoframework_sources += plugin_sources
 
-openssl_dep = dependency('openssl', required: true)
+openssl_dep = dependency('openssl', required : true)
 
-install_headers(signedvideoframework_public_headers,
-  install_dir : '@0@/signed-video-framework'.format(get_option('includedir')))
+install_headers(
+    signedvideoframework_public_headers,
+    install_dir : '@0@/signed-video-framework'.format(get_option('includedir')))
 
 signedvideoframework_deps = [ openssl_dep ]
 
-signedvideoframework = shared_library('signed-video-framework',
-  signedvideoframework_sources,
-  dependencies : signedvideoframework_deps,
-  install : true,
+signedvideoframework = shared_library(
+    'signed-video-framework',
+    signedvideoframework_sources,
+    version : meson.project_version(),
+    dependencies : signedvideoframework_deps,
+    install : true,
 )
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(
-    name: 'signed-video-framework',
-    description: 'Signed Video Framework',
+    name : 'signed-video-framework',
+    description : 'Signed Video Framework',
 )

--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -43,6 +43,7 @@ signedvideoframework = shared_library(
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(
+    signedvideoframework,
     name : 'signed-video-framework',
     description : 'Signed Video Framework',
 )

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -741,6 +741,7 @@ maybe_validate_gop(signed_video_t *self, h26x_nalu_t *nalu)
   latest->number_of_expected_picture_nalus = -1;
   latest->number_of_received_picture_nalus = -1;
   latest->number_of_pending_picture_nalus = -1;
+  latest->public_key_has_changed = false;
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -567,6 +567,7 @@ validate_authenticity(signed_video_t *self)
     num_expected_nalus = -1;
     num_received_nalus = -1;
   }
+  if (latest->public_key_has_changed) valid = SV_AUTH_RESULT_NOT_OK;
 
   // Update |latest_validation| with the validation result.
   latest->authenticity = valid;

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -46,7 +46,7 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "R1.0.2"
+#define SIGNED_VIDEO_VERSION "R1.0.3"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -46,7 +46,7 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "R1.0.1"
+#define SIGNED_VIDEO_VERSION "R1.0.2"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -190,14 +190,12 @@ openssl_verify_hash(const signature_info_t *signature_info, int *verified_result
   return svi_rc_to_signed_video_rc(status);
 }
 
-/* Creates a RSA private key and stores it as a PEM file in the designated location. */
+/* Creates a RSA private key and stores it as a PEM file in the designated location. Existing key
+ * will be overwritten. */
 static svi_rc
 create_rsa_private_key(const key_paths_t *key_paths)
 {
   if (!key_paths) return SVI_INVALID_PARAMETER;
-
-  // Return directly if private key file already exists
-  if (access(key_paths->full_path_to_private_key, F_OK | R_OK) == 0) return SVI_OK;
 
   EVP_PKEY *pkey = NULL;
   BIGNUM *bn = NULL;
@@ -242,14 +240,12 @@ create_rsa_private_key(const key_paths_t *key_paths)
   return status;
 }
 
-/* Creates a ECDSA private key and stores it as a PEM file in the designated location. */
+/* Creates a ECDSA private key and stores it as a PEM file in the designated location. Existing key
+ * will be overwritten. */
 static svi_rc
 create_ecdsa_private_key(const key_paths_t *key_paths)
 {
   if (!key_paths) return SVI_INVALID_PARAMETER;
-
-  // Return directly if private key file already exists
-  if (access(key_paths->full_path_to_private_key, F_OK | R_OK) == 0) return SVI_OK;
 
   EC_KEY *ec_key = NULL;
   EVP_PKEY *pkey = NULL;

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -542,7 +542,7 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
     SVI_THROW(sv_rc_to_svi_rc(openssl_key_memory_allocated(
         &signature_info->public_key, &signature_info->public_key_size, pubkey_size)));
 
-    if(memcmp(data_ptr, signature_info->public_key, pubkey_size) != 0 && self->gop_state.has_public_key) {
+    if (memcmp(data_ptr, signature_info->public_key, pubkey_size) && self->gop_state.has_public_key) {
       self->latest_validation->public_key_has_changed = true;
     }
     memcpy(signature_info->public_key, data_ptr, pubkey_size);

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -542,6 +542,9 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
     SVI_THROW(sv_rc_to_svi_rc(openssl_key_memory_allocated(
         &signature_info->public_key, &signature_info->public_key_size, pubkey_size)));
 
+    if(memcmp(data_ptr, signature_info->public_key, pubkey_size) != 0 && self->gop_state.has_public_key) {
+      self->latest_validation->public_key_has_changed = true;
+    }
     memcpy(signature_info->public_key, data_ptr, pubkey_size);
     self->gop_state.has_public_key = true;
     data_ptr += pubkey_size;

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '0.0.0',
+  version : '1.0.1',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '1.0.2',
+  version : '1.0.3',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '1.0.1',
+  version : '1.0.2',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -881,9 +881,9 @@ START_TEST(detect_change_of_public_key)
 
   // The list will be validated successfully up to the third SEI (G) which has the new Public key.
   //
-  //   GI      -> .P (valid, 1 pending, public_key_has_changed = false)
-  //   IPPGI   -> ....P (valid, 1 pending, public_key_has_changed = false)
-  //   IPPG*I  -> NNN.P (invalid, 1 pending, public_key_has_changed = true, -3 missing)
+  //   GI      -> .P     (valid, 1 pending, public_key_has_changed = false)
+  //   IPPGI   -> ....P  (valid, 1 pending, public_key_has_changed = false)
+  //   IPPG*I  -> NNN.P  (invalid, 1 pending, public_key_has_changed = true, -3 missing)
   //   IPPPG*I -> N....P (invalid, 1 pending, public_key_has_changed = false)
   // where G* has the new Public key. Note that we get -3 missing since we receive 3 more than what
   // is expected according to G*.

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -872,7 +872,7 @@ START_TEST(detect_change_of_public_key)
   nalu_list_check_str(list, "GIPPGIPP");
 
   // Generate another GOP from scratch
-  // This will get a new public key
+  // This will generate a new private key, hence transmit a different public key.
   nalu_list_t *list_with_new_public_key = create_signed_nalus("IPPPI", settings[_i]);
   nalu_list_check_str(list_with_new_public_key, "GIPPPGI");
 

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -178,6 +178,7 @@ validate_nalu_list(signed_video_t *sv, nalu_list_t *list,
       default:
         break;
       }
+      ck_assert(!latest->public_key_has_changed);
       // Check if product_info has been received and set correctly.
       if (latest->authenticity != SV_AUTH_RESULT_NOT_SIGNED) {
         ck_assert_int_eq(strcmp(auth_report->product_info.hardware_id, HW_ID), 0);


### PR DESCRIPTION
A video can only be signed by one Private key, hence only validated by
one Public key. If a second Public key is detected in the stream or set
by the user, any further validation should be indicated as invalid.
