### PR TITLE
New vendor API get_axis_communications_supplemental_authenticity

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -21,6 +21,9 @@
 #include <assert.h>  // assert
 #include <stdlib.h>  // free
 
+#ifdef SV_VENDOR_AXIS_COMMUNICATIONS
+#include "axis-communications/sv_vendor_axis_communications_internal.h"
+#endif
 #include "includes/signed_video_auth.h"
 #include "includes/signed_video_interfaces.h"  // signature_info_t
 #include "includes/signed_video_openssl.h"  // openssl_verify_hash()
@@ -712,6 +715,36 @@ prepare_for_validation(signed_video_t *self)
 
     SVI_THROW_IF_WITH_MSG(
         gop_state->signing_present && !self->has_public_key, SVI_UNKNOWN, "No public key present");
+
+#ifdef SV_VENDOR_AXIS_COMMUNICATIONS
+    // If "Axis Communications AB" can be identified from the |product_info|, get
+    // |supplemental_authenticity| from |vendor_handle|.
+    if (self->product_info->manufacturer &&
+        strcmp(self->product_info->manufacturer, "Axis Communications AB") == 0) {
+
+      sv_vendor_axis_supplemental_authenticity_t supplemental_authenticity = {0};
+      SVI_THROW(get_axis_communications_supplemental_authenticity(
+          self->vendor_handle, &supplemental_authenticity));
+      if (strcmp(self->product_info->serial_number, supplemental_authenticity.serial_number) != 0) {
+        self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_NOT_OK;
+      } else {
+        // Convert to SignedVideoPublicKeyValidation
+        switch (supplemental_authenticity.public_key_validation) {
+          case 1:
+            self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_OK;
+            break;
+          case 0:
+            self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_NOT_OK;
+            break;
+          case -1:
+          default:
+            self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_NOT_FEASIBLE;
+            break;
+        }
+      }
+    }
+#endif
+
     // If we have received a SEI there is a signature to use for verification.
     if (self->gop_info_detected.has_gop_sei) {
       SVI_THROW(sv_rc_to_svi_rc(

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -722,14 +722,14 @@ prepare_for_validation(signed_video_t *self)
     if (self->product_info->manufacturer &&
         strcmp(self->product_info->manufacturer, "Axis Communications AB") == 0) {
 
-      sv_vendor_axis_supplemental_authenticity_t supplemental_authenticity = {0};
+      sv_vendor_axis_supplemental_authenticity_t *supplemental_authenticity = NULL;
       SVI_THROW(get_axis_communications_supplemental_authenticity(
           self->vendor_handle, &supplemental_authenticity));
-      if (strcmp(self->product_info->serial_number, supplemental_authenticity.serial_number) != 0) {
+      if (strcmp(self->product_info->serial_number, supplemental_authenticity->serial_number)) {
         self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_NOT_OK;
       } else {
         // Convert to SignedVideoPublicKeyValidation
-        switch (supplemental_authenticity.public_key_validation) {
+        switch (supplemental_authenticity->public_key_validation) {
           case 1:
             self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_OK;
             break;

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -292,6 +292,37 @@ set_axis_communications_public_key(void *handle,
   return status;
 }
 
+svi_rc
+get_axis_communications_supplemental_authenticity(void *handle,
+    sv_vendor_axis_supplemental_authenticity_t *supplemental_authenticity)
+{
+  if (!handle || !supplemental_authenticity) return SVI_INVALID_PARAMETER;
+
+  sv_vendor_axis_communications_t *self = (sv_vendor_axis_communications_t *)handle;
+
+  // Reset input |supplemental_authenticity|.
+  supplemental_authenticity->public_key_validation = -1;  // Unknown/error
+  // Clear any |serial_number| data in |supplemental_authenticity|.
+  char *serial_number = supplemental_authenticity->serial_number;
+  memset(serial_number, 0, SV_VENDOR_AXIS_SER_NO_MAX_LENGTH);
+
+  // TODO: Fill in the skeleton below step by step.
+  // svi_rc status = SVI_UNKNOWN;
+  // SVI_TRY()
+  //   SVI_THROW(verify_and_parse_certificate_chain(self));
+  //   SVI_THROW(deserialize_attestation(self));
+  //   SVI_THROW(verify_axis_communications_public_key(self));
+  // Set public key validation information.
+  supplemental_authenticity->public_key_validation =
+      self->supplemental_authenticity.public_key_validation;
+  strcpy(serial_number, (const char *)self->supplemental_authenticity.serial_number);
+
+  // SVI_CATCH()
+  // SVI_DONE(status)
+
+  return SVI_OK;
+}
+
 // Definitions of public APIs declared in sv_vendor_axis_communications.h.
 
 SignedVideoReturnCode

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -294,17 +294,11 @@ set_axis_communications_public_key(void *handle,
 
 svi_rc
 get_axis_communications_supplemental_authenticity(void *handle,
-    sv_vendor_axis_supplemental_authenticity_t *supplemental_authenticity)
+    sv_vendor_axis_supplemental_authenticity_t **supplemental_authenticity)
 {
   if (!handle || !supplemental_authenticity) return SVI_INVALID_PARAMETER;
 
   sv_vendor_axis_communications_t *self = (sv_vendor_axis_communications_t *)handle;
-
-  // Reset input |supplemental_authenticity|.
-  supplemental_authenticity->public_key_validation = -1;  // Unknown/error
-  // Clear any |serial_number| data in |supplemental_authenticity|.
-  char *serial_number = supplemental_authenticity->serial_number;
-  memset(serial_number, 0, SV_VENDOR_AXIS_SER_NO_MAX_LENGTH);
 
   // TODO: Fill in the skeleton below step by step.
   // svi_rc status = SVI_UNKNOWN;
@@ -312,13 +306,11 @@ get_axis_communications_supplemental_authenticity(void *handle,
   //   SVI_THROW(verify_and_parse_certificate_chain(self));
   //   SVI_THROW(deserialize_attestation(self));
   //   SVI_THROW(verify_axis_communications_public_key(self));
-  // Set public key validation information.
-  supplemental_authenticity->public_key_validation =
-      self->supplemental_authenticity.public_key_validation;
-  strcpy(serial_number, (const char *)self->supplemental_authenticity.serial_number);
 
   // SVI_CATCH()
   // SVI_DONE(status)
+
+  *supplemental_authenticity = &self->supplemental_authenticity;
 
   return SVI_OK;
 }

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
@@ -117,12 +117,13 @@ set_axis_communications_public_key(void *handle,
  * SEI, it is possible to verify the origin of the Public signing key.
  *
  * @param handle The handle to Axis Communications specific information.
- * @param supplemental_authenticity Pointer to the supplemental autenticity report, to be filled in.
+ * @param supplemental_authenticity Pointer to the address of supplemental autenticity report in
+ *   |handle|.
  *
  * @returns An internal return code to catch potential errors.
  */
 svi_rc
 get_axis_communications_supplemental_authenticity(void *handle,
-    sv_vendor_axis_supplemental_authenticity_t *supplemental_authenticity);
+    sv_vendor_axis_supplemental_authenticity_t **supplemental_authenticity);
 
 #endif  // __SV_VENDOR_AXIS_COMMUNICATIONS_INTERNAL_H__

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
@@ -110,4 +110,19 @@ set_axis_communications_public_key(void *handle,
     size_t public_key_size,
     bool public_key_has_changed);
 
+/**
+ * @brief Gets the Axis supplemental authenticity report
+ *
+ * With the attestation report and certificate chain, set by the signer and added as metadata in the
+ * SEI, it is possible to verify the origin of the Public signing key.
+ *
+ * @param handle The handle to Axis Communications specific information.
+ * @param supplemental_authenticity Pointer to the supplemental autenticity report, to be filled in.
+ *
+ * @returns An internal return code to catch potential errors.
+ */
+svi_rc
+get_axis_communications_supplemental_authenticity(void *handle,
+    sv_vendor_axis_supplemental_authenticity_t *supplemental_authenticity);
+
 #endif  // __SV_VENDOR_AXIS_COMMUNICATIONS_INTERNAL_H__

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1613,8 +1613,7 @@ START_TEST(vendor_axis_communications_operation)
     latest = &(auth_report->latest_validation);
     ck_assert(latest);
     ck_assert_int_eq(strcmp(latest->validation_str, ".P"), 0);
-    // Currently |public_key_validation| is not updated internally.
-    ck_assert_int_eq(latest->public_key_validation, SV_PUBKEY_VALIDATION_NOT_FEASIBLE);
+    ck_assert_int_eq(latest->public_key_validation, SV_PUBKEY_VALIDATION_NOT_OK);
     // We are done with auth_report.
     latest = NULL;
     signed_video_authenticity_report_free(auth_report);


### PR DESCRIPTION
to fetch status of public key used to validate the video.

The API is called before validating the authenticity and is triggered
if Axis is the manufacturer.
