### PR TITLE
Fixes a flaw when a SEI is lost from start

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -89,12 +89,14 @@ decode_sei_data(signed_video_t *self, const uint8_t *payload, size_t payload_siz
     // If number of |potentially_missed_gops| is negative, we have either lost SEIs together with a
     // wraparound of |global_gop_counter|, or a reset of Signed Video was done on the camera. The
     // correct number of lost SEIs is of less importance, since we only want to know IF we have lost
-    // any. Therefore, make sure we map the value into the positive side only. When it comes to a
-    // reset on the camera we could signal to the user, but we will still not be able to validate
-    // pending NALUs.
+    // any. Therefore, make sure we map the value into the positive side only. It is possible to
+    // signal to the validation side that a reset was done on the camera, but it is still not
+    // possible to validate pending NALUs.
     if (potentially_missed_gops < 0) potentially_missed_gops += INT64_MAX;
+    // It is only possible to know if a SEI has been lost if the |global_gop_counter| is in sync.
+    // Otherwise, the counter cannot be trusted.
     self->gop_info_detected.has_lost_sei =
-        (potentially_missed_gops > 0) && !self->gop_state.is_first_validation;
+        (potentially_missed_gops > 0) && self->gop_info->global_gop_counter_is_synced;
     // If the previous NALU was a SEI we needed one more NALU to complete the GOP
     // (AUTH_STATE_WAIT_FOR_NEXT_NALU). This is where we are now and ready for validation. If we
     // have not received the I NALU and have lost at least one SEI, we have lost the transition
@@ -245,12 +247,9 @@ verify_hashes_with_hash_list(signed_video_t *self, int *num_expected_nalus, int 
       // OK, or keep pending for second use.
       if (item->second_hash && !item->need_second_verification) {
         item->need_second_verification = true;
-        // If this item will be used in a second verification we set the flag
-        // |first_verification_not_authentic|. There is one exception though. If this is the first
-        // validation and the validation fails we are out of sync. The SEI is probably associated
-        // with a GOP not present in this segment of the stream. This case is handled separately in
-        // validate_authenticity(), but we should not flag the first verification as not authentic.
-        item->first_verification_not_authentic = !self->gop_state.is_first_validation;
+        // If this item will be used in a second verification the flag
+        // |first_verification_not_authentic| is set.
+        item->first_verification_not_authentic = true;
       } else {
         // Reset |need_second_verification|.
         item->need_second_verification = false;
@@ -283,7 +282,7 @@ verify_hashes_with_hash_list(signed_video_t *self, int *num_expected_nalus, int 
   if (last_used_item) {
     if (latest_match_idx != compare_idx) {
       // Last verified hash is invalid.
-      last_used_item->first_verification_not_authentic = !self->gop_state.is_first_validation;
+      last_used_item->first_verification_not_authentic = true;
       // Give this NALU a second verification because it could be that it is present in the next GOP
       // and brought in here due to some lost NALUs.
       last_used_item->need_second_verification = true;
@@ -523,7 +522,8 @@ validate_authenticity(signed_video_t *self)
 
   // Collect statistics from the nalu_list. This is used to validate the GOP and provide additional
   // information to the user.
-  h26x_nalu_list_get_stats(self->nalu_list, &num_invalid_nalus, &num_missed_nalus);
+  bool has_valid_nalus =
+      h26x_nalu_list_get_stats(self->nalu_list, &num_invalid_nalus, &num_missed_nalus);
   DEBUG_LOG("Number of invalid NALUs = %d.", num_invalid_nalus);
   DEBUG_LOG("Number of missed NALUs = %d.", num_missed_nalus);
 
@@ -540,6 +540,7 @@ validate_authenticity(signed_video_t *self)
         (num_missed_nalus >= num_expected_nalus - 1)) {
       valid = SV_AUTH_RESULT_NOT_OK;
     }
+    self->gop_info->global_gop_counter_is_synced = true;
   }
   // Determine if this GOP is valid, but has missing information. This happens if we have detected
   // missed NALUs or if the GOP is incomplete.
@@ -548,29 +549,35 @@ validate_authenticity(signed_video_t *self)
     DEBUG_LOG("Successful validation, but detected missing NALUs");
   }
   // The very first validation needs to be handled separately. If this is truly the start of a
-  // stream we have all necessary information to successfully validate the authenticity. We can
-  // interpret this as being in sync with its signing counterpart. If this session validates the
+  // stream we have all necessary information to successfully validate the authenticity. It can be
+  // interpreted as being in sync with its signing counterpart. If this session validates the
   // authenticity of a segment of a stream, e.g., an exported file, we start out of sync. The first
   // SEI may be associated with a GOP prior to this segment.
-  // TODO: The current implementation can only handle the case when the SEI is not delayed. We
-  // should add a test for exporting to a file with delayed SEIs and then also fix the flaw.
-  if (gop_state->is_first_validation &&
-      (valid == SV_AUTH_RESULT_NOT_OK || valid == SV_AUTH_RESULT_OK_WITH_MISSING_INFO)) {
-    // We have validated the authenticity based on one single NALU, but failed. A success can only
-    // happen if we are at the beginning of the original stream. For all other cases, for example,
-    // if we validate the authenticity of an exported file, the first SEI may be associated with a
-    // part of the original stream not present in the file. Hence, mark as
-    // SV_AUTH_RESULT_SIGNATURE_PRESENT instead.
-    DEBUG_LOG("This first validation cannot be performed");
-    // Since we verify the linking hash twice we need to remove the set
-    // |first_verification_not_authentic|. Otherwise, the false failure leaks into the next GOP.
-    // Further, empty items marked 'M', may have been added at the beginning. These have no meaning
-    // and may only confuse the user. These should be removed. This is handled in
-    // h26x_nalu_list_remove_missing_items().
-    h26x_nalu_list_remove_missing_items(self->nalu_list);
-    valid = SV_AUTH_RESULT_SIGNATURE_PRESENT;
-    num_expected_nalus = -1;
-    num_received_nalus = -1;
+  if (gop_state->is_first_validation) {
+    // Change status from SV_AUTH_RESULT_OK to SV_AUTH_RESULT_SIGNATURE_PRESENT if no valid NALUs
+    // were found when collecting stats.
+    if ((valid == SV_AUTH_RESULT_OK) && !has_valid_nalus) {
+      valid = SV_AUTH_RESULT_SIGNATURE_PRESENT;
+    }
+    // If validation was successful, the |global_gop_counter| is in sync.
+    self->gop_info->global_gop_counter_is_synced = (valid == SV_AUTH_RESULT_OK);
+    if (valid != SV_AUTH_RESULT_OK) {
+      // We have validated the authenticity based on one single NALU, but failed. A success can only
+      // happen if we are at the beginning of the original stream. For all other cases, for example,
+      // if we validate the authenticity of an exported file, the first SEI may be associated with a
+      // part of the original stream not present in the file. Hence, mark as
+      // SV_AUTH_RESULT_SIGNATURE_PRESENT instead.
+      DEBUG_LOG("This first validation cannot be performed");
+      // Since we verify the linking hash twice we need to remove the set
+      // |first_verification_not_authentic|. Otherwise, the false failure leaks into the next GOP.
+      // Further, empty items marked 'M', may have been added at the beginning. These have no
+      // meaning and may only confuse the user. These should be removed. This is handled in
+      // h26x_nalu_list_remove_missing_items().
+      h26x_nalu_list_remove_missing_items(self->nalu_list);
+      valid = SV_AUTH_RESULT_SIGNATURE_PRESENT;
+      num_expected_nalus = -1;
+      num_received_nalus = -1;
+    }
   }
   if (latest->public_key_has_changed) valid = SV_AUTH_RESULT_NOT_OK;
 

--- a/lib/src/signed_video_h26x_nalu_list.h
+++ b/lib/src/signed_video_h26x_nalu_list.h
@@ -139,8 +139,11 @@ h26x_nalu_list_get_next_sei_item(const h26x_nalu_list_t* list);
  *   authentic, is written.
  * @param num_missing_nalus A pointer to which the number of missing NALUs, detected by the
  *   validation, is written.
+ *
+ * @returns True if at least one item is validated as authentic including those that are pending a
+ *   second verification.
  */
-void
+bool
 h26x_nalu_list_get_stats(const h26x_nalu_list_t* list,
     int* num_invalid_nalus,
     int* num_missing_nalus);

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -46,7 +46,7 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v1.1.6"
+#define SIGNED_VIDEO_VERSION "v1.1.7"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME
@@ -224,6 +224,8 @@ struct _gop_info_t {
   hash_type_t signature_hash_type;  // The type of hash signed, either gop_hash or document hash.
   uint32_t global_gop_counter;  // The index of the current GOP, incremented when encoded in the
   // TLV.
+  bool global_gop_counter_is_synced;  // Turns true when a SEI corresponding to the segment is
+  // detected.
   int verified_signature_hash;  // Status of last hash-signature-pair verification. Has 1 for
   // success, 0 for fail, and -1 for error.
 };

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -938,6 +938,65 @@ START_TEST(lost_g_before_late_sei_arrival)
 END_TEST
 
 /* Test description
+ * Consider a scenario where the validation side starts recording a video stream from the second
+ * GOP, and the SEIs arrive late. This test validates proper results if the second SEI is lost and
+ * the first SEI arrives inside the second GOP.
+ */
+START_TEST(lost_g_and_gop_with_late_sei_arrival)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  nalu_list_t *list = create_signed_nalus("IPIPPPIPPPIP", settings[_i]);
+  nalu_list_check_str(list, "GIPGIPPPGIPPPGIP");
+
+  // Get the first SEI, to be added back later.
+  nalu_list_item_t *sei = nalu_list_pop_first_item(list);
+  nalu_list_item_check_str(sei, "G");
+  nalu_list_check_str(list, "IPGIPPPGIPPPGIP");
+
+  // Remove the first GOP to mimic the start of the validation side.
+  remove_item_then_check_and_free(list, 1, "I");
+  nalu_list_check_str(list, "PGIPPPGIPPPGIP");
+  remove_item_then_check_and_free(list, 1, "P");
+  nalu_list_check_str(list, "GIPPPGIPPPGIP");
+  remove_item_then_check_and_free(list, 1, "G");
+  nalu_list_check_str(list, "IPPPGIPPPGIP");
+
+  // Inject the SEI into the second GOP.
+  nalu_list_append_item(list, sei, 2);
+  nalu_list_check_str(list, "IPGPPGIPPPGIP");
+
+  // Move the remaining SEIs.
+  sei = nalu_list_remove_item(list, 6);
+  nalu_list_item_check_str(sei, "G");
+  nalu_list_check_str(list, "IPGPPIPPPGIP");
+  nalu_list_append_item(list, sei, 7);
+  nalu_list_check_str(list, "IPGPPIPGPPGIP");
+
+  sei = nalu_list_remove_item(list, 11);
+  nalu_list_item_check_str(sei, "G");
+  nalu_list_check_str(list, "IPGPPIPGPPIP");
+  nalu_list_append_item(list, sei, 12);
+  nalu_list_check_str(list, "IPGPPIPGPPIPG");
+
+  // We will get 6 pending nalus:
+  //
+  // IPG         has_signature & 2 pending (IP)
+  // IP(G)PPIPG  valid & 2 pending (last IP) since they will be validated next time
+  // IP(G)PPIPG  valid & 2 pending (last IP)
+  struct validation_stats expected = {.valid_gops = 2, .pending_nalus = 6, .has_signature = 1};
+  if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
+    // The two pending NALUs of the first validation will not be noticed.
+    expected.pending_nalus = 4;
+  }
+  validate_nalu_list(NULL, list, expected);
+
+  nalu_list_free(list);
+}
+END_TEST
+
+/* Test description
  * Verify that we can validate authenticity correctly if we lose all NALUs between two SEIs. */
 START_TEST(lost_all_nalus_between_two_seis)
 {
@@ -1663,6 +1722,7 @@ signed_video_suite(void)
   tcase_add_loop_test(tc, sei_arrives_late, s, e);
   tcase_add_loop_test(tc, all_seis_arrive_late, s, e);
   tcase_add_loop_test(tc, lost_g_before_late_sei_arrival, s, e);
+  tcase_add_loop_test(tc, lost_g_and_gop_with_late_sei_arrival, s, e);
   tcase_add_loop_test(tc, lost_all_nalus_between_two_seis, s, e);
   tcase_add_loop_test(tc, add_one_sei_nalu_after_signing, s, e);
   tcase_add_loop_test(tc, camera_reset_on_signing_side, s, e);


### PR DESCRIPTION
together with a first SEI showing up late in the stream.
This caused a state in the validation process to always show 'invalid'
when in fact everything is valid.

A check test for this scenario is added.

Also bumps the version to v1.1.7
