### PR TITLE
Fixes bug in pkgconfig

### DIFF
--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -22,24 +22,27 @@ signedvideoframework_sources = files(
   'signed_video_tlv.h',
 )
 
-# Until plugin management in place the plugin file(s) are added to the sources.
+# Until plugin management is in place the plugin file(s) are added to the sources.
 signedvideoframework_sources += plugin_sources
 
-openssl_dep = dependency('openssl', required: true)
+openssl_dep = dependency('openssl', required : true)
 
-install_headers(signedvideoframework_public_headers,
-  install_dir : '@0@/signed-video-framework'.format(get_option('includedir')))
+install_headers(
+    signedvideoframework_public_headers,
+    install_dir : '@0@/signed-video-framework'.format(get_option('includedir')))
 
 signedvideoframework_deps = [ openssl_dep ]
 
-signedvideoframework = shared_library('signed-video-framework',
-  signedvideoframework_sources,
-  dependencies : signedvideoframework_deps,
-  install : true,
+signedvideoframework = shared_library(
+    'signed-video-framework',
+    signedvideoframework_sources,
+    version : meson.project_version(),
+    dependencies : signedvideoframework_deps,
+    install : true,
 )
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(
-    name: 'signed-video-framework',
-    description: 'Signed Video Framework',
+    name : 'signed-video-framework',
+    description : 'Signed Video Framework',
 )

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '0.0.0',
+  version : '1.0.1',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
The share library signedvideoframework was never added to the config.
Further, the shared library is now versioned.
Also, minor style changes made to lib/src/meson.build.
