### PR TITLE
Fixes a bug when the signing side falls back to light version

### DIFF
--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -235,6 +235,10 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
     return 0;
   }
 
+  // Reset |signature_hash_type| to |GOP_HASH|. If the |hash_list| is successfully added,
+  // |signature_hash_type| is changed to |DOCUMENT_HASH|.
+  self->gop_info->signature_hash_type = GOP_HASH;
+
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
     // Create new local signature.

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -46,7 +46,7 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v1.1.4"
+#define SIGNED_VIDEO_VERSION "v1.1.5"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '1.1.4',
+  version : '1.1.5',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1671,7 +1671,7 @@ signed_video_suite(void)
   tcase_add_loop_test(tc, no_signature, s, e);
   tcase_add_loop_test(tc, multislice_no_signature, s, e);
   tcase_add_loop_test(tc, late_public_key_and_no_sei_before_key_arrives, s, e);
-  tcase_add_loop_test(tc, fallback_to_gop_level, 0, NUM_SETTINGS);
+  tcase_add_loop_test(tc, fallback_to_gop_level, s, e);
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
   tcase_add_loop_test(tc, vendor_axis_communications_operation, s, e);
 #endif

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -489,9 +489,7 @@ END_TEST
  *
  * we automatically fall back on SV_AUTHENTICITY_LEVEL_GOP in at the third "I".
  *
- * We test this by comparing the SEI NALU sizes. The first one should include one hash in the hash
- * list, the second one four hashes and the last one no hash list at all, hence
- *   size_3 < size_1 < size_2
+ * We test this by examine if the generated SEI has the HASH_LIST_TAG present or not.
  */
 START_TEST(fallback_to_gop_level)
 {


### PR DESCRIPTION
The light version here means the SV_AUTHENTICITY_LEVEL_GOP, which kicks in
if the hash_list becomes too long; currently at 300 NALUs.

A test in check_h26xsigned_auth.c has been added and the description of
the corresponding test in check_h26xsigned_sign.c has been updated.
