### PR TITLE
Fixes valgrind errors

### DIFF
--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -46,7 +46,7 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v1.1.1"
+#define SIGNED_VIDEO_VERSION "v1.1.2"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -425,24 +425,20 @@ openssl_key_memory_allocated(void **key, size_t *key_size, size_t new_key_size)
   // Return if memory size match.
   if (*key_size == new_key_size) return SV_OK;
 
-  void *new_key = NULL;
-  svi_rc status = SVI_UNKNOWN;
-  SVI_TRY()
-    // Re-allocate memory.
-    new_key = realloc(*key, new_key_size);
-    SVI_THROW_IF(!new_key, SVI_MEMORY);
-  SVI_CATCH()
-  {
-    free(*key);
+  // Free existing key.
+  free(*key);
+  *key = NULL;
+
+  // Allocate memory for a new one.
+  void *new_key = calloc(1, new_key_size);
+  if (!new_key) {
     new_key_size = 0;
   }
-  SVI_DONE(status)
-
   // Set key also upon failure, for which it will be a null pointer.
   *key_size = new_key_size;
   *key = new_key;
 
-  return svi_rc_to_signed_video_rc(status);
+  return new_key ? SV_OK : SV_MEMORY;
 }
 
 /* Reads the public key from the private key. */

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -542,7 +542,7 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
     SVI_THROW(sv_rc_to_svi_rc(openssl_key_memory_allocated(
         &signature_info->public_key, &signature_info->public_key_size, pubkey_size)));
 
-    if (memcmp(data_ptr, signature_info->public_key, pubkey_size) && self->has_public_key) {
+    if (self->has_public_key && memcmp(data_ptr, signature_info->public_key, pubkey_size)) {
       self->latest_validation->public_key_has_changed = true;
     }
     memcpy(signature_info->public_key, data_ptr, pubkey_size);

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '1.1.1',
+  version : '1.1.2',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',
@@ -23,7 +23,7 @@ signing_plugin = get_option('signingplugin')
 # Determine if 'threaded_unless_check_dep' should use 'threaded' or 'unthreaded'
 if (signing_plugin == 'threaded_unless_check_dep' and check_dep.found())
   signing_plugin = 'unthreaded'
-else
+elif (signing_plugin == 'threaded_unless_check_dep')
   signing_plugin = 'threaded'
 endif
 

--- a/tests/test_checks.sh
+++ b/tests/test_checks.sh
@@ -12,14 +12,14 @@ echo ""
 echo "=== Runs check tests with default (unthreaded) signing plugin ==="
 echo ""
 
-meson -Dbuildtype=debug -Dsigningplugin=threaded_unless_check_dep . build
+meson -Dbuildtype=debug . build
 ninja -C build test
 
 echo ""
 echo "=== Now Runs check tests with SIGNED_VIDEO_DEBUG ==="
 echo ""
 
-meson -Ddebugprints=true -Dbuildtype=debug -Dsigningplugin=unthreaded --reconfigure . build
+meson -Ddebugprints=true -Dbuildtype=debug -Dsigningplugin=threaded_unless_check_dep --reconfigure . build
 ninja -C build test
 
 echo ""


### PR DESCRIPTION
- Double free in payload_buffer
- memcmp() of uninitialized data
- Correctly handles meson option signingplugin
- Rewrites openssl_key_memory_allocated()
- Checks has_public_key before memcmp()
- Updates version to v1.1.2
