### PR TITLE
The public Axis root CA is not added to SEI

### DIFF
--- a/lib/src/includes/sv_vendor_axis_communications.h
+++ b/lib/src/includes/sv_vendor_axis_communications.h
@@ -58,9 +58,9 @@
  */
 SignedVideoReturnCode
 sv_vendor_axis_communications_set_attestation_report(signed_video_t *sv,
-    void *attestation,
+    const void *attestation,
     uint8_t attestation_size,
-    char *certificate_chain);
+    const char *certificate_chain);
 
 // APIs for validating a signed video.
 

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -46,7 +46,7 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v1.1.3"
+#define SIGNED_VIDEO_VERSION "v1.1.4"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '1.1.3',
+  version : '1.1.4',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1519,7 +1519,7 @@ START_TEST(vendor_axis_communications_operation)
   void *attestation = calloc(1, attestation_size);
   // Setting |attestation| and |certificate_chain|.
   sv_rc = sv_vendor_axis_communications_set_attestation_report(
-      sv, attestation, attestation_size, LONG_STRING);
+      sv, attestation, attestation_size, axisDummyCertificateChain);
   ck_assert_int_eq(sv_rc, SV_OK);
   free(attestation);
 

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -300,9 +300,8 @@ START_TEST(vendor_axis_communications_operation)
   // Check setting attestation report.
   const size_t attestation_size = 2;
   void *attestation = calloc(1, attestation_size);
-  char *cert_chain = "certificate_chain";
   sv_rc = sv_vendor_axis_communications_set_attestation_report(
-      NULL, attestation, attestation_size, cert_chain);
+      NULL, attestation, attestation_size, axisDummyCertificateChain);
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
   // Setting nothing is an ivalid operation.
   sv_rc = sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, NULL);
@@ -315,15 +314,17 @@ START_TEST(vendor_axis_communications_operation)
   // Setting only the |attestation| is a valid operation.
   sv_rc = sv_vendor_axis_communications_set_attestation_report(sv, attestation, 1, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
-  // Setting only the |cert_chain| is a valid operation.
-  sv_rc = sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, cert_chain);
+  // Setting only the |axisDummyCertificateChain| is a valid operation.
+  sv_rc =
+      sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, axisDummyCertificateChain);
   ck_assert_int_eq(sv_rc, SV_OK);
   // Setting a new |attestation| is not supported.
   sv_rc =
       sv_vendor_axis_communications_set_attestation_report(sv, attestation, attestation_size, NULL);
   ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
-  // Setting a new |cert_chain| is not supported.
-  sv_rc = sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, cert_chain);
+  // Setting a new |axisDummyCertificateChain| is not supported.
+  sv_rc =
+      sv_vendor_axis_communications_set_attestation_report(sv, NULL, 0, axisDummyCertificateChain);
   ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
   free(attestation);
 

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -33,6 +33,30 @@
 #define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
 #define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000
 
+// A dummy certificate chain with three certificates as expected. The last certificate has no
+// ending  '\n' to excercise more of the code.
+const char *axisDummyCertificateChain =
+    "-----BEGIN CERTIFICATE-----\n"
+    "-----END CERTIFICATE-----\n"
+    "-----BEGIN CERTIFICATE-----\n"
+    "-----END CERTIFICATE-----\n"
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIClDCCAfagAwIBAgIBATAKBggqhkjOPQQDBDBcMR8wHQYDVQQKExZBeGlzIENv\n"
+    "bW11bmljYXRpb25zIEFCMRgwFgYDVQQLEw9BeGlzIEVkZ2UgVmF1bHQxHzAdBgNV\n"
+    "BAMTFkF4aXMgRWRnZSBWYXVsdCBDQSBFQ0MwHhcNMjAxMDI2MDg0MzEzWhcNMzUx\n"
+    "MDI2MDg0MzEzWjBcMR8wHQYDVQQKExZBeGlzIENvbW11bmljYXRpb25zIEFCMRgw\n"
+    "FgYDVQQLEw9BeGlzIEVkZ2UgVmF1bHQxHzAdBgNVBAMTFkF4aXMgRWRnZSBWYXVs\n"
+    "dCBDQSBFQ0MwgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABAEmfjxRiTrvjLZol9gG\n"
+    "3YCUxcoWihbz2L3+6sp120I+KA/tLhYIDMais32M0tAqld5VDo1FWvi6kEVtqQn4\n"
+    "3+rOzgH8XkXolP+QFNSdKUPyJawnM4B9/jPZ6OA5bG7R1CNKmP4JpkYWqrD22hjc\n"
+    "AV9Hf/hz5TK2pc5IBHIxZyMcnlBc26NmMGQwHQYDVR0OBBYEFJBaAarD0kirmPmR\n"
+    "vCdrM6kt0XChMB8GA1UdIwQYMBaAFJBaAarD0kirmPmRvCdrM6kt0XChMBIGA1Ud\n"
+    "EwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMEA4GLADCB\n"
+    "hwJBUfwiBK0TIRJebWm9/nsNAEkjbxao40oeMUg+I3mDNr7guNJUo4ugOfToGpnm\n"
+    "3QLOhEJzyHqPBHTChxEd5bGVUW8CQgDR/ZAr405Ohk5kpM/gmzELP+fYDZfuTFut\n"
+    "w3S8HMYSvMWbTCzN+qnq+GV1goSS6vjVr95EpDxCVIxkKOvuxhyVDg==\n"
+    "-----END CERTIFICATE-----";
+
 char private_key_rsa[RSA_PRIVATE_KEY_ALLOC_BYTES];
 size_t private_key_size_rsa;
 char private_key_ecdsa[ECDSA_PRIVATE_KEY_ALLOC_BYTES];

--- a/tests/check/signed_video_helpers.h
+++ b/tests/check/signed_video_helpers.h
@@ -34,7 +34,10 @@
 #define SER_NO "serial_no"
 #define MANUFACT "manufacturer"
 #define ADDR "address"
-#define LONG_STRING "aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaacc"
+#define LONG_STRING \
+  "aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaa" \
+  "aaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbb" \
+  "bbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaacc"
 
 typedef enum { SV_RECURRENCE_ONE = 1, SV_RECURRENCE_EIGHT = 8 } SignedVideoRecurrence;
 typedef enum {
@@ -52,6 +55,8 @@ struct sv_setting {
 
 #define NUM_SETTINGS 24
 extern const struct sv_setting settings[NUM_SETTINGS];
+
+extern const char *axisDummyCertificateChain;
 
 /* Creates a signed_video_t session and initialize it by setting
  * 1. a path to openssl keys


### PR DESCRIPTION
The certificate chain set by an Axis camera consists of three certificates.
The last one is the public root CA. This certificate is also added to
the library for ease of use when verifying the certificate chain.
Transmitting something that is already present in signed-video-framework
only increases the bitrate. Instead, this last certificate is added to the
certificate chain when decoding the tag. If the original chain did not use
the Axis root CA to sign verification of the chain will fail anyhow.

Tests have been updated.

Version bumped to v1.1.4
