### PR TITLE
The public Axis root CA is not added to SEI

### DIFF
--- a/lib/src/includes/sv_vendor_axis_communications.h
+++ b/lib/src/includes/sv_vendor_axis_communications.h
@@ -58,9 +58,9 @@
  */
 SignedVideoReturnCode
 sv_vendor_axis_communications_set_attestation_report(signed_video_t *sv,
-    void *attestation,
+    const void *attestation,
     uint8_t attestation_size,
-    char *certificate_chain);
+    const char *certificate_chain);
 
 // APIs for validating a signed video.
 

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -21,6 +21,7 @@
 #include "includes/sv_vendor_axis_communications.h"
 
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>  // malloc, memcpy, calloc, free
 
 #include "signed_video_internal.h"
@@ -32,6 +33,24 @@
 static const sv_tlv_tag_t axis_communications_encoders[AXIS_COMMUNICATIONS_NUM_ENCODERS] = {
     VENDOR_AXIS_COMMUNICATIONS_TAG,
 };
+
+static const char *trustedAxisRootCA =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIClDCCAfagAwIBAgIBATAKBggqhkjOPQQDBDBcMR8wHQYDVQQKExZBeGlzIENv\n"
+    "bW11bmljYXRpb25zIEFCMRgwFgYDVQQLEw9BeGlzIEVkZ2UgVmF1bHQxHzAdBgNV\n"
+    "BAMTFkF4aXMgRWRnZSBWYXVsdCBDQSBFQ0MwHhcNMjAxMDI2MDg0MzEzWhcNMzUx\n"
+    "MDI2MDg0MzEzWjBcMR8wHQYDVQQKExZBeGlzIENvbW11bmljYXRpb25zIEFCMRgw\n"
+    "FgYDVQQLEw9BeGlzIEVkZ2UgVmF1bHQxHzAdBgNVBAMTFkF4aXMgRWRnZSBWYXVs\n"
+    "dCBDQSBFQ0MwgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABAEmfjxRiTrvjLZol9gG\n"
+    "3YCUxcoWihbz2L3+6sp120I+KA/tLhYIDMais32M0tAqld5VDo1FWvi6kEVtqQn4\n"
+    "3+rOzgH8XkXolP+QFNSdKUPyJawnM4B9/jPZ6OA5bG7R1CNKmP4JpkYWqrD22hjc\n"
+    "AV9Hf/hz5TK2pc5IBHIxZyMcnlBc26NmMGQwHQYDVR0OBBYEFJBaAarD0kirmPmR\n"
+    "vCdrM6kt0XChMB8GA1UdIwQYMBaAFJBaAarD0kirmPmRvCdrM6kt0XChMBIGA1Ud\n"
+    "EwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMEA4GLADCB\n"
+    "hwJBUfwiBK0TIRJebWm9/nsNAEkjbxao40oeMUg+I3mDNr7guNJUo4ugOfToGpnm\n"
+    "3QLOhEJzyHqPBHTChxEd5bGVUW8CQgDR/ZAr405Ohk5kpM/gmzELP+fYDZfuTFut\n"
+    "w3S8HMYSvMWbTCzN+qnq+GV1goSS6vjVr95EpDxCVIxkKOvuxhyVDg==\n"
+    "-----END CERTIFICATE-----\n";
 
 // Definition of |vendor_handle|.
 typedef struct _sv_vendor_axis_communications_t {
@@ -59,6 +78,35 @@ sv_vendor_axis_communications_teardown(void *handle)
   free(self);
 }
 
+/* This function finds the beginning of the last certificate, which is the public Axis root CA
+ * certificate. The size of the other certificates is returned. If the last certificate differs from
+ * what is expected, or if number of certificates is not equal to three, 0 is returned.
+ *
+ * Note that the returned size excludes any null-terminated characters.
+ */
+static size_t
+get_certificate_chain_encode_size(const sv_vendor_axis_communications_t *self)
+{
+  size_t certificate_chain_encode_size = 0;
+
+  // Find the start of the third certificate in |certificate_chain|.
+  const char *cert_chain_ptr = self->certificate_chain;
+  const char *cert_ptr = self->certificate_chain;
+  int certs_left = 3;
+  while (certs_left > 0 && cert_ptr) {
+    cert_ptr = strstr(cert_chain_ptr, "-----BEGIN CERTIFICATE-----");
+    certs_left--;
+    cert_chain_ptr = cert_ptr + 1;
+  }
+  // Check if |cert_ptr| is the third certificate and compare it against expected
+  // |trustedAxisRootCA|.
+  if ((certs_left == 0) && cert_ptr && (strcmp(cert_ptr, trustedAxisRootCA) == 0)) {
+    certificate_chain_encode_size = cert_ptr - self->certificate_chain;
+  }
+
+  return certificate_chain_encode_size;
+}
+
 size_t
 encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, uint8_t *data)
 {
@@ -66,6 +114,7 @@ encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, uint8_
   if (!self) return 0;
 
   size_t data_size = 0;
+  size_t certificate_chain_encode_size = get_certificate_chain_encode_size(self);
   const uint8_t version = 1;  // Increment when the change breaks the format
 
   // If there is no attestation report, skip encoding, that is return 0.
@@ -75,7 +124,7 @@ encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, uint8_
   //  - version (1 byte)
   //  - attestation_size (1 byte)
   //  - attestation (attestation_size bytes)
-  //  - certificate_chain (certificate_chain_size bytes)
+  //  - certificate_chain (certificate_chain_size bytes) excluding |trustedAxisRootCA|
 
   data_size += sizeof(version);
   // Size of attestation report
@@ -83,7 +132,7 @@ encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, uint8_
   data_size += self->attestation_size;  // To write |attestation|
 
   // Size of certificate chain
-  data_size += strlen(self->certificate_chain) + 1;
+  data_size += certificate_chain_encode_size;
 
   if (!data) return data_size;
 
@@ -99,8 +148,8 @@ encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, uint8_
     write_byte(last_two_bytes, &data_ptr, attestation[jj], true);
   }
   // Write |certificate_chain|.
-  write_byte_many(&data_ptr, self->certificate_chain, strlen(self->certificate_chain) + 1,
-      last_two_bytes, true);
+  write_byte_many(
+      &data_ptr, self->certificate_chain, certificate_chain_encode_size, last_two_bytes, true);
 
   return (data_ptr - data);
 }
@@ -142,16 +191,16 @@ decode_axis_communications_handle(void *handle, const uint8_t *data, size_t data
     SVI_THROW_IF(data_size <= (size_t)attestation_size + 2, SVI_DECODING_ERROR);
     cert_size = data_size - attestation_size - 2;
 
-    // Allocate memory for |certificate_chain|
+    // Allocate memory for |certificate_chain| including |trustedAxisRootCA| and null-terminated
+    // character.
     if (!self->certificate_chain) {
-      self->certificate_chain = calloc(1, cert_size);
+      self->certificate_chain = calloc(1, cert_size + strlen(trustedAxisRootCA) + 1);
       SVI_THROW_IF(!self->certificate_chain, SVI_MEMORY);
     }
-    // If |certificate_chain| has already been allocated, but with a different size. Something has
-    // gone wrong or someone has manipulated the data.
-    // SVI_THROW_IF(cert_size != self->certificate_chain_size, SVI_NOT_SUPPORTED);
     memcpy(self->certificate_chain, data_ptr, cert_size);
     data_ptr += cert_size;
+    // Copy the |trustedAxisRootCA| to end of |certificate_chain|.
+    strcpy(self->certificate_chain + cert_size, trustedAxisRootCA);
 
     SVI_THROW_IF(data_ptr != data + data_size, SVI_DECODING_ERROR);
   SVI_CATCH()
@@ -164,9 +213,9 @@ decode_axis_communications_handle(void *handle, const uint8_t *data, size_t data
 
 SignedVideoReturnCode
 sv_vendor_axis_communications_set_attestation_report(signed_video_t *sv,
-    void *attestation,
+    const void *attestation,
     uint8_t attestation_size,
-    char *certificate_chain)
+    const char *certificate_chain)
 {
   // Sanity check inputs. It is allowed to set either one of |attestation| and |certificate_chain|,
   // but a mismatch between |attestation| and |attestation_size| returns SV_INVALID_PARAMETER.
@@ -197,10 +246,22 @@ sv_vendor_axis_communications_set_attestation_report(signed_video_t *sv,
     // If |certificate_chain| already exists, return error.
     if (self->certificate_chain) return SV_NOT_SUPPORTED;
     // Allocate memory and copy to |self|.
-    self->certificate_chain = calloc(1, strlen(certificate_chain) + 1);
+    size_t certificate_chain_size = strlen(certificate_chain);
+    if (certificate_chain_size == 0) goto catch_error;
+
+    bool has_newline_at_end = false;
+    if (certificate_chain[certificate_chain_size - 1] == '\n') {
+      has_newline_at_end = true;
+    }
+    // Allocate memory for |certificate_chain| + null-terminated character and maybe extra '\n'.
+    self->certificate_chain = calloc(1, certificate_chain_size + (has_newline_at_end ? 1 : 2));
     allocated_certificate_chain = true;
     if (!self->certificate_chain) goto catch_error;
     strcpy(self->certificate_chain, certificate_chain);
+    if (!has_newline_at_end) {
+      strcpy(self->certificate_chain + certificate_chain_size, "\n");
+      DEBUG_LOG("Adding newline since certificate_chain did not end with it.");
+    }
   }
 
   sv->vendor_encoders = axis_communications_encoders;

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1519,7 +1519,7 @@ START_TEST(vendor_axis_communications_operation)
   void *attestation = calloc(1, attestation_size);
   // Setting |attestation| and |certificate_chain|.
   sv_rc = sv_vendor_axis_communications_set_attestation_report(
-      sv, attestation, attestation_size, LONG_STRING);
+      sv, attestation, attestation_size, axisDummyCertificateChain);
   ck_assert_int_eq(sv_rc, SV_OK);
   free(attestation);
 

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -300,9 +300,8 @@ START_TEST(vendor_axis_communications_operation)
   // Check setting attestation report.
   const size_t attestation_size = 2;
   void *attestation = calloc(1, attestation_size);
-  char *cert_chain = "certificate_chain";
   sv_rc = sv_vendor_axis_communications_set_attestation_report(
-      NULL, attestation, attestation_size, cert_chain);
+      NULL, attestation, attestation_size, axisDummyCertificateChain);
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
   // Setting nothing is an ivalid operation.
   sv_rc = sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, NULL);
@@ -315,15 +314,17 @@ START_TEST(vendor_axis_communications_operation)
   // Setting only the |attestation| is a valid operation.
   sv_rc = sv_vendor_axis_communications_set_attestation_report(sv, attestation, 1, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
-  // Setting only the |cert_chain| is a valid operation.
-  sv_rc = sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, cert_chain);
+  // Setting only the |axisDummyCertificateChain| is a valid operation.
+  sv_rc =
+      sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, axisDummyCertificateChain);
   ck_assert_int_eq(sv_rc, SV_OK);
   // Setting a new |attestation| is not supported.
   sv_rc =
       sv_vendor_axis_communications_set_attestation_report(sv, attestation, attestation_size, NULL);
   ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
-  // Setting a new |cert_chain| is not supported.
-  sv_rc = sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, cert_chain);
+  // Setting a new |axisDummyCertificateChain| is not supported.
+  sv_rc =
+      sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, axisDummyCertificateChain);
   ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
   free(attestation);
 

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -33,6 +33,30 @@
 #define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
 #define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000
 
+// A dummy certificate chain with three certificates as expected. The last certificate has no
+// ending  '\n' to excercise more of the code.
+const char *axisDummyCertificateChain =
+    "-----BEGIN CERTIFICATE-----\n"
+    "-----END CERTIFICATE-----\n"
+    "-----BEGIN CERTIFICATE-----\n"
+    "-----END CERTIFICATE-----\n"
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIClDCCAfagAwIBAgIBATAKBggqhkjOPQQDBDBcMR8wHQYDVQQKExZBeGlzIENv\n"
+    "bW11bmljYXRpb25zIEFCMRgwFgYDVQQLEw9BeGlzIEVkZ2UgVmF1bHQxHzAdBgNV\n"
+    "BAMTFkF4aXMgRWRnZSBWYXVsdCBDQSBFQ0MwHhcNMjAxMDI2MDg0MzEzWhcNMzUx\n"
+    "MDI2MDg0MzEzWjBcMR8wHQYDVQQKExZBeGlzIENvbW11bmljYXRpb25zIEFCMRgw\n"
+    "FgYDVQQLEw9BeGlzIEVkZ2UgVmF1bHQxHzAdBgNVBAMTFkF4aXMgRWRnZSBWYXVs\n"
+    "dCBDQSBFQ0MwgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABAEmfjxRiTrvjLZol9gG\n"
+    "3YCUxcoWihbz2L3+6sp120I+KA/tLhYIDMais32M0tAqld5VDo1FWvi6kEVtqQn4\n"
+    "3+rOzgH8XkXolP+QFNSdKUPyJawnM4B9/jPZ6OA5bG7R1CNKmP4JpkYWqrD22hjc\n"
+    "AV9Hf/hz5TK2pc5IBHIxZyMcnlBc26NmMGQwHQYDVR0OBBYEFJBaAarD0kirmPmR\n"
+    "vCdrM6kt0XChMB8GA1UdIwQYMBaAFJBaAarD0kirmPmRvCdrM6kt0XChMBIGA1Ud\n"
+    "EwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMEA4GLADCB\n"
+    "hwJBUfwiBK0TIRJebWm9/nsNAEkjbxao40oeMUg+I3mDNr7guNJUo4ugOfToGpnm\n"
+    "3QLOhEJzyHqPBHTChxEd5bGVUW8CQgDR/ZAr405Ohk5kpM/gmzELP+fYDZfuTFut\n"
+    "w3S8HMYSvMWbTCzN+qnq+GV1goSS6vjVr95EpDxCVIxkKOvuxhyVDg==\n"
+    "-----END CERTIFICATE-----";
+
 char private_key_rsa[RSA_PRIVATE_KEY_ALLOC_BYTES];
 size_t private_key_size_rsa;
 char private_key_ecdsa[ECDSA_PRIVATE_KEY_ALLOC_BYTES];

--- a/tests/check/signed_video_helpers.h
+++ b/tests/check/signed_video_helpers.h
@@ -34,7 +34,10 @@
 #define SER_NO "serial_no"
 #define MANUFACT "manufacturer"
 #define ADDR "address"
-#define LONG_STRING "aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaacc"
+#define LONG_STRING \
+  "aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaa" \
+  "aaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbb" \
+  "bbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaacc"
 
 typedef enum { SV_RECURRENCE_ONE = 1, SV_RECURRENCE_EIGHT = 8 } SignedVideoRecurrence;
 typedef enum {
@@ -52,6 +55,8 @@ struct sv_setting {
 
 #define NUM_SETTINGS 24
 extern const struct sv_setting settings[NUM_SETTINGS];
+
+extern const char *axisDummyCertificateChain;
 
 /* Creates a signed_video_t session and initialize it by setting
  * 1. a path to openssl keys


### PR DESCRIPTION
The certificate chain set by an Axis camera consists of three certificates.
The last one is the public root CA. This certificate is also added to
the library for ease of use when verifying the certificate chain.
Transmitting something that is already present in signed-video-framework
only increases the bitrate. Instead, this last certificate is added to the
certificate chain when decoding the tag. If the original chain did not use
the Axis root CA to sign verification of the chain will fail anyhow.

Tests have been updated.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
