### PR TITLE
Adds public_key_validation to signed_video_latest_validation_t

### DIFF
--- a/lib/src/includes/signed_video_auth.h
+++ b/lib/src/includes/signed_video_auth.h
@@ -53,6 +53,22 @@ typedef enum {
 } SignedVideoAuthenticityResult;
 
 /**
+ * Status of public key validation
+ */
+typedef enum {
+  SV_PUBKEY_VALIDATION_NOT_FEASIBLE = 0,
+  // There are no means to verify the public key. This happens if no attestation exists or if the
+  // public key was not part of the stream.
+  SV_PUBKEY_VALIDATION_NOT_OK = 1,
+  // The Public key in the SEI was not validated successfully. The video might be correct, but its
+  // origin could not be verified.
+  SV_PUBKEY_VALIDATION_OK = 2,
+  // The Public key in the stream was validated successfully. The origin of the key is correct and
+  // trustworthy when validating the video.
+  SV_PUBKEY_VALIDATION_NUM_STATES
+} SignedVideoPublicKeyValidation;
+
+/**
  * Struct storing the latest validation result. In general, that spans an entire GOP, but for long
  * GOP lengths an intermediate validation may be provided.
  */
@@ -98,6 +114,10 @@ typedef struct {
   // is still ignored.
   //   ..._..PP_P
   //         .._...PPP
+  SignedVideoPublicKeyValidation public_key_validation;
+  // The result of the latest Public key validation. If the Public key is present in the SEI, it has
+  // to be validated to associate the video with a source. If it is not feasible to validate the
+  // Public key, it should be validated manually to secure proper video authenticity.
 } signed_video_latest_validation_t;
 
 /**

--- a/lib/src/signed_video_authenticity.c
+++ b/lib/src/signed_video_authenticity.c
@@ -162,6 +162,7 @@ transfer_latest_validation(signed_video_latest_validation_t *dst,
     dst->number_of_expected_picture_nalus = src->number_of_expected_picture_nalus;
     dst->number_of_received_picture_nalus = src->number_of_received_picture_nalus;
     dst->number_of_pending_picture_nalus = src->number_of_pending_picture_nalus;
+    dst->public_key_validation = src->public_key_validation;
   SVI_CATCH()
   SVI_DONE(status)
 
@@ -243,6 +244,7 @@ latest_validation_init(signed_video_latest_validation_t *self)
   self->number_of_expected_picture_nalus = -1;
   self->number_of_received_picture_nalus = -1;
   self->number_of_pending_picture_nalus = 0;
+  self->public_key_validation = SV_PUBKEY_VALIDATION_NOT_FEASIBLE;
 
   free(self->validation_str);
   self->validation_str = NULL;


### PR DESCRIPTION
This member will be used to communicate the status of the public key validation,
necessary to secure full video authenticity.
