### PR TITLE
Fixes unwanted behavior when signing fails in threaded plugin

### DIFF
--- a/lib/plugins/unthreaded-signing/plugin.c
+++ b/lib/plugins/unthreaded-signing/plugin.c
@@ -93,7 +93,8 @@ bool
 sv_interface_get_signature(void *plugin_handle,
     uint8_t *signature,
     size_t max_signature_size,
-    size_t *written_signature_size)
+    size_t *written_signature_size,
+    SignedVideoReturnCode *error)
 {
   sv_unthreaded_plugin_t *self = (sv_unthreaded_plugin_t *)plugin_handle;
 
@@ -109,6 +110,8 @@ sv_interface_get_signature(void *plugin_handle,
       *written_signature_size = self->signature_size;
     }
   }
+  if (error) *error = SV_OK;
+
   return has_signature;
 }
 

--- a/lib/src/includes/signed_video_interfaces.h
+++ b/lib/src/includes/signed_video_interfaces.h
@@ -91,6 +91,8 @@ sv_interface_sign_hash(void *plugin_handle, signature_info_t *signature_info);
  *   plugin cannot write all the data to |signature|, no data should be written and
  *   |written_signature_size| should be set to 0.
  * @param written_signature_size The actual size of the data written to |signature|.
+ * @param error Pointer to catch an error that occured when signing. A NULL pointer should be
+ *   allowed to skip collecting an error.
  *
  * @returns True if signature is updated, else False
  */
@@ -98,7 +100,8 @@ bool
 sv_interface_get_signature(void *plugin_handle,
     uint8_t *signature,
     size_t max_signature_size,
-    size_t *written_signature_size);
+    size_t *written_signature_size,
+    SignedVideoReturnCode *error);
 
 /**
  * @brief Sets up the signing plugin

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -540,8 +540,10 @@ signed_video_add_nalu_for_signing(signed_video_t *self,
     // completed.
     if ((nalu.nalu_type == NALU_TYPE_I || nalu.nalu_type == NALU_TYPE_P) && nalu.is_primary_slice &&
         signature_info->signature) {
+      SignedVideoReturnCode signature_error = SV_UNKNOWN_FAILURE;
       while (sv_interface_get_signature(self->plugin_handle, signature_info->signature,
-          signature_info->max_signature_size, &signature_info->signature_size)) {
+          signature_info->max_signature_size, &signature_info->signature_size, &signature_error)) {
+        SVI_THROW(sv_rc_to_svi_rc(signature_error));
 #ifdef SIGNED_VIDEO_DEBUG
         // TODO: This might not work for blocked signatures, that is if the hash in
         // |signature_info| does not correspond to the copied |signature|.
@@ -612,8 +614,10 @@ signed_video_set_end_of_stream(signed_video_t *self)
     add_payload_to_buffer(self, payload, payload_signature_ptr);
     // Fetch the signature. If it is not ready we exit without generating the SEI.
     signature_info_t *signature_info = self->signature_info;
+    SignedVideoReturnCode signature_error = SV_UNKNOWN_FAILURE;
     while (sv_interface_get_signature(self->plugin_handle, signature_info->signature,
-        signature_info->max_signature_size, &signature_info->signature_size)) {
+        signature_info->max_signature_size, &signature_info->signature_size, &signature_error)) {
+      SVI_THROW(sv_rc_to_svi_rc(signature_error));
       SVI_THROW(complete_sei_nalu_and_add_to_prepend(self));
     }
 

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -46,7 +46,7 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v1.1.5"
+#define SIGNED_VIDEO_VERSION "v1.1.6"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '1.1.5',
+  version : '1.1.6',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
If signing fails the error is propagated from the plugin to the library
when sv_interface_get_signature() is called, and further to the user.

NOTE: This causes a change in the public API sv_interface_get_signature().

Version is bumped to 1.1.6.
