### PR TITLE
Adds a payload_buffer to store ongoing SEIs

### DIFF
--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -1107,7 +1107,6 @@ signed_video_create(SignedVideoCodec codec)
 
     version_str_to_bytes(self->code_version, SIGNED_VIDEO_VERSION);
     self->codec = codec;
-    self->payload_ptr = NULL;
 
     // Allocate memory for the signature_info struct.
     self->signature_info = signature_create();
@@ -1169,8 +1168,6 @@ signed_video_reset(signed_video_t *self)
     // Empty the |nalu_list|.
     h26x_nalu_list_free_items(self->nalu_list);
 
-    self->payload_ptr = NULL;
-
     SVI_THROW(reset_gop_hash(self));
   SVI_CATCH()
   SVI_DONE(status)
@@ -1189,6 +1186,7 @@ signed_video_free(signed_video_t *self)
 
   // Free any NALUs left to prepend.
   free_and_reset_nalu_to_prepend_list(self);
+  free_payload_buffer(self->payload_buffer);
 
   h26x_nalu_list_free(self->nalu_list);
 

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -122,7 +122,6 @@ complete_sei_nalu_and_add_to_prepend(signed_video_t *self)
   // GOP.
   if (self->signature_info->signature_size == 0) {
     signed_video_nalu_data_free(payload);
-    payload = NULL;
     status = SVI_OK;
     goto done;
   } else if (!payload) {

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -123,8 +123,6 @@ struct _gop_info_detected_t {
 struct _signed_video_t {
   int code_version[SV_VERSION_BYTES];
   uint16_t last_two_bytes;
-  uint8_t *signature_payload_ptr;  // Pointer to signature payload
-  uint8_t *payload_ptr;  // Pointer to payload. Store payload pointer when SEI is delayed
   SignedVideoCodec codec;  // Codec used in this session.
 
   // Private structures
@@ -134,6 +132,11 @@ struct _signed_video_t {
   // Frames to prepend list
   signed_video_nalu_to_prepend_t nalus_to_prepend_list[MAX_NALUS_TO_PREPEND];
   int num_nalus_to_prepend;
+  // Buffer of payload pointer pairs. Each pair holds the memory for a SEI in preparation and to be
+  // added to the prepend list. The first location of the pair is pointing to the allocated memory
+  // of the payload and the second location to where the signature is about to be added.
+  uint8_t *payload_buffer[MAX_NALUS_TO_PREPEND * 2];
+  int payload_buffer_idx;  // Pointer to the current free location of the buffer.
 
   // TODO: Collect everything needed by the authentication part only in one struct/object, which
   // then is not needed to be created on the signing side, saving some memory.
@@ -245,5 +248,9 @@ product_info_free_members(signed_video_product_info_t *product_info);
 /* Defined in signed_video_h26x_sign.c */
 void
 free_and_reset_nalu_to_prepend_list(signed_video_t *signed_video);
+
+/* Frees all allocated memory of payload pointers in the buffer. */
+void
+free_payload_buffer(uint8_t *payload_buffer[]);
 
 #endif  // __SIGNED_VIDEO_INTERNAL__


### PR DESCRIPTION
When a SEI is about to be created everything up to the signature is
written. It is then completed when the signature exists. This means
that SEIs can pile up and storing pointers to these memory slots is
necessary for other signing plugins.

The members payload_ptr and signature_payload_ptr have been removed
since the are not used anymore.
