### PR TITLE
Only generate private_key if neccesary

### DIFF
--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -264,7 +264,7 @@ START_TEST(intact_stream)
   // |settings|; See signed_video_helpers.h.
 
   // Create a list of NALUs given the input string.
-  nalu_list_t *list = create_signed_nalus("IPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPGI");
 
   // One pending NALU per GOP.
@@ -280,7 +280,7 @@ START_TEST(intact_multislice_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IiPpPpIiPpPpIi", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IiPpPpIiPpPpIi", settings[_i]);
   nalu_list_check_str(list, "GIiPpPpGIiPpPpGIi");
 
   // One pending NALU per GOP.
@@ -299,7 +299,7 @@ START_TEST(intact_stream_with_pps_nalu_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("VIPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("VIPPIPPI", settings[_i]);
   nalu_list_check_str(list, "VGIPPGIPPGI");
 
   // One pending NALU per GOP.
@@ -315,7 +315,7 @@ START_TEST(intact_stream_with_pps_bytestream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("VIPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("VIPPIPPI", settings[_i]);
   nalu_list_check_str(list, "VGIPPGIPPGI");
 
   // Pop the PPS NALU and inject it before the I-NALU.
@@ -338,7 +338,7 @@ START_TEST(intact_ms_stream_with_pps_nalu_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i]);
   nalu_list_check_str(list, "VGIiPpPpGIiPpPpGIi");
 
   // One pending NALU per GOP.
@@ -354,7 +354,7 @@ START_TEST(intact_ms_stream_with_pps_bytestream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i]);
   nalu_list_check_str(list, "VGIiPpPpGIiPpPpGIi");
 
   // Pop the PPS NALU and inject it before the I-NALU.
@@ -385,7 +385,7 @@ START_TEST(intact_with_undefined_nalu_in_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPXPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPXPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPXPGIPPGI");
 
   // One pending NALU per GOP.
@@ -401,7 +401,7 @@ START_TEST(intact_with_undefined_multislice_nalu_in_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IiPpXPpIiPpPpIi", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IiPpXPpIiPpPpIi", settings[_i]);
   nalu_list_check_str(list, "GIiPpXPpGIiPpPpGIi");
 
   // One pending NALU per GOP.
@@ -423,7 +423,7 @@ START_TEST(remove_one_p_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   // Item counting starts at 1.  Middle P-NALU in second non-empty GOP: GIPPGIP P PGIPPGI
@@ -454,7 +454,7 @@ START_TEST(interchange_two_p_nalus)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   // Item counting starts at 1.  Middle P-NALU in second non-empty GOP: GIPPGIP P PGIPPGI
@@ -489,7 +489,7 @@ START_TEST(modify_one_p_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   // Second P-NALU in first non-empty GOP: GIP P GIPPPGIPPGI
@@ -514,7 +514,7 @@ START_TEST(modify_one_i_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   // Modify the I-NALU in second non-empty GOP: GIPPG I PPPGIPPGI
@@ -549,7 +549,7 @@ START_TEST(remove_the_g_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGI");
 
   // G-NALU of second non-empty GOP: GIPPGIPP G IPPGIPPGI.
@@ -577,7 +577,7 @@ START_TEST(remove_the_i_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGI");
 
   // I-NALU of third non-empty GOP: GIPPGIPPG I PPGIPPGI.
@@ -606,7 +606,7 @@ START_TEST(remove_the_gi_nalus)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGI");
 
   // G-NALU of second non-empty GOP: GIPPGIPP G IPPGIPPGI.
@@ -640,7 +640,7 @@ START_TEST(sei_arrives_late)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPPGIPPPGIPPPGI");
 
   // Remove the second SEI, that is, number 6 in the list: GIPPP (G) IPPPGIPPPGI.
@@ -667,7 +667,7 @@ END_TEST
 static nalu_list_t *
 generate_delayed_sei_list(struct sv_setting setting)
 {
-  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPPIP", setting, false);
+  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPPIP", setting);
   nalu_list_check_str(list, "GIPPPGIPPPGIPPPGIPPPGIP");
 
   // Remove each SEI in the list and append it 2 items later (which in practice becomes 1 item later
@@ -722,7 +722,7 @@ START_TEST(lost_g_before_late_sei_arrival)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPPGIPPPGIPPPGIPPGI");
 
   // Remove the third SEI, that is, number 11 in the list: GIPPPGIPPP (G) IPPPGIPPGI.
@@ -765,7 +765,7 @@ START_TEST(lost_all_nalus_between_two_seis)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPPGIPPPGIPPPGIPPGI");
 
   // Remove IPPP between the second and third G.
@@ -801,7 +801,7 @@ START_TEST(add_one_sei_nalu_after_signing)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   const uint8_t id = 0;
@@ -835,11 +835,11 @@ START_TEST(camera_reset_on_signing_side)
   // |settings|; See signed_video_helpers.h.
 
   // Generate 2 GOPs
-  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPP");
 
   // Generate another GOP from scratch
-  nalu_list_t *list_after_reset = create_signed_nalus("IPPPI", settings[_i], true);
+  nalu_list_t *list_after_reset = create_signed_nalus_int("IPPPI", settings[_i], true);
   nalu_list_check_str(list_after_reset, "GIPPPGI");
 
   nalu_list_append_and_free(list, list_after_reset);
@@ -868,12 +868,12 @@ START_TEST(detect_change_of_public_key)
   // |settings|; See signed_video_helpers.h.
 
   // Generate 2 GOPs
-  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPP");
 
   // Generate another GOP from scratch
   // This will generate a new private key, hence transmit a different public key.
-  nalu_list_t *list_with_new_public_key = create_signed_nalus("IPPPI", settings[_i], true);
+  nalu_list_t *list_with_new_public_key = create_signed_nalus_int("IPPPI", settings[_i], true);
   nalu_list_check_str(list_with_new_public_key, "GIPPPGI");
 
   nalu_list_append_and_free(list, list_with_new_public_key);
@@ -915,7 +915,7 @@ END_TEST
 static nalu_list_t *
 mimic_au_fast_forward_and_get_list(signed_video_t *sv, struct sv_setting setting)
 {
-  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", setting, false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", setting);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGI");
 
   // Extract the first 3 NALUs from the list. This should be the empty GOP and in the middle of the
@@ -1060,7 +1060,7 @@ END_TEST
 static nalu_list_t *
 mimic_file_export(struct sv_setting setting, bool include_i_nalu_at_end)
 {
-  nalu_list_t *list = create_signed_nalus("VIPPIPPIPPIPPIPP", setting, false);
+  nalu_list_t *list = create_signed_nalus("VIPPIPPIPPIPPIPP", setting);
   nalu_list_check_str(list, "VGIPPGIPPGIPPGIPPGIPP");
 
   // Remove the initial PPS/SPS/VPS NALU to add back later

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -264,7 +264,7 @@ START_TEST(intact_stream)
   // |settings|; See signed_video_helpers.h.
 
   // Create a list of NALUs given the input string.
-  nalu_list_t *list = create_signed_nalus("IPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPPGI");
 
   // One pending NALU per GOP.
@@ -280,7 +280,7 @@ START_TEST(intact_multislice_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IiPpPpIiPpPpIi", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IiPpPpIiPpPpIi", settings[_i], false);
   nalu_list_check_str(list, "GIiPpPpGIiPpPpGIi");
 
   // One pending NALU per GOP.
@@ -299,7 +299,7 @@ START_TEST(intact_stream_with_pps_nalu_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("VIPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("VIPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "VGIPPGIPPGI");
 
   // One pending NALU per GOP.
@@ -315,7 +315,7 @@ START_TEST(intact_stream_with_pps_bytestream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("VIPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("VIPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "VGIPPGIPPGI");
 
   // Pop the PPS NALU and inject it before the I-NALU.
@@ -338,7 +338,7 @@ START_TEST(intact_ms_stream_with_pps_nalu_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i], false);
   nalu_list_check_str(list, "VGIiPpPpGIiPpPpGIi");
 
   // One pending NALU per GOP.
@@ -354,7 +354,7 @@ START_TEST(intact_ms_stream_with_pps_bytestream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i], false);
   nalu_list_check_str(list, "VGIiPpPpGIiPpPpGIi");
 
   // Pop the PPS NALU and inject it before the I-NALU.
@@ -385,7 +385,7 @@ START_TEST(intact_with_undefined_nalu_in_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPXPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPXPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPXPGIPPGI");
 
   // One pending NALU per GOP.
@@ -401,7 +401,7 @@ START_TEST(intact_with_undefined_multislice_nalu_in_stream)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IiPpXPpIiPpPpIi", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IiPpXPpIiPpPpIi", settings[_i], false);
   nalu_list_check_str(list, "GIiPpXPpGIiPpPpGIi");
 
   // One pending NALU per GOP.
@@ -423,7 +423,7 @@ START_TEST(remove_one_p_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   // Item counting starts at 1.  Middle P-NALU in second non-empty GOP: GIPPGIP P PGIPPGI
@@ -454,7 +454,7 @@ START_TEST(interchange_two_p_nalus)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   // Item counting starts at 1.  Middle P-NALU in second non-empty GOP: GIPPGIP P PGIPPGI
@@ -489,7 +489,7 @@ START_TEST(modify_one_p_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   // Second P-NALU in first non-empty GOP: GIP P GIPPPGIPPGI
@@ -514,7 +514,7 @@ START_TEST(modify_one_i_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   // Modify the I-NALU in second non-empty GOP: GIPPG I PPPGIPPGI
@@ -549,7 +549,7 @@ START_TEST(remove_the_g_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGI");
 
   // G-NALU of second non-empty GOP: GIPPGIPP G IPPGIPPGI.
@@ -577,7 +577,7 @@ START_TEST(remove_the_i_nalu)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGI");
 
   // I-NALU of third non-empty GOP: GIPPGIPPG I PPGIPPGI.
@@ -606,7 +606,7 @@ START_TEST(remove_the_gi_nalus)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGI");
 
   // G-NALU of second non-empty GOP: GIPPGIPP G IPPGIPPGI.
@@ -640,7 +640,7 @@ START_TEST(sei_arrives_late)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPPGIPPPGIPPPGI");
 
   // Remove the second SEI, that is, number 6 in the list: GIPPP (G) IPPPGIPPPGI.
@@ -667,7 +667,7 @@ END_TEST
 static nalu_list_t *
 generate_delayed_sei_list(struct sv_setting setting)
 {
-  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPPIP", setting);
+  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPPIP", setting, false);
   nalu_list_check_str(list, "GIPPPGIPPPGIPPPGIPPPGIP");
 
   // Remove each SEI in the list and append it 2 items later (which in practice becomes 1 item later
@@ -722,7 +722,7 @@ START_TEST(lost_g_before_late_sei_arrival)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPPGIPPPGIPPPGIPPGI");
 
   // Remove the third SEI, that is, number 11 in the list: GIPPPGIPPP (G) IPPPGIPPGI.
@@ -765,7 +765,7 @@ START_TEST(lost_all_nalus_between_two_seis)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPPGIPPPGIPPPGIPPGI");
 
   // Remove IPPP between the second and third G.
@@ -801,7 +801,7 @@ START_TEST(add_one_sei_nalu_after_signing)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPPPGIPPGI");
 
   const uint8_t id = 0;
@@ -835,11 +835,11 @@ START_TEST(camera_reset_on_signing_side)
   // |settings|; See signed_video_helpers.h.
 
   // Generate 2 GOPs
-  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPP");
 
   // Generate another GOP from scratch
-  nalu_list_t *list_after_reset = create_signed_nalus("IPPPI", settings[_i]);
+  nalu_list_t *list_after_reset = create_signed_nalus("IPPPI", settings[_i], true);
   nalu_list_check_str(list_after_reset, "GIPPPGI");
 
   nalu_list_append_and_free(list, list_after_reset);
@@ -868,12 +868,12 @@ START_TEST(detect_change_of_public_key)
   // |settings|; See signed_video_helpers.h.
 
   // Generate 2 GOPs
-  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i]);
+  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i], false);
   nalu_list_check_str(list, "GIPPGIPP");
 
   // Generate another GOP from scratch
   // This will generate a new private key, hence transmit a different public key.
-  nalu_list_t *list_with_new_public_key = create_signed_nalus("IPPPI", settings[_i]);
+  nalu_list_t *list_with_new_public_key = create_signed_nalus("IPPPI", settings[_i], true);
   nalu_list_check_str(list_with_new_public_key, "GIPPPGI");
 
   nalu_list_append_and_free(list, list_with_new_public_key);
@@ -915,7 +915,7 @@ END_TEST
 static nalu_list_t *
 mimic_au_fast_forward_and_get_list(signed_video_t *sv, struct sv_setting setting)
 {
-  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", setting);
+  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPI", setting, false);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGI");
 
   // Extract the first 3 NALUs from the list. This should be the empty GOP and in the middle of the
@@ -1060,7 +1060,7 @@ END_TEST
 static nalu_list_t *
 mimic_file_export(struct sv_setting setting, bool include_i_nalu_at_end)
 {
-  nalu_list_t *list = create_signed_nalus("VIPPIPPIPPIPPIPP", setting);
+  nalu_list_t *list = create_signed_nalus("VIPPIPPIPPIPPIPP", setting, false);
   nalu_list_check_str(list, "VGIPPGIPPGIPPGIPPGIPP");
 
   // Remove the initial PPS/SPS/VPS NALU to add back later
@@ -1211,7 +1211,7 @@ START_TEST(recurrence)
   int recurrence = 3;
 
   nalu_list_t *list =
-      create_signed_nalus_recurrence("IPPIPPIPPIPPIPPIPPI", settings[_i], recurrence);
+      create_signed_nalus_recurrence("IPPIPPIPPIPPIPPIPPI", settings[_i], recurrence, false);
   ck_assert(list);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGIPPGIPPGI");
 

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1211,7 +1211,7 @@ START_TEST(recurrence)
   int recurrence = 3;
 
   nalu_list_t *list =
-      create_signed_nalus_recurrence("IPPIPPIPPIPPIPPIPPI", settings[_i], recurrence, false);
+      create_signed_nalus_recurrence("IPPIPPIPPIPPIPPIPPI", settings[_i], recurrence);
   ck_assert(list);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGIPPGIPPGI");
 

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -467,7 +467,7 @@ START_TEST(recurrence)
   int recurrence = 3;
 
   nalu_list_t *list =
-      create_signed_nalus_recurrence("IPPIPPIPPIPPIPPIPPI", settings[_i], recurrence, false);
+      create_signed_nalus_recurrence("IPPIPPIPPIPPIPPIPPI", settings[_i], recurrence);
   ck_assert(list);
   nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGIPPGIPPGI");
 

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -276,7 +276,7 @@ START_TEST(correct_nalu_sequence_with_eos)
   /* This test runs in a loop with loop index _i, corresponding to struct sv_setting _i
    * in |settings|; See signed_video_helpers.h. */
 
-  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPG");
   nalu_list_free(list);
 }
@@ -288,7 +288,7 @@ START_TEST(correct_nalu_sequence_without_eos)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPP");
   nalu_list_free(list);
 }
@@ -315,7 +315,7 @@ START_TEST(correct_multislice_sequence_with_eos)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i
   // in |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IiPpPpIiPpPp", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IiPpPpIiPpPp", settings[_i]);
   nalu_list_check_str(list, "GIiPpPpGIiPpPpG");
   nalu_list_free(list);
 }
@@ -327,7 +327,7 @@ START_TEST(correct_multislice_nalu_sequence_without_eos)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IiPpPpIiPpPp", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IiPpPpIiPpPp", settings[_i]);
   nalu_list_check_str(list, "GIiPpPpGIiPpPp");
   nalu_list_free(list);
 }
@@ -352,7 +352,7 @@ START_TEST(sei_increase_with_gop_length)
 
   SignedVideoAuthenticityLevel auth_level = settings[_i].auth_level;
 
-  nalu_list_t *list = create_signed_nalus("IPPIPPPPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPPIPPPPPI", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPPPPPGI");
   nalu_list_item_t *sei_3 = nalu_list_remove_item(list, 12);
   nalu_list_item_check_str(sei_3, "G");
@@ -443,7 +443,7 @@ START_TEST(undefined_nalu_in_sequence)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPXPIPPI", settings[_i], false);
+  nalu_list_t *list = create_signed_nalus("IPXPIPPI", settings[_i]);
   nalu_list_check_str(list, "GIPXPGIPPGI");
   nalu_list_free(list);
 }

--- a/tests/check/meson.build
+++ b/tests/check/meson.build
@@ -48,5 +48,5 @@ foreach t : tests
   # run tests in own directories
   workdir = join_paths(meson.current_build_dir(), t[0] + '@workdir')
   run_command('sh', '-c', 'mkdir -p ' + workdir)
-  test(t[0], testexe, env:test_env, workdir: workdir)
+  test(t[0], testexe, env:test_env, workdir: workdir, timeout: 5 * 60)
 endforeach

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -30,6 +30,9 @@
 #include "lib/src/signed_video_h26x_internal.h"  // signed_video_set_recurrence_interval()
 #include "lib/src/signed_video_internal.h"  // _signed_video_t
 
+#define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
+#define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000
+
 char global_private_key_rsa[RSA_PRIVATE_KEY_ALLOC_BYTES];
 size_t global_private_key_size_rsa;
 sign_algo_t global_algo_rsa;
@@ -121,6 +124,13 @@ create_signed_nalus_with_sv(signed_video_t *sv, const char *str)
   return list;
 }
 
+/* See function create_signed_nalus_int */
+nalu_list_t *
+create_signed_nalus(const char *str, struct sv_setting settings)
+{
+  return create_signed_nalus_int(str, settings, false);
+}
+
 /* Generates a signed video stream for the selected setting. The stream is returned as a
  * nalu_list_t.
  *
@@ -129,7 +139,7 @@ create_signed_nalus_with_sv(signed_video_t *sv, const char *str)
  * generated NALUs are then passed through the signing process and corresponding generated
  * sei-nalus are added to the stream. */
 nalu_list_t *
-create_signed_nalus(const char *str, struct sv_setting settings, bool new_priv_key)
+create_signed_nalus_int(const char *str, struct sv_setting settings, bool new_priv_key)
 {
   if (!str) return NULL;
   signed_video_t *sv = get_initialized_signed_video(settings.codec, settings.algo, new_priv_key);

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -33,12 +33,10 @@
 #define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
 #define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000
 
-char global_private_key_rsa[RSA_PRIVATE_KEY_ALLOC_BYTES];
-size_t global_private_key_size_rsa;
-sign_algo_t global_algo_rsa;
-char global_private_key_ecdsa[ECDSA_PRIVATE_KEY_ALLOC_BYTES];
-size_t global_private_key_size_ecdsa;
-sign_algo_t global_algo_ecdsa;
+char private_key_rsa[RSA_PRIVATE_KEY_ALLOC_BYTES];
+size_t private_key_size_rsa;
+char private_key_ecdsa[ECDSA_PRIVATE_KEY_ALLOC_BYTES];
+size_t private_key_size_ecdsa;
 
 const struct sv_setting settings[NUM_SETTINGS] = {
     {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_GOP, SIGN_ALGO_RSA},
@@ -189,31 +187,27 @@ get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo, bool new_
   // Generating private keys takes long time. In unit_tests a new private key is only generated if
   // it's really needed. One RSA key and one ECDSA key is stored globally to handle the scenario.
   if (algo == SIGN_ALGO_RSA) {
-    if (global_private_key_size_rsa == 0 || new_private_key) {
+    if (private_key_size_rsa == 0 || new_private_key) {
       rc = signed_video_generate_private_key(algo, "./", &private_key, &private_key_size);
       ck_assert_int_eq(rc, SV_OK);
 
       assert(private_key_size < RSA_PRIVATE_KEY_ALLOC_BYTES);
-      memcpy(global_private_key_rsa, private_key, private_key_size);
-      global_private_key_size_rsa = private_key_size;
-      global_algo_rsa = algo;
+      memcpy(private_key_rsa, private_key, private_key_size);
+      private_key_size_rsa = private_key_size;
     }
-    rc = signed_video_set_private_key(
-        sv, global_algo_rsa, global_private_key_rsa, global_private_key_size_rsa);
+    rc = signed_video_set_private_key(sv, algo, private_key_rsa, private_key_size_rsa);
     ck_assert_int_eq(rc, SV_OK);
   }
   if (algo == SIGN_ALGO_ECDSA) {
-    if (global_private_key_size_ecdsa == 0 || new_private_key) {
+    if (private_key_size_ecdsa == 0 || new_private_key) {
       rc = signed_video_generate_private_key(algo, "./", &private_key, &private_key_size);
       ck_assert_int_eq(rc, SV_OK);
 
       assert(private_key_size < ECDSA_PRIVATE_KEY_ALLOC_BYTES);
-      memcpy(global_private_key_ecdsa, private_key, private_key_size);
-      global_private_key_size_ecdsa = private_key_size;
-      global_algo_ecdsa = algo;
+      memcpy(private_key_ecdsa, private_key, private_key_size);
+      private_key_size_ecdsa = private_key_size;
     }
-    rc = signed_video_set_private_key(
-        sv, global_algo_ecdsa, global_private_key_ecdsa, global_private_key_size_ecdsa);
+    rc = signed_video_set_private_key(sv, algo, private_key_ecdsa, private_key_size_ecdsa);
     ck_assert_int_eq(rc, SV_OK);
   }
 

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -161,13 +161,10 @@ create_signed_nalus_int(const char *str, struct sv_setting settings, bool new_pr
  * generated sei-nalus are added to the stream. Content in sei-nalus is dependent on the recurrence
  * value. */
 nalu_list_t *
-create_signed_nalus_recurrence(const char *str,
-    struct sv_setting settings,
-    int recurrence,
-    bool new_private_key)
+create_signed_nalus_recurrence(const char *str, struct sv_setting settings, int recurrence)
 {
   if (!str) return NULL;
-  signed_video_t *sv = get_initialized_signed_video(settings.codec, settings.algo, new_private_key);
+  signed_video_t *sv = get_initialized_signed_video(settings.codec, settings.algo, false);
   ck_assert(sv);
   ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings.auth_level), SV_OK);
   ck_assert_int_eq(signed_video_set_recurrence_interval(sv, recurrence), SV_OK);

--- a/tests/check/signed_video_helpers.h
+++ b/tests/check/signed_video_helpers.h
@@ -45,10 +45,10 @@ extern const struct sv_setting settings[NUM_SETTINGS];
  * 1. a path to openssl keys
  * 2. product info strings
  *
- * new_priv_key = Generate a new private key or not.
+ * new_private_key = Generate a new private key or not.
  * This is useful for testing the signing part and generating a signed stream of nalus. */
 signed_video_t *
-get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo, bool new_priv_key);
+get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo, bool new_private_key);
 
 /* See function create_signed_nalus_int */
 nalu_list_t *
@@ -72,10 +72,10 @@ create_signed_nalus(const char *str, struct sv_setting settings);
  *   X: Invalid nalu, i.e., not a H26x nalu.
  *
  * settings = the session setup for this test.
- * new_priv_key = Generate a new private key or not.
+ * new_private_key = Generate a new private key or not.
  */
 nalu_list_t *
-create_signed_nalus_int(const char *str, struct sv_setting settings, bool new_priv_key);
+create_signed_nalus_int(const char *str, struct sv_setting settings, bool new_private_key);
 
 /* Creates a nalu_list_t with all the NALUs produced after signing. This mimic what leaves the
  * camera. Content in sei-nalus is dependent on the recurrence value.
@@ -84,7 +84,7 @@ nalu_list_t *
 create_signed_nalus_recurrence(const char *str,
     struct sv_setting settings,
     int recurrence,
-    bool new_priv_key);
+    bool new_private_key);
 
 /* Generates a signed video stream of NALUs for a user-owned signed_video_t session.
  *

--- a/tests/check/signed_video_helpers.h
+++ b/tests/check/signed_video_helpers.h
@@ -32,9 +32,6 @@
 #define MANUFACT "manufacturer"
 #define ADDR "address"
 
-#define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
-#define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000
-
 struct sv_setting {
   SignedVideoCodec codec;
   SignedVideoAuthenticityLevel auth_level;
@@ -52,6 +49,10 @@ extern const struct sv_setting settings[NUM_SETTINGS];
  * This is useful for testing the signing part and generating a signed stream of nalus. */
 signed_video_t *
 get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo, bool new_priv_key);
+
+/* See function create_signed_nalus_int */
+nalu_list_t *
+create_signed_nalus(const char *str, struct sv_setting settings);
 
 /* Creates a nalu_list_t with all the NALUs produced after signing. This mimic what leaves the
  * camera.
@@ -74,7 +75,7 @@ get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo, bool new_
  * new_priv_key = Generate a new private key or not.
  */
 nalu_list_t *
-create_signed_nalus(const char *str, struct sv_setting settings, bool new_priv_key);
+create_signed_nalus_int(const char *str, struct sv_setting settings, bool new_priv_key);
 
 /* Creates a nalu_list_t with all the NALUs produced after signing. This mimic what leaves the
  * camera. Content in sei-nalus is dependent on the recurrence value.

--- a/tests/check/signed_video_helpers.h
+++ b/tests/check/signed_video_helpers.h
@@ -21,8 +21,8 @@
 #ifndef __SIGNED_VIDEO_HELPERS_H__
 #define __SIGNED_VIDEO_HELPERS_H__
 
-#include "lib/src/includes/signed_video_interfaces.h"  // sign_algo_t
 #include "lib/src/includes/signed_video_common.h"  // signed_video_t, SignedVideoCodec
+#include "lib/src/includes/signed_video_interfaces.h"  // sign_algo_t
 #include "lib/src/includes/signed_video_sign.h"  // SignedVideoAuthenticityLevel
 #include "nalu_list.h"  // nalu_list_t
 
@@ -45,9 +45,10 @@ extern const struct sv_setting settings[NUM_SETTINGS];
  * 1. a path to openssl keys
  * 2. product info strings
  *
+ * new_priv_key = Generate a new private key or not.
  * This is useful for testing the signing part and generating a signed stream of nalus. */
 signed_video_t *
-get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo);
+get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo, bool new_priv_key);
 
 /* Creates a nalu_list_t with all the NALUs produced after signing. This mimic what leaves the
  * camera.
@@ -67,16 +68,19 @@ get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo);
  *   X: Invalid nalu, i.e., not a H26x nalu.
  *
  * settings = the session setup for this test.
+ * new_priv_key = Generate a new private key or not.
  */
 nalu_list_t *
-create_signed_nalus(const char *str, struct sv_setting settings);
+create_signed_nalus(const char *str, struct sv_setting settings, bool new_priv_key);
 
 /* Creates a nalu_list_t with all the NALUs produced after signing. This mimic what leaves the
  * camera. Content in sei-nalus is dependent on the recurrence value.
  */
 nalu_list_t *
-create_signed_nalus_recurrence(const char *str, struct sv_setting settings,
-    int recurrence);
+create_signed_nalus_recurrence(const char *str,
+    struct sv_setting settings,
+    int recurrence,
+    bool new_priv_key);
 
 /* Generates a signed video stream of NALUs for a user-owned signed_video_t session.
  *
@@ -89,8 +93,7 @@ create_signed_nalus_with_sv(signed_video_t *sv, const char *str);
 /* Removes the NALU list items with position |item_number| from the |list|. The item is, after a
  * check against the expected |str|, then freed. */
 void
-remove_item_then_check_and_free(nalu_list_t *list, int item_number,
-    const char *str);
+remove_item_then_check_and_free(nalu_list_t *list, int item_number, const char *str);
 
 /* Modifies the id of |item_number| by incrementing the value by one. Applies to both codecs in
  * |h26x_lists|. A sanity check on expected string of that item is done. */

--- a/tests/check/signed_video_helpers.h
+++ b/tests/check/signed_video_helpers.h
@@ -32,6 +32,9 @@
 #define MANUFACT "manufacturer"
 #define ADDR "address"
 
+#define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
+#define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000
+
 struct sv_setting {
   SignedVideoCodec codec;
   SignedVideoAuthenticityLevel auth_level;

--- a/tests/check/signed_video_helpers.h
+++ b/tests/check/signed_video_helpers.h
@@ -81,10 +81,7 @@ create_signed_nalus_int(const char *str, struct sv_setting settings, bool new_pr
  * camera. Content in sei-nalus is dependent on the recurrence value.
  */
 nalu_list_t *
-create_signed_nalus_recurrence(const char *str,
-    struct sv_setting settings,
-    int recurrence,
-    bool new_private_key);
+create_signed_nalus_recurrence(const char *str, struct sv_setting settings, int recurrence);
 
 /* Generates a signed video stream of NALUs for a user-owned signed_video_t session.
  *


### PR DESCRIPTION
It takes long time to generate private keys during unit tests. Therefore two
copies of private keys are saved. One with algo RSA and one with algo
ECDSA.
