### PR TITLE
Refactors tlv_find_tag

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -792,9 +792,9 @@ maybe_validate_gop(signed_video_t *self, h26x_nalu_t *nalu)
  * In this function we update the h26x_nalu_t member |hashable_data_size| w.r.t. that. The pointer
  * to the start is still the same. */
 static void
-update_hashable_data(signed_video_t *self, h26x_nalu_t *nalu)
+update_hashable_data(h26x_nalu_t *nalu)
 {
-  assert(self && nalu && (nalu->is_valid > 0));
+  assert(nalu && (nalu->is_valid > 0));
   if (!nalu->is_hashable || !nalu->is_gop_sei) return;
 
   // This is a Signed Video generated NALU of type SEI. As payload it holds TLV data where the last
@@ -803,7 +803,7 @@ update_hashable_data(signed_video_t *self, h26x_nalu_t *nalu)
   // emulation prevention bytes) coresponding to that tag. This is done by scanning the TLV for that
   // tag.
   const uint8_t *signature_tag_ptr =
-      tlv_find_tag(self, nalu->tlv_start_in_nalu_data, nalu->tlv_size, SIGNATURE_TAG, true);
+      tlv_find_tag(nalu->tlv_start_in_nalu_data, nalu->tlv_size, SIGNATURE_TAG, true);
 
   if (signature_tag_ptr) nalu->hashable_data_size = signature_tag_ptr - nalu->hashable_data;
 }
@@ -816,7 +816,7 @@ register_nalu(signed_video_t *self, h26x_nalu_t *nalu)
 
   if (nalu->is_valid == 0) return SVI_OK;
 
-  update_hashable_data(self, nalu);
+  update_hashable_data(nalu);
   return hash_and_add_for_auth(self, nalu);
 }
 

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -542,7 +542,8 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
     SVI_THROW(sv_rc_to_svi_rc(openssl_key_memory_allocated(
         &signature_info->public_key, &signature_info->public_key_size, pubkey_size)));
 
-    if (memcmp(data_ptr, signature_info->public_key, pubkey_size) && self->gop_state.has_public_key) {
+    if (memcmp(data_ptr, signature_info->public_key, pubkey_size) &&
+        self->gop_state.has_public_key) {
       self->latest_validation->public_key_has_changed = true;
     }
     memcpy(signature_info->public_key, data_ptr, pubkey_size);
@@ -871,16 +872,12 @@ tlv_decode(signed_video_t *self, const uint8_t *data, size_t data_size)
 }
 
 const uint8_t *
-tlv_find_tag(signed_video_t *self,
-    const uint8_t *tlv_data,
-    size_t tlv_data_size,
-    sv_tlv_tag_t tag,
-    bool with_ep)
+tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bool with_ep)
 {
   const uint8_t *tlv_data_ptr = tlv_data;
   const uint8_t *latest_tag_location = NULL;
 
-  if (!self || !tlv_data || tlv_data_size == 0) return 0;
+  if (!tlv_data || tlv_data_size == 0) return 0;
 
   uint16_t last_two_bytes = LAST_TWO_BYTES_INIT_VALUE;
   while (tlv_data_ptr < tlv_data + tlv_data_size) {

--- a/lib/src/signed_video_tlv.h
+++ b/lib/src/signed_video_tlv.h
@@ -87,7 +87,6 @@ tlv_decode(signed_video_t *signed_video, const uint8_t *data, size_t data_size);
  * there are new tags, but never decodes it. The function can handle data both with and without
  * emulation prevention bytes.
  *
- * @param signed_video Pointer to the signed_video_t session.
  * @param tlv_data Pointer to the TLV data to scan.
  * @param tlv_data_size Size of the TLV data.
  * @param tag The tag to search for and when detected returns its location.
@@ -96,11 +95,7 @@ tlv_decode(signed_video_t *signed_video, const uint8_t *data, size_t data_size);
  * @returns A pointer to the location of the tag to scan for. Returns NULL if the tag was not found.
  */
 const uint8_t *
-tlv_find_tag(signed_video_t *signed_video,
-    const uint8_t *tlv_data,
-    size_t tlv_data_size,
-    sv_tlv_tag_t tag,
-    bool with_ep);
+tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bool with_ep);
 
 /**
  * @brief Reads bits from p into val.


### PR DESCRIPTION
removes input parameter |self| which is not used.
