### PR TITLE
Splits validation status 'U' into 'U' and '_'

### DIFF
--- a/lib/src/includes/signed_video_auth.h
+++ b/lib/src/includes/signed_video_auth.h
@@ -75,9 +75,10 @@ typedef struct {
   // NALU's authenticity individually. Each NALU is marked by one of these characters:
   // 'P' : Pending validation. This is the initial value. The NALU has been registered and waiting
   //       for authenticity validation.
-  // 'U' : The NALU has an unknown authenticity. This occurs for NALUs that are not used in signing
-  //       the video. A NALU with an authenticity status marked as 'U' can be considered authentic
-  //       since it has no impact on the video.
+  // 'U' : The NALU has an unknown authenticity. This occurs if the NALU could not be parsed, or if
+  //     : the SEI is associated with NALUs not part of the validating segment.
+  // '_' : The NALU is ignored and therefore not part of the signature. The NALU has no impact on
+  //       the video and can be considered authentic.
   // '.' : The NALU has been validated as authentic.
   // 'N' : The NALU has been validated as not authentic.
   // 'M' : The validation has detected one or more missing NALUs at this position.
@@ -85,12 +86,14 @@ typedef struct {
   //       invalid NALU.
 
   // Example:
-  // Two consecutive |validation_str|. Five NALUs were added between them and the first two of them
-  // could successfully be validated, whereas the last three are still pending. The previous
-  // validation left three pending and one unknown NALU for the next validation. These were
-  // successfully validate, and the unknown is still 'U'.
-  //   ...U..PPUP
-  //         ..U...PPP
+  // Two consecutive |validation_str|. After 10 NALUs a authentication result was received
+  // generating the first string. Left for next validation are the three pending NALUs (P's) and
+  // the ignored NALU ('_'). Five new NALUs were added before the authentication result was
+  // updated. A new string has been generated (second line) and now the pending NALUs have been
+  // validated successfully (the P's have been turned into '.'). Note that the ignored NALU ('_')
+  // is still ignored.
+  //   ..._..PP_P
+  //         .._...PPP
 } signed_video_latest_validation_t;
 
 /**

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -35,6 +35,7 @@ typedef enum {
   NALU_TYPE_I = 2,
   NALU_TYPE_P = 3,
   NALU_TYPE_PS = 4,  // Parameter Set: PPS/SPS/VPS
+  NALU_TYPE_OTHER = 5,
 } SignedVideoFrameType;
 
 typedef enum {
@@ -73,10 +74,10 @@ struct _h26x_nalu_list_item_t {
   char validation_status;  // The authentication status which can take on the following characters:
   // 'P' : Pending validation. This is the initial value. The NALU has been registered and waiting
   //       for validating the authenticity.
-  // 'U' : The NALU has an unknown authenticity. This occurs for NALUs that are not used in signing
-  //       the video, or an initial SEI representing a GOP not present in the video. A NALU with an
-  //       authenticity status marked as U can be considered authentic since it has no impact on the
-  //       video.
+  // 'U' : The NALU has an unknown authenticity. This occurs if the NALU could not be parsed, or if
+  //     : the SEI is associated with NALUs not part of the validating segment.
+  // '_' : The NALU is ignored and therefore not part of the signature. The NALU has no impact on
+  //       the video and can be considered authentic.
   // '.' : The NALU has been validated authentic.
   // 'N' : The NALU has been validated not authentic.
   // 'M' : The validation has detected one or more missing NALUs at this position. Note that

--- a/lib/src/signed_video_h26x_nalu_list.c
+++ b/lib/src/signed_video_h26x_nalu_list.c
@@ -72,7 +72,7 @@ get_validation_status_from_nalu(const h26x_nalu_t *nalu)
   if (nalu->is_hashable) {
     return 'P';
   } else {
-    return 'U';
+    return '_';
   }
 }
 


### PR DESCRIPTION
'U' now marks an unknown authenticity, for example when a NALU header
is broken.
'_' marks an ignored NALU, which is not hashed and therefore not part
of the signature.

A new SignedVideoFrameType (NALU_TYPE_OTHER) for 'uninteresting' NALUs.
