### PR TITLE
Changes behavior of set_axis_communications_public_key()

### DIFF
--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1570,6 +1570,9 @@ START_TEST(vendor_axis_communications_operation)
   ck_assert_int_eq(sv_rc, SV_OK);
   free(attestation);
 
+  sv_rc = signed_video_set_product_info(sv, HW_ID, FW_VER, NULL, "Axis Communications AB", ADDR);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
   // // Check setting recurrence.
   // sv_rc = signed_video_set_recurrence_interval_frames(sv, 1);
   // ck_assert_int_eq(sv_rc, SV_OK);
@@ -1610,6 +1613,8 @@ START_TEST(vendor_axis_communications_operation)
     latest = &(auth_report->latest_validation);
     ck_assert(latest);
     ck_assert_int_eq(strcmp(latest->validation_str, ".P"), 0);
+    // Currently |public_key_validation| is not updated internally.
+    ck_assert_int_eq(latest->public_key_validation, SV_PUBKEY_VALIDATION_NOT_FEASIBLE);
     // We are done with auth_report.
     latest = NULL;
     signed_video_authenticity_report_free(auth_report);


### PR DESCRIPTION
now updates public_key_validation if the key is not EC instead of returning
an error.

Also adds checking public_key_validation in Axis test.
