### PR TITLE
Fixes a bug in set_axis_communications_public_key

### DIFF
--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -663,10 +663,8 @@ set_axis_communications_public_key(void *handle,
   EVP_PKEY *pkey = NULL;
   BIO *bp = NULL;
 
-  // If the Public key previously has been validated unsuccessful or if the Public key has not
-  // changed, skip checking type and size.
-  if (self->supplemental_authenticity.public_key_validation != 0 ||
-      self->public_key == public_key) {
+  // If the Public key previously has been validated unsuccessful, skip checking type and size.
+  if (self->supplemental_authenticity.public_key_validation == 0) {
     return SVI_OK;
   }
 


### PR DESCRIPTION
Now truly skips setting the public key if previous validation failed.
Further, the check if pointer to public_key is the same is no guarantee
the keys differ, and comparing the content is not enough either since
the pointers may differ. To be completely safe, we always check the
size and type of the public_key.
