### PR TITLE
Removes auth_state_t

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -29,7 +29,7 @@
 #include "includes/signed_video_openssl.h"  // openssl_verify_hash()
 #include "signed_video_authenticity.h"  // create_local_authenticity_report_if_needed()
 #include "signed_video_defines.h"  // svi_rc
-#include "signed_video_h26x_internal.h"  // gop_state_reset(), update_gop_hash()
+#include "signed_video_h26x_internal.h"  // gop_state_*(), update_gop_hash(), update_validation_flags()
 #include "signed_video_h26x_nalu_list.h"  // h26x_nalu_list_append()
 #include "signed_video_internal.h"  // gop_info_t, gop_state_t, reset_gop_hash()
 #include "signed_video_openssl_internal.h"  // openssl_get_algo_of_public_key()
@@ -55,6 +55,10 @@ static svi_rc
 prepare_for_validation(signed_video_t *self);
 static bool
 is_recurrent_data_decoded(signed_video_t *self);
+static bool
+has_pending_gop(signed_video_t *self);
+static bool
+validation_is_feasible(const h26x_nalu_list_item_t *item);
 
 static void
 remove_used_in_gop_hash(h26x_nalu_list_t *nalu_list);
@@ -96,15 +100,13 @@ decode_sei_data(signed_video_t *self, const uint8_t *payload, size_t payload_siz
     if (potentially_missed_gops < 0) potentially_missed_gops += INT64_MAX;
     // It is only possible to know if a SEI has been lost if the |global_gop_counter| is in sync.
     // Otherwise, the counter cannot be trusted.
-    self->gop_info_detected.has_lost_sei =
+    self->gop_state.has_lost_sei =
         (potentially_missed_gops > 0) && self->gop_info->global_gop_counter_is_synced;
-    // If the previous NALU was a SEI we needed one more NALU to complete the GOP
-    // (AUTH_STATE_WAIT_FOR_NEXT_NALU). This is where we are now and ready for validation. If we
-    // have not received the I NALU and have lost at least one SEI, we have lost the transition
-    // between GOPs.
-    if ((self->gop_state.prev_auth_state == AUTH_STATE_WAIT_FOR_NEXT_NALU) &&
-        self->gop_info_detected.has_lost_sei) {
-      self->gop_info_detected.gop_transition_is_lost = true;
+    // Every SEI is associated with a GOP. If a lost SEI has been detected, and no GOP end has been
+    // found prior to this SEI, it means both a SEI and a I-frame was lost. This is defined as a
+    // lost GOP transition.
+    if (self->gop_state.no_gop_end_before_sei && self->gop_state.has_lost_sei) {
+      self->gop_state.gop_transition_is_lost = true;
     }
 
   SVI_CATCH()
@@ -295,6 +297,10 @@ verify_hashes_with_hash_list(signed_video_t *self, int *num_expected_nalus, int 
       // We cannot mark the last item as Missing since it will be handled a second time in the next
       // GOP.
       num_unused_expected_hashes--;
+      if (num_unused_expected_hashes >= 0) {
+        // Avoids reporting the lost linked hash twice.
+        num_verified_hashes++;
+      }
       // No need to check the return value. A failure only affects the statistics. In the worst case
       // we may signal SV_AUTH_RESULT_OK instead of SV_AUTH_RESULT_OK_WITH_MISSING_INFO.
       h26x_nalu_list_add_missing(nalu_list, num_unused_expected_hashes, true, last_used_item);
@@ -399,7 +405,7 @@ verify_hashes_with_gop_hash(signed_video_t *self, int *num_expected_nalus, int *
   num_received_hashes =
       set_validation_status_of_items_used_in_gop_hash(self->nalu_list, validation_status);
 
-  if (!self->gop_state.is_first_validation && first_gop_hash_item) {
+  if (!self->validation_flags.is_first_validation && first_gop_hash_item) {
     int num_missing_nalus = num_expected_hashes - num_received_hashes;
     const bool append = first_gop_hash_item->nalu->is_first_nalu_in_gop;
     // No need to check the return value. A failure only affects the statistics. In the worst case
@@ -460,7 +466,7 @@ verify_hashes_without_sei(signed_video_t *self)
   }
 
   // If we have verified a GOP without a SEI, we should increment the |global_gop_counter|.
-  if (self->gop_state.signing_present && (num_marked_items > 0)) {
+  if (self->validation_flags.signing_present && (num_marked_items > 0)) {
     self->gop_info->global_gop_counter++;
   }
 
@@ -495,7 +501,7 @@ validate_authenticity(signed_video_t *self)
   assert(self);
 
   gop_state_t *gop_state = &(self->gop_state);
-  gop_info_detected_t *gop_info_detected = &(self->gop_info_detected);
+  validation_flags_t *validation_flags = &(self->validation_flags);
   signed_video_latest_validation_t *latest = self->latest_validation;
 
   SignedVideoAuthenticityResult valid = SV_AUTH_RESULT_NOT_OK;
@@ -506,8 +512,7 @@ validate_authenticity(signed_video_t *self)
   int num_missed_nalus = -1;
   bool verify_success = false;
 
-  if (!gop_info_detected->has_gop_sei ||
-      (gop_info_detected->has_lost_sei && !gop_info_detected->gop_transition_is_lost)) {
+  if (gop_state->has_lost_sei && !gop_state->gop_transition_is_lost) {
     DEBUG_LOG("We never received the SEI associated with this GOP");
     // We never received the SEI nalu, but we know we have passed a GOP transition. Hence, we cannot
     // verify this GOP. Marking this GOP as not OK by verify_hashes_without_sei().
@@ -536,7 +541,7 @@ validate_authenticity(signed_video_t *self)
   // it afterwards.
   // TODO: Move this inside the verify_hashes_ functions. We should not need to perform any special
   // actions on the output.
-  if (!gop_state->is_first_validation) {
+  if (!validation_flags->is_first_validation) {
     if ((valid == SV_AUTH_RESULT_OK) && (num_expected_nalus > 1) &&
         (num_missed_nalus >= num_expected_nalus - 1)) {
       valid = SV_AUTH_RESULT_NOT_OK;
@@ -554,7 +559,7 @@ validate_authenticity(signed_video_t *self)
   // interpreted as being in sync with its signing counterpart. If this session validates the
   // authenticity of a segment of a stream, e.g., an exported file, we start out of sync. The first
   // SEI may be associated with a GOP prior to this segment.
-  if (gop_state->is_first_validation) {
+  if (validation_flags->is_first_validation) {
     // Change status from SV_AUTH_RESULT_OK to SV_AUTH_RESULT_SIGNATURE_PRESENT if no valid NALUs
     // were found when collecting stats.
     if ((valid == SV_AUTH_RESULT_OK) && !has_valid_nalus) {
@@ -647,9 +652,9 @@ compute_gop_hash(signed_video_t *self, h26x_nalu_list_item_t *sei)
       found_item_after_sei = (item->prev == sei);
       // Check if this |is_first_nalu_in_gop|, but used in verification for the first time.
       found_next_gop = (item->nalu->is_first_nalu_in_gop && !item->need_second_verification);
-      // If this is the SEI associated with the GOP we skip it. The hash will be added to |gop_hash|
-      // as the last hash.
-      if (item == sei) {
+      // If this is the SEI associated with the GOP, or any SEI, we skip it. The SEI hash will be
+      // added to |gop_hash| as the last hash.
+      if (item->nalu->is_gop_sei) {
         item = item->next;
         continue;
       }
@@ -695,7 +700,7 @@ prepare_for_validation(signed_video_t *self)
 {
   assert(self);
 
-  gop_state_t *gop_state = &(self->gop_state);
+  validation_flags_t *validation_flags = &(self->validation_flags);
   h26x_nalu_list_t *nalu_list = self->nalu_list;
   signature_info_t *signature_info = self->signature_info;
 
@@ -721,8 +726,8 @@ prepare_for_validation(signed_video_t *self)
       memcpy(signature_info->hash, self->gop_info->gop_hash, HASH_DIGEST_SIZE);
     }
 
-    SVI_THROW_IF_WITH_MSG(gop_state->signing_present && !self->has_public_key, SVI_NOT_SUPPORTED,
-        "No public key present");
+    SVI_THROW_IF_WITH_MSG(validation_flags->signing_present && !self->has_public_key,
+        SVI_NOT_SUPPORTED, "No public key present");
 
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
     // If "Axis Communications AB" can be identified from the |product_info|, get
@@ -754,7 +759,7 @@ prepare_for_validation(signed_video_t *self)
 #endif
 
     // If we have received a SEI there is a signature to use for verification.
-    if (self->gop_info_detected.has_gop_sei) {
+    if (self->gop_state.has_gop_sei) {
       SVI_THROW(sv_rc_to_svi_rc(
           openssl_verify_hash(signature_info, &self->gop_info->verified_signature_hash)));
     }
@@ -769,12 +774,9 @@ prepare_for_validation(signed_video_t *self)
 static bool
 is_recurrent_data_decoded(signed_video_t *self)
 {
-  gop_state_t *gop_state = &(self->gop_state);
-  gop_info_detected_t *gop_info_detected = &(self->gop_info_detected);
-  signed_video_latest_validation_t *latest = self->latest_validation;
   h26x_nalu_list_t *nalu_list = self->nalu_list;
 
-  if (self->has_public_key || !gop_state->signing_present) return true;
+  if (self->has_public_key || !self->validation_flags.signing_present) return true;
 
   bool recurrent_data_decoded = false;
   h26x_nalu_list_item_t *item = nalu_list->first_item;
@@ -787,14 +789,88 @@ is_recurrent_data_decoded(signed_video_t *self)
     }
     item = item->next;
   }
-  if (!recurrent_data_decoded) {
-    DEBUG_LOG("Public key missing");
-    // TODO: Investigate if it's needed to take any special actions when moving to the next GOP
-    gop_state_reset(gop_state, gop_info_detected);
-    latest->authenticity = SV_AUTH_RESULT_SIGNATURE_PRESENT;
-  }
 
   return recurrent_data_decoded;
+}
+
+/* Loops through the |nalu_list| to find out if there are GOPs that awaits validation. */
+static bool
+has_pending_gop(signed_video_t *self)
+{
+  assert(self && self->nalu_list);
+  gop_state_t *gop_state = &(self->gop_state);
+  h26x_nalu_list_item_t *item = self->nalu_list->first_item;
+  h26x_nalu_list_item_t *last_hashable_item = NULL;
+  // Statistics collected while looping through the NALUs.
+  int num_pending_gop_ends = 0;
+  bool found_pending_gop_sei = false;
+  bool found_pending_nalu_after_gop_sei = false;
+  bool found_pending_gop = false;
+
+  // Reset the |gop_state| members before running through the NALUs in |nalu_list|.
+  gop_state_reset(gop_state);
+
+  while (item && !found_pending_gop) {
+    gop_state_update(gop_state, item->nalu);
+    // Collect statistics from pending and hashable NALUs only. The others are either out of date or
+    // not part of the validation.
+    if (item->validation_status == 'P' && item->nalu && item->nalu->is_hashable) {
+      num_pending_gop_ends += (item->nalu->is_first_nalu_in_gop && !item->need_second_verification);
+      found_pending_gop_sei |= item->nalu->is_gop_sei;
+      found_pending_nalu_after_gop_sei |=
+          last_hashable_item && last_hashable_item->nalu->is_gop_sei;
+      last_hashable_item = item;
+    }
+    if (!self->validation_flags.signing_present) {
+      // If the video is not signed we need at least 2 I-frames to have a complete GOP.
+      found_pending_gop |= (num_pending_gop_ends >= 2);
+    } else {
+      // When the video is signed it is time to validate when there is at least one GOP and a SEI.
+      found_pending_gop |= (num_pending_gop_ends > 0) && found_pending_gop_sei;
+    }
+    // When a SEI is detected there can at most be one more NALU to perform validation.
+    found_pending_gop |= found_pending_nalu_after_gop_sei;
+    item = item->next;
+  }
+
+  if (!found_pending_gop && last_hashable_item && last_hashable_item->nalu->is_gop_sei) {
+    gop_state->validate_after_next_nalu = true;
+  }
+  gop_state->no_gop_end_before_sei = found_pending_nalu_after_gop_sei && (num_pending_gop_ends < 2);
+
+  return found_pending_gop;
+}
+
+/* Determines if the |item| is up for a validation.
+ * The NALU should be hashable and pending validation.
+ * If so, validation is triggered on any of the below
+ *   - a SEI (since if the SEI arrives late, the SEI is the final piece for validation)
+ *   - a new I-frame (since this marks the end of a GOP)
+ *   - the first hashable NALU right after a pending SEI (if a SEI has not been validated, we need
+ *     at most one more hashable NALU) */
+static bool
+validation_is_feasible(const h26x_nalu_list_item_t *item)
+{
+  if (!item->nalu) return false;
+  if (!item->nalu->is_hashable) return false;
+  if (item->validation_status != 'P') return false;
+
+  // Validation may be done upon a SEI.
+  if (item->nalu->is_gop_sei) return true;
+  // Validation may be done upon the end of a GOP.
+  if (item->nalu->is_first_nalu_in_gop && !item->need_second_verification) return true;
+  // Validation may be done upon a hashable NALU right after a SEI. This happens when the SEI was
+  // generated and attached to the same NALU that triggered the action.
+  item = item->prev;
+  while (item) {
+    if (item->nalu && item->nalu->is_hashable) {
+      break;
+    }
+    item = item->prev;
+  }
+  if (item && item->nalu->is_gop_sei && item->validation_status == 'P') return true;
+
+  return false;
 }
 
 /* Validates the authenticity of the video since last time if the state says so. After the
@@ -804,88 +880,72 @@ maybe_validate_gop(signed_video_t *self, h26x_nalu_t *nalu)
 {
   assert(self && nalu);
 
-  gop_state_t *gop_state = &(self->gop_state);
-  gop_info_detected_t *gop_info_detected = &(self->gop_info_detected);
+  validation_flags_t *validation_flags = &(self->validation_flags);
   signed_video_latest_validation_t *latest = self->latest_validation;
   h26x_nalu_list_t *nalu_list = self->nalu_list;
+  bool validation_feasible = true;
 
-  if (gop_state->auth_state != AUTH_STATE_VALIDATE) return SVI_OK;
-  // We cannot end up in AUTH_STATE_VALIDATE if the NALU is not hashable.
-  assert(nalu->is_hashable);
+  // Make sure the current NALU can trigger a validation.
+  validation_feasible &= validation_is_feasible(nalu_list->last_item);
+  // Make sure there is enough information to perform validation.
+  validation_feasible &= is_recurrent_data_decoded(self);
 
-  // Copy |gop_info_detected| and |gop_state| to struct |nalu_list|. This is needed if the public
-  // key arrives late. When public key eventually arrives, correct |gop_info_detected| and
-  // |gop_state| can be used for that specific gop.
-  if (nalu_list->gop_idx < MAX_PENDING_GOPS) {
-    memcpy(&nalu_list->gop_state_pending[nalu_list->gop_idx], gop_state, sizeof(gop_state_t));
-    memcpy(&nalu_list->gop_info_detected_pending[nalu_list->gop_idx], gop_info_detected,
-        sizeof(gop_info_detected_t));
-    nalu_list->gop_idx++;
-  } else {
-    DEBUG_LOG("Warning: Number of pending gops exeeds limit > %d", MAX_PENDING_GOPS);
-    return SVI_MEMORY;
-  }
-
-  if (!is_recurrent_data_decoded(self)) {
-    DEBUG_LOG("No recurrent data yet received");
+  // Abort if validation is not feasible.
+  if (!validation_feasible) {
+    // If this is the first arrived SEI, but could still not validate the authenticity, signal to
+    // the user that the Signed Video feature has been detected.
+    if (validation_flags->is_first_sei) {
+      latest->authenticity = SV_AUTH_RESULT_SIGNATURE_PRESENT;
+      latest->number_of_expected_picture_nalus = -1;
+      latest->number_of_received_picture_nalus = -1;
+      latest->number_of_pending_picture_nalus = h26x_nalu_list_num_pending_items(nalu_list);
+      latest->public_key_has_changed = false;
+      self->validation_flags.has_auth_result = true;
+    }
     return SVI_OK;
   }
 
-  // Initialize latest validation.
-  latest->authenticity = SV_AUTH_RESULT_NOT_OK;
-  latest->number_of_expected_picture_nalus = -1;
-  latest->number_of_received_picture_nalus = -1;
-  latest->number_of_pending_picture_nalus = -1;
-  latest->public_key_has_changed = false;
-
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
-    // Loop through possible pending gops and validate them
-    for (int i = 0; i < nalu_list->gop_idx; i++) {
-      memcpy(gop_state, &nalu_list->gop_state_pending[i], sizeof(gop_state_t));
-      memcpy(
-          gop_info_detected, &nalu_list->gop_info_detected_pending[i], sizeof(gop_info_detected_t));
-
-      // Need to force setting |is_first validation| since it is overwritten in the memcpy above
-      if (i > 0) gop_state->is_first_validation = false;
+    // Keep validating as long as there are pending GOPs.
+    bool stop_validating = false;
+    while (has_pending_gop(self) && !stop_validating) {
+      // Initialize latest validation.
+      latest->authenticity = SV_AUTH_RESULT_NOT_OK;
+      latest->number_of_expected_picture_nalus = -1;
+      latest->number_of_received_picture_nalus = -1;
+      latest->number_of_pending_picture_nalus = -1;
+      latest->public_key_has_changed = false;
 
       SVI_THROW(prepare_for_validation(self));
 
-      if (!gop_state->signing_present) {
-        verify_hashes_without_sei(self);
+      if (!validation_flags->signing_present) {
         latest->authenticity = SV_AUTH_RESULT_NOT_SIGNED;
+        // Since no validation is performed (all items are kept pending) a forced stop is introduced
+        // to avoid a dead lock.
+        stop_validating = true;
       } else {
         validate_authenticity(self);
       }
 
       // The flag |is_first_validation| is used to ignore the first validation if we start the
       // validation in the middle of a stream. Now it is time to reset it.
-      gop_state->is_first_validation = false;
+      validation_flags->is_first_validation = !validation_flags->signing_present;
 
-      // Reset the gop_state_t and gop_info_detected_t.
-      gop_state_reset(gop_state, gop_info_detected);
-      // If we find a pending SEI and it is the latest NALU the state should be
-      // AUTH_STATE_WAIT_FOR_NEXT_NALU.
-      h26x_nalu_list_item_t *sei = h26x_nalu_list_get_next_sei_item(nalu_list);
-      if (sei && (sei == self->nalu_list->last_item)) {
-        gop_info_detected->has_gop_sei = true;
-        gop_state->auth_state = AUTH_STATE_WAIT_FOR_NEXT_NALU;
-      }
-      // The current signature is no longer valid.
       self->gop_info->verified_signature_hash = -1;
+      self->validation_flags.has_auth_result = true;
+
+      // All statistics but pending NALUs have already been collected.
+      latest->number_of_pending_picture_nalus = h26x_nalu_list_num_pending_items(nalu_list);
+
+      DEBUG_LOG("Validated GOP as %s", kAuthResultValidStr[latest->authenticity]);
+      DEBUG_LOG("Expected number of NALUs = %d", latest->number_of_expected_picture_nalus);
+      DEBUG_LOG("Received number of NALUs = %d", latest->number_of_received_picture_nalus);
+      DEBUG_LOG("Number of pending NALUs = %d", latest->number_of_pending_picture_nalus);
     }
-    nalu_list->gop_idx = 0;
 
   SVI_CATCH()
   SVI_DONE(status)
-
-  // All statistics but pending NALUs have already been collected.
-  latest->number_of_pending_picture_nalus = h26x_nalu_list_num_pending_items(nalu_list);
-
-  DEBUG_LOG("Validated GOP as %s", kAuthResultValidStr[latest->authenticity]);
-  DEBUG_LOG("Expected number of NALUs = %d", latest->number_of_expected_picture_nalus);
-  DEBUG_LOG("Received number of NALUs = %d", latest->number_of_received_picture_nalus);
-  DEBUG_LOG("Number of pending NALUs = %d", latest->number_of_pending_picture_nalus);
 
   return status;
 }
@@ -927,27 +987,18 @@ register_nalu(signed_video_t *self, h26x_nalu_t *nalu)
 
 /* The basic order of actions are:
  * 1. Every NALU should be parsed and added to the h26x_nalu_list (|nalu_list|).
- * 2. Apply pre-actions depending on state and NALU, for example, moving from AUTH_STATE_INIT when
- *    we received the first "useful" NALU.
- * 3. Register NALU, in general that means hash the NALU if it is hashable and store it. Then update
- *    the gop_hash.
- * 4. Take action depending on state and NALU, then move to a new state. In principle this is done
- *    until we reach a no-action state. For example, the first state may be AUTH_STATE_GOP_END and
- *    the action is to verify the signature, followed by moving it to AUTH_STATE_VALIDATE. Then we
- *    validate the authenticity and move the state to AUTH_STATE_WAIT_FOR_GOP_END or
- *    AUTH_STATE_INIT.
- */
+ * 2. Update validation flags given the added NALU.
+ * 3. Register NALU, in general that means hash the NALU if it is hashable and store it.
+ * 4. Validate a pending GOP if possible. */
 static svi_rc
 signed_video_add_h26x_nalu(signed_video_t *self, const uint8_t *nalu_data, size_t nalu_data_size)
 {
   if (!self || !nalu_data || (nalu_data_size == 0)) return SVI_INVALID_PARAMETER;
 
   h26x_nalu_list_t *nalu_list = self->nalu_list;
-  gop_state_t *gop_state = &(self->gop_state);
-  gop_info_detected_t *gop_info_detected = &(self->gop_info_detected);
-  gop_state->has_auth_result = false;
   h26x_nalu_t nalu = parse_nalu_info(nalu_data, nalu_data_size, self->codec, true);
   DEBUG_LOG("Received a %s of size %zu B", nalu_type_to_str(&nalu), nalu.nalu_data_size);
+  self->validation_flags.has_auth_result = false;
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
@@ -958,15 +1009,10 @@ signed_video_add_h26x_nalu(signed_video_t *self, const uint8_t *nalu_data, size_
     // is set accordingly.
     SVI_THROW(h26x_nalu_list_append(nalu_list, &nalu));
     SVI_THROW_IF(nalu.is_valid < 0, SVI_UNKNOWN);
-    gop_state_pre_actions(&self->gop_state, &nalu);
+    update_validation_flags(&self->validation_flags, &nalu);
     SVI_THROW(register_nalu(self, &nalu));
-    gop_state_update(gop_state, gop_info_detected, &nalu);
     SVI_THROW(maybe_validate_gop(self, &nalu));
   SVI_CATCH()
-  {
-    // We aborted while processing the NALU; reset |auth_state|.
-    gop_state->auth_state = AUTH_STATE_INIT;
-  }
   SVI_DONE(status)
 
   // We need to make a copy of the |nalu| independently of failure.
@@ -998,7 +1044,7 @@ signed_video_add_nalu_and_authenticate(signed_video_t *self,
     SVI_THROW(create_local_authenticity_report_if_needed(self));
 
     SVI_THROW(signed_video_add_h26x_nalu(self, nalu_data, nalu_data_size));
-    if (self->gop_state.has_auth_result) {
+    if (self->validation_flags.has_auth_result) {
       if (authenticity) *authenticity = signed_video_get_authenticity_report(self);
       // Reset the timestamp for the next report.
       self->latest_validation->has_timestamp = false;

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -699,6 +699,40 @@ parse_nalu_info(const uint8_t *nalu_data,
 
 /* Helper function to public APIs */
 
+/* Internal APIs for validation_flags_t functions */
+
+/* Prints the |validation_flags| */
+void
+validation_flags_print(const validation_flags_t *validation_flags)
+{
+  if (!validation_flags) return;
+
+  DEBUG_LOG("         has_auth_result: %u", validation_flags->has_auth_result);
+  DEBUG_LOG("     is_first_validation: %u", validation_flags->is_first_validation);
+  DEBUG_LOG("         signing_present: %u", validation_flags->signing_present);
+  DEBUG_LOG("            is_first_sei: %u", validation_flags->is_first_sei);
+  DEBUG_LOG("");
+}
+
+void
+validation_flags_init(validation_flags_t *validation_flags)
+{
+  if (!validation_flags) return;
+
+  memset(validation_flags, 0, sizeof(validation_flags_t));
+  validation_flags->is_first_validation = true;
+}
+
+void
+update_validation_flags(validation_flags_t *validation_flags, h26x_nalu_t *nalu)
+{
+  if (!validation_flags || !nalu) return;
+
+  validation_flags->is_first_sei = !validation_flags->signing_present && nalu->is_gop_sei;
+  // As soon as we receive a SEI, Signed Video is present.
+  validation_flags->signing_present |= nalu->is_gop_sei;
+}
+
 /* Internal APIs for gop_state_t functions */
 
 /* Prints the |gop_state| */
@@ -707,84 +741,12 @@ gop_state_print(const gop_state_t *gop_state)
 {
   if (!gop_state) return;
 
-  DEBUG_LOG("        has_auth_result: %u", gop_state->has_auth_result);
-  DEBUG_LOG("    is_first_validation: %u", gop_state->is_first_validation);
-  DEBUG_LOG("        signing_present: %u", gop_state->signing_present);
-  DEBUG_LOG("num_pending_validations: %d", gop_state->num_pending_validations);
-  DEBUG_LOG("             auth_state: %d", gop_state->auth_state);
-  DEBUG_LOG("         cur_auth_state: %d", gop_state->cur_auth_state);
-  DEBUG_LOG("        prev_auth_state: %d", gop_state->prev_auth_state);
+  DEBUG_LOG("             has_gop_sei: %u", gop_state->has_gop_sei);
+  DEBUG_LOG("validate_after_next_nalu: %u", gop_state->validate_after_next_nalu);
+  DEBUG_LOG("   no_gop_end_before_sei: %u", gop_state->no_gop_end_before_sei);
+  DEBUG_LOG("            has_lost_sei: %u", gop_state->has_lost_sei);
+  DEBUG_LOG("  gop_transition_is_lost: %u", gop_state->gop_transition_is_lost);
   DEBUG_LOG("");
-}
-
-/* Initializes all counters and members of a |gop_state|. */
-void
-gop_state_init(gop_state_t *gop_state)
-{
-  if (!gop_state) return;
-
-  memset(gop_state, 0, sizeof(gop_state_t));
-  gop_state->is_first_validation = true;
-  gop_state->auth_state = AUTH_STATE_INIT;
-  gop_state->prev_auth_state = AUTH_STATE_INIT;
-}
-
-/* Initializes all counters and members of a |gop_info_detected|. */
-void
-gop_info_detected_init(gop_info_detected_t *gop_info_detected)
-{
-  if (!gop_info_detected) return;
-
-  memset(gop_info_detected, 0, sizeof(gop_info_detected_t));
-  gop_info_detected->has_gop_sei = false;
-}
-
-void
-gop_state_pre_actions(gop_state_t *gop_state, h26x_nalu_t *nalu)
-{
-  if (!gop_state || !nalu) return;
-
-  // The auth_state_t can only be updated if the NALU is hashable, that is, part of Signed Video.
-  if (!nalu->is_hashable) return;
-
-  // As soon as we receive a SEI, Signed Video is present.
-  gop_state->signing_present |= nalu->is_gop_sei;
-
-  // Store the previous auth_state.
-  gop_state->prev_auth_state = gop_state->cur_auth_state;
-  // If we receive an I NALU we have a GOP transition and should move to AUTH_STATE_GOP_END. The SEI
-  // can at earliest arrive just before the closing I NALU. If that is the case, we move to
-  // AUTH_STATE_WAIT_FOR_NEXT_NALU. Otherwise, being in the middle of a GOP, we should be in
-  // AUTH_STATE_WAIT_FOR_GOP_END.
-  auth_state_t is_sei_state =
-      nalu->is_gop_sei ? AUTH_STATE_WAIT_FOR_NEXT_NALU : AUTH_STATE_WAIT_FOR_GOP_END;
-  auth_state_t is_first_nalu_state = nalu->is_first_nalu_in_gop ? AUTH_STATE_GOP_END : is_sei_state;
-  // Default new state.
-  auth_state_t new_auth_state = is_first_nalu_state;
-  switch (gop_state->auth_state) {
-    case AUTH_STATE_INIT:
-    case AUTH_STATE_WAIT_FOR_GOP_END:
-      // Use default state.
-      break;
-    case AUTH_STATE_WAIT_FOR_NEXT_NALU:
-      // We got an 'on time' SEI and now received the last NALU, which means we have reached the end
-      // of a GOP.
-      new_auth_state = AUTH_STATE_GOP_END;
-      break;
-    case AUTH_STATE_GOP_END:
-      // We have passed a GOP transition and wait for the SEI to arrive. If we instead reach a new
-      // GOP transition (|is_first_nalu_in_gop|) it is time to validate the GOP without the SEI.
-      new_auth_state = nalu->is_first_nalu_in_gop ? AUTH_STATE_VALIDATE : AUTH_STATE_GOP_END;
-      break;
-    case AUTH_STATE_VALIDATE:
-    default:
-      // We should not end up here, but if we do move to AUTH_STATE_INIT.
-      new_auth_state = AUTH_STATE_INIT;
-      break;
-  }
-  gop_state->auth_state = new_auth_state;
-  // Store the current auth_state.
-  gop_state->cur_auth_state = gop_state->auth_state;
 }
 
 /* Updates the |gop_state| w.r.t. a |nalu|.
@@ -792,66 +754,28 @@ gop_state_pre_actions(gop_state_t *gop_state, h26x_nalu_t *nalu)
  * Since auth_state is updated along the way, the only thing we need to update is |has_gop_sei| to
  * know if we have received a signature for this GOP. */
 void
-gop_state_update(gop_state_t *gop_state, gop_info_detected_t *gop_info_detected, h26x_nalu_t *nalu)
+gop_state_update(gop_state_t *gop_state, h26x_nalu_t *nalu)
 {
-  if (!gop_state || !gop_info_detected || !nalu) return;
+  if (!gop_state || !nalu) return;
 
-  // If the NALU is not valid we should not take any actions.
+  // If the NALU is not valid nor hashable no action should be taken.
   if (nalu->is_valid <= 0 || !nalu->is_hashable) return;
 
-  gop_info_detected->has_gop_sei |= nalu->is_gop_sei;
-  // If we are in AUTH_STATE_GOP_END we have passed the transition to a new GOP. As soon as we have
-  // the SEI we can proceed to AUTH_STATE_VALIDATE.
-  if ((gop_state->auth_state == AUTH_STATE_GOP_END) && gop_info_detected->has_gop_sei) {
-    gop_state->auth_state = AUTH_STATE_VALIDATE;
-  }
+  gop_state->has_gop_sei |= nalu->is_gop_sei;
 }
 
 /* Resets the |gop_state| after validating a GOP. The function returns true if a reset of the
  * gop_hash is needed. */
 void
-gop_state_reset(gop_state_t *gop_state, gop_info_detected_t *gop_info_detected)
+gop_state_reset(gop_state_t *gop_state)
 {
-  if (!gop_state || !gop_info_detected) return;
+  if (!gop_state) return;
 
-  if (gop_state->auth_state != AUTH_STATE_VALIDATE) {
-    DEBUG_LOG("Unexpected try to reset GOP state");
-    return;
-  }
-
-  // In general, the reset is as follows:
-  //  - remove the flags { |has_gop_sei|, |has_lost_sei|, |gop_transition_is_lost| }, since they
-  //    were used in the latest validation
-  //  - decrease the |num_pending_validations| by one, since we have just consumed one
-  //  - set |auth_state| to AUTH_STATE_WAIT_FOR_GOP_END, since we have already moved passed the GOP
-  //    transition
-  //  - set the flag |has_auth_result| to communicate that we should provide an authenticity report
-  //    to the user
-  //
-  // There are two exceptions though
-  // 1) If there are still pending validations we move straight to AUTH_STATE_GOP_END, because we
-  //    have already moved passed another GOP transition.
-  // 2) If we have lost a SEI, but managed to detect a GOP transition, we used the SEI information
-  //    to validate the wrong GOP, hence we should not reset |has_gop_sei|, and we should move
-  //    straight to AUTH_STATE_GOP_END.
-
-  if (gop_info_detected->has_lost_sei && !gop_info_detected->gop_transition_is_lost) {
-    // The previous SEI never arrived. The latest one was used to validate the wrong GOP. Move to
-    // state AUTH_STATE_GOP_END.
-    gop_state->auth_state = AUTH_STATE_GOP_END;
-  } else {
-    gop_state->auth_state = AUTH_STATE_WAIT_FOR_GOP_END;
-    gop_info_detected->has_gop_sei = false;
-  }
-  // Decrease counter for pending validations.
-  gop_state->num_pending_validations--;
-  // If we still have pending validations, we should move straight to AUTH_STATE_GOP_END.
-  if (gop_state->num_pending_validations > 0) gop_state->auth_state = AUTH_STATE_GOP_END;
-  // Reset the rest of the flags.
-  gop_info_detected->has_lost_sei = false;
-  gop_info_detected->gop_transition_is_lost = false;
-  // Tell the user there is an authenticity result available.
-  gop_state->has_auth_result = true;
+  gop_state->has_lost_sei = false;
+  gop_state->gop_transition_is_lost = false;
+  gop_state->has_gop_sei = false;
+  gop_state->no_gop_end_before_sei = false;
+  gop_state->validate_after_next_nalu = false;
 }
 
 /* Others */
@@ -1058,7 +982,6 @@ hash_and_add_for_auth(signed_video_t *self, const h26x_nalu_t *nalu)
 
   gop_info_t *gop_info = self->gop_info;
   gop_state_t *gop_state = &self->gop_state;
-  gop_info_detected_t gop_info_detected = self->gop_info_detected;
 
   // Store the hash in the |last_item| of |nalu_list|.
   h26x_nalu_list_item_t *this_item = self->nalu_list->last_item;
@@ -1073,11 +996,8 @@ hash_and_add_for_auth(signed_video_t *self, const h26x_nalu_t *nalu)
     // Check if we have a potential transition to a new GOP. This happens if the current NALU
     // |is_first_nalu_in_gop|. If we have lost the first NALU of a GOP we can still make a guess by
     // checking if |has_gop_sei| flag is set. It is set if the previous hashable NALU was SEI.
-    if (nalu->is_first_nalu_in_gop || gop_info_detected.has_gop_sei) {
-      assert(gop_state->num_pending_validations >= 0);
-
+    if (nalu->is_first_nalu_in_gop || (gop_state->validate_after_next_nalu && !nalu->is_gop_sei)) {
       // Updates counters and reset flags.
-      gop_state->num_pending_validations++;
       gop_info->has_reference_hash = false;
 
       // Hash the NALU again, but this time store the hash as a |second_hash|. This is needed since
@@ -1131,8 +1051,8 @@ signed_video_create(SignedVideoCodec codec)
     // authentication side. The check is done there instead.
 
     self->signing_present = -1;
-    gop_state_init(&(self->gop_state));
-    gop_info_detected_init(&(self->gop_info_detected));
+    gop_state_reset(&(self->gop_state));
+    validation_flags_init(&(self->validation_flags));
 
     self->last_two_bytes = LAST_TWO_BYTES_INIT_VALUE;
     for (int i = 0; i < MAX_NALUS_TO_PREPEND; i++) {
@@ -1184,8 +1104,8 @@ signed_video_reset(signed_video_t *self)
     self->gop_info->has_reference_hash = false;
     self->gop_info->global_gop_counter_is_synced = false;
 
-    gop_state_init(&(self->gop_state));
-    gop_info_detected_init(&(self->gop_info_detected));
+    gop_state_reset(&(self->gop_state));
+    validation_flags_init(&(self->validation_flags));
     latest_validation_init(self->latest_validation);
     // Empty the |nalu_list|.
     h26x_nalu_list_free_items(self->nalu_list);

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -29,8 +29,6 @@
 typedef struct _h26x_nalu_list_item_t h26x_nalu_list_item_t;
 typedef struct _h26x_nalu_t h26x_nalu_t;
 
-#define MAX_PENDING_GOPS 120
-
 typedef enum {
   NALU_TYPE_UNDEFINED = 0,
   NALU_TYPE_SEI = 1,
@@ -65,11 +63,6 @@ struct _h26x_nalu_list_t {
   h26x_nalu_list_item_t *last_item;  // Points to the last item in the linked list, that is, the
   // latest NALU added for validation.
   int num_items;  // The number of items linked together in the list.
-
-  // Keep pending gop data needed for validation if public_key is late
-  gop_state_t gop_state_pending[MAX_PENDING_GOPS];
-  gop_info_detected_t gop_info_detected_pending[MAX_PENDING_GOPS];
-  int gop_idx;
 };
 
 /**
@@ -148,29 +141,25 @@ struct _h26x_nalu_t {
 /* Internal APIs for gop_state_t functions */
 
 void
+validation_flags_print(const validation_flags_t *validation_flags);
+
+void
+validation_flags_init(validation_flags_t *validation_flags);
+
+/* Updates the |gop_state| w.r.t. a |nalu|. */
+void
+update_validation_flags(validation_flags_t *validation_flags, h26x_nalu_t *nalu);
+
+void
 gop_state_print(const gop_state_t *gop_state);
 
-/* Initializes all counters and members of a |gop_state|. */
+/* Updates the |gop_state| w.r.t. a |nalu|. */
 void
-gop_state_init(gop_state_t *gop_state);
+gop_state_update(gop_state_t *gop_state, h26x_nalu_t *nalu);
 
-/* Initializes all counters and members of |gop_info_detected|. */
+/* Resets/Initializes the |gop_state| after validating a GOP. */
 void
-gop_info_detected_init(gop_info_detected_t *gop_info_detected);
-
-/* Updates the |gop_state| and |gop_info_detected| w.r.t. a |nalu|. */
-void
-gop_state_update(gop_state_t *gop_state, gop_info_detected_t *gop_info_detected, h26x_nalu_t *nalu);
-
-/* Changes the current |gop_state|, given the new received |nalu|. This is called prior to any
- * actions, since it may involve a necessary reset of the gop_hash. */
-void
-gop_state_pre_actions(gop_state_t *gop_state, h26x_nalu_t *nalu);
-
-/* Resets the |gop_state| after validating a GOP. The function returns true if a reset of the
- * gop_hash is needed. */
-void
-gop_state_reset(gop_state_t *gop_state, gop_info_detected_t *gop_info_detected);
+gop_state_reset(gop_state_t *gop_state);
 
 /* Others */
 void

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -31,8 +31,8 @@
 #include "signed_video_defines.h"  // svi_rc, sv_tlv_tag_t
 
 typedef struct _gop_info_t gop_info_t;
+typedef struct _validation_flags_t validation_flags_t;
 typedef struct _gop_state_t gop_state_t;
-typedef struct _gop_info_detected_t gop_info_detected_t;
 
 // Forward declare h26x_nalu_list_t here for signed_video_t.
 typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
@@ -72,52 +72,25 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 
 #define HASH_LIST_SIZE (HASH_DIGEST_SIZE * MAX_GOP_LENGTH)
 
-/**
- * The authentication state machine
- * The process of validating the authenticity of a video is described by a set of operating states.
- * The main goal is to produce an authentication result. This is done when the end of a GOP is
- * reached.
- *
- * The basic processing flow of a NALU can be found in the description of
- * signed_video_add_h26x_nalu().
- */
-typedef enum {
-  AUTH_STATE_INIT = 0,  // The initial state; waiting for a first hashable NALU.
-  AUTH_STATE_WAIT_FOR_GOP_END = 1,  // The normal state where NALUs are hashed and added. This state
-  // is left as soon as a SEI is received, or if a new GOP with an I NALU is detected.
-  AUTH_STATE_WAIT_FOR_NEXT_NALU = 2,  // The SEI prepends a picture NALU, and in some situations the
-  // hash of that NALU is included in the document hash generating the signature. Hence, the
-  // framework needs to wait for another NALU before authenticity validation can be performed.
-  AUTH_STATE_GOP_END = 3,  // Received an I NALU. The framework is ready for validation when the
-  // SEI has been received.
-  AUTH_STATE_VALIDATE = 4,  // Validate authenticity and produce an authentication result.
-} auth_state_t;
-
-struct _gop_state_t {
-  bool has_auth_result;  // State to indicate that an authenticity result is available for the user.
-  bool is_first_validation;  // State to indicate if this is the first validation. If so, a failing
-  // validation result is not necessarily true, since the framework may be out of sync, e.g. after
+struct _validation_flags_t {
+  bool has_auth_result;  // Indicates that an authenticity result is available for the user.
+  bool is_first_validation;  // Indicates if this is the first validation. If so, a failing
+  // validation result is not necessarily true, since the framework may be out of sync, e.g., after
   // exporting to a file.
-  bool signing_present;  // State to indicate if Signed Video is present or not. It is only possible
-  // to move from false to true unless a reset is performed.
-  // TODO: Get rid of the dependency of |num_pending_validations|.
-  int num_pending_validations;  // Counter for number of pending validations.
-  auth_state_t auth_state;  // Operating state of the authentication process.
-
-  // Some detection is done while decoding the SEI and based on the |auth_state|, and some are done
-  // when decoding the SEI, which is done upon validation. Therefore, both current and previous
-  // states of |auth_state|, after calling gop_state_pre_actions(), are stored.
-  auth_state_t cur_auth_state;  // Current |auth_state| after gop_state_pre_actions().
-  auth_state_t prev_auth_state;  // Previous |cur_auth_state|.
+  bool signing_present;  // Indicates if Signed Video is present or not. It is only possible to move
+  // from false to true unless a reset is performed.
+  bool is_first_sei;  // Indicates that this is the first received SEI.
 };
 
-struct _gop_info_detected_t {
-  bool has_gop_sei;  // State to indicate that the current GOP has received a SEI NALU.
-  // The authenticity is not always validated directly when a SEI NALU is received.
-  bool has_lost_sei;  // State to indicate if the SEI NALU of the GOP was lost.
-  bool gop_transition_is_lost;  // State to indicate if the transition between GOPs has been lost.
+struct _gop_state_t {
+  bool has_gop_sei;  // The GOP includes a SEI.
+  bool has_lost_sei;  // Has detected a lost SEI since last validation.
+  bool no_gop_end_before_sei;  // No GOP end (I-frame) has been found before the SEI.
+  bool gop_transition_is_lost;  // The transition between GOPs has been lost.
   // This can be detected if a lost SEI is detected, and at the same time waiting for an I NALU. An
   // example when this happens is if an entire AU is lost including both the SEI and the I NALU.
+  bool validate_after_next_nalu;  // State to inform the algorithm to perform validation up the next
+  // hashable NALU.
 };
 
 struct _signed_video_t {
@@ -152,8 +125,8 @@ struct _signed_video_t {
   h26x_nalu_list_t *nalu_list;
   bool authentication_started;
 
+  validation_flags_t validation_flags;
   gop_state_t gop_state;
-  gop_info_detected_t gop_info_detected;
   unsigned recurrence;
   unsigned recurrence_offset;
 

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -290,9 +290,21 @@ START_TEST(intact_stream)
   struct validation_stats expected = {.valid_gops = 7, .pending_nalus = 7};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 5;
-      expected.pending_nalus = 5;
-      expected.has_signature = 2;
+      // The Public Key is present in G* and as soon as this SEI shows up it is possible to start
+      // validation
+      //
+      // GIPPGIPPG*IPPGIPPGIPPGIPPGI
+      //
+      // G                           -> (signature) -> P         (1 pending)
+      // GIPPGIPPG*                  ->     (valid) -> .....PPPP (4 pending)
+      //      IPPG*I                 ->     (valid) -> ....P     (1 pending)
+      //           IPPGI             ->     (valid) -> ....P
+      //               IPPGI         ->     (valid) -> ....P
+      //                   IPPGI     ->     (valid) -> ....P
+      //                       IPPGI ->     (valid) -> ....P
+      expected.valid_gops = 6;
+      expected.pending_nalus = 10;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -313,9 +325,17 @@ START_TEST(intact_multislice_stream)
   struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 3};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 1;
-      expected.pending_nalus = 1;
-      expected.has_signature = 2;
+      // The Public Key is present in G* and as soon as this SEI shows up it is possible to start
+      // validation
+      //
+      // GIiPpPpGIiPpPpG*Ii
+      //
+      // G                 -> (signature) -> P               (1 pending)
+      // GIiPpPpGIiPpPpG*  ->     (valid) -> ........PPPPPPP (7 pending)
+      //         IiPpPpG*I ->     (valid) -> .......P        (1 pending)
+      expected.valid_gops = 2;
+      expected.pending_nalus = 9;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -339,9 +359,9 @@ START_TEST(intact_stream_with_pps_nalu_stream)
   struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 3};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 1;
-      expected.pending_nalus = 1;
-      expected.has_signature = 2;
+      expected.valid_gops = 2;
+      expected.pending_nalus = 6;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -365,13 +385,26 @@ START_TEST(intact_stream_with_pps_bytestream)
   nalu_list_append_item(list, item, 1);
   nalu_list_check_str(list, "GVIPPGIPPGI");
 
+  // GVIPPGIPPGI
+  //
+  // GVI         -> (valid) ._P   (1 pending)
+  //   IPPGI     -> (valid) ....P (1 pending)
+  //       IPPGI -> (valid) ....P (1 pending)
   // One pending NALU per GOP.
-  struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 3};
+  struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 3, .has_signature = 0};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 1;
-      expected.pending_nalus = 1;
-      expected.has_signature = 2;
+      // The Public Key is present in G* and as soon as this SEI shows up it is possible to start
+      // validation
+      //
+      // GVIPPGIPPG*I
+      //
+      // G            -> (signature) -> P          (1 pending)
+      // GVIPPGIPPG*  ->     (valid) -> ._....PPPP (4 pending)
+      //       IPPG*I ->     (valid) -> ....P      (1 pending)
+      expected.valid_gops = 2;
+      expected.pending_nalus = 6;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -392,9 +425,9 @@ START_TEST(intact_ms_stream_with_pps_nalu_stream)
   struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 3};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 1;
-      expected.pending_nalus = 1;
-      expected.has_signature = 2;
+      expected.valid_gops = 2;
+      expected.pending_nalus = 9;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -422,9 +455,9 @@ START_TEST(intact_ms_stream_with_pps_bytestream)
   struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 3};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 1;
-      expected.pending_nalus = 1;
-      expected.has_signature = 2;
+      expected.valid_gops = 2;
+      expected.pending_nalus = 9;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -453,9 +486,9 @@ START_TEST(intact_with_undefined_nalu_in_stream)
   struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 3};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 1;
-      expected.pending_nalus = 1;
-      expected.has_signature = 2;
+      expected.valid_gops = 2;
+      expected.pending_nalus = 6;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -476,9 +509,9 @@ START_TEST(intact_with_undefined_multislice_nalu_in_stream)
   struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 3};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 1;
-      expected.pending_nalus = 1;
-      expected.has_signature = 2;
+      expected.valid_gops = 2;
+      expected.pending_nalus = 9;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -518,16 +551,28 @@ START_TEST(remove_one_p_nalu)
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_GOP) {
-        expected.valid_gops = 0;
+        // GIPPGIPPG*IPPGI
+        //
+        // G               -> (signature) -> P
+        // GIPPGIPPG*      ->     (valid) -> .....PPPP (4 pending)
+        //      IPPG*I     ->   (invalid) -> NNNNP     (1 pending)
+        //           IPPGI ->   (invalid) -> N...P
+        expected.valid_gops = 1;
         expected.invalid_gops = 2;
-        expected.pending_nalus = 2;
-        expected.has_signature = 2;
+        expected.pending_nalus = 7;
+        expected.has_signature = 1;
       }
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
-        expected.valid_gops = 1;
+        // GIPPGIPPG*IPPGI
+        //
+        // G               -> (signature) -> P
+        // GIPPGIPPG*      ->     (valid) -> .....PPPP (4 pending)
+        //      IPPG*I     ->   (missing) -> ..M..P    (1 pending)
+        //           IPPGI ->     (valid) -> ....P
+        expected.valid_gops = 2;
         expected.invalid_gops = 0;
-        expected.pending_nalus = 2;
-        expected.has_signature = 2;
+        expected.pending_nalus = 7;
+        expected.has_signature = 1;
       }
     }
   }
@@ -568,16 +613,28 @@ START_TEST(interchange_two_p_nalus)
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_GOP) {
-        expected.valid_gops = 0;
+        // GIPPGIPPPG*IPPGI
+        //
+        // G                -> (signature) -> P
+        // GIPPGIPPPG*      ->     (valid) -> .....PPPPP (5 pending)
+        //      IPPPG*I     ->   (invalid) -> NNNNNP     (1 pending)
+        //            IPPGI ->   (invalid) -> N...P
+        expected.valid_gops = 1;
         expected.invalid_gops = 2;
-        expected.pending_nalus = 2;
-        expected.has_signature = 2;
+        expected.pending_nalus = 8;
+        expected.has_signature = 1;
       }
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
-        expected.valid_gops = 1;
+        // GIPPGIPPPG*IPPGI
+        //
+        // G                -> (signature) -> P
+        // GIPPGIPPPG*      ->     (valid) -> .....PPPPP (5 pending)
+        //      IPPPG*I     ->   (invalid) -> ..NN.P     (1 pending)
+        //            IPPGI ->     (valid) -> ....P
+        expected.valid_gops = 2;
         expected.invalid_gops = 1;
-        expected.pending_nalus = 2;
-        expected.has_signature = 2;
+        expected.pending_nalus = 8;
+        expected.has_signature = 1;
       }
     }
   }
@@ -613,16 +670,28 @@ START_TEST(modify_one_p_nalu)
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_GOP) {
+        // GIPPGIPPPG*IPPGI
+        //
+        // G                -> (signature) -> P
+        // GIPPGIPPPG*      ->   (invalid) -> .NNNNPPPPP (5 pending)
+        //      IPPPG*I     ->   (invalid) -> NNNNNP     (1 pending)
+        //            IPPGI ->     (valid) -> ....P
         expected.valid_gops = 1;
-        expected.invalid_gops = 1;
-        expected.pending_nalus = 2;
-        expected.has_signature = 2;
+        expected.invalid_gops = 2;
+        expected.pending_nalus = 8;
+        expected.has_signature = 1;
       }
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
-        expected.valid_gops = 1;
+        // GIPPGIPPPG*IPPGI
+        //
+        // G                -> (signature) -> P
+        // GIPPGIPPPG*      ->   (invalid) -> ...N.PPPPP (5 pending)
+        //      IPPPG*I     ->     (valid) -> .....P     (1 pending)
+        //            IPPGI ->     (valid) -> ....P
+        expected.valid_gops = 2;
         expected.invalid_gops = 1;
-        expected.pending_nalus = 2;
-        expected.has_signature = 2;
+        expected.pending_nalus = 8;
+        expected.has_signature = 1;
       }
     }
   }
@@ -656,15 +725,27 @@ START_TEST(modify_one_i_nalu)
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_GOP) {
+        // GIPPGIPPPG*IPPGI
+        //
+        // G                -> (signature) -> P
+        // GIPPGIPPPG*      ->   (invalid) -> .NNNNPPPPP (5 pending)
+        //      IPPPG*I     ->   (invalid) -> NNNNNP     (1 pending)
+        //            IPPGI ->   (invalid) -> N...P
         expected.valid_gops = 0;
-        expected.invalid_gops = 2;
-        expected.pending_nalus = 2;
-        expected.has_signature = 2;
+        expected.invalid_gops = 3;
+        expected.pending_nalus = 8;
+        expected.has_signature = 1;
       }
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
-        expected.valid_gops = 0;
-        expected.pending_nalus = 2;
-        expected.has_signature = 2;
+        // GIPPGIPPPG*IPPGI
+        //
+        // G                -> (signature) -> P
+        // GIPPGIPPPG*      ->     (valid) -> .....PPPPP (5 pending)
+        //      IPPPG*I     ->   (invalid) -> NNNN.P     (1 pending)
+        //            IPPGI ->   (invalid) -> N...P
+        expected.valid_gops = 1;
+        expected.pending_nalus = 8;
+        expected.has_signature = 1;
       }
     }
   }
@@ -695,20 +776,25 @@ START_TEST(remove_the_g_nalu)
   remove_item_then_check_and_free(list, remove_nalu_number, "G");
   nalu_list_check_str(list, "GIPPGIPPIPPGIPPGI");
 
-  // We will get 8 pending nalus:
+  // GIPPGIPPIPPGIPPGI
   //
-  // GI        valid & 1 pending
-  // IPPGI     valid & 1 pending
-  // IPPIPPG invalid & 4 pending (last 4) since they will be validated next time
-  // IPPGI   invalid & 1 pending
-  // IPPGI     valid & 1 pending
+  // GI                ->   (valid) -> .P
+  //  IPPGI            ->   (valid) -> ....P
+  //      IPPIPPG      -> (invalid) -> NNNPPPP
+  //         IPPGI     -> (invalid) -> N...P
+  //             IPPGI ->   (valid) -> ....P
   struct validation_stats expected = {.valid_gops = 3, .invalid_gops = 2, .pending_nalus = 8};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
+      // Note that the SEI including the Public Key was removed and a second validation result is
+      // never produced.
+      // GIPPGIPPIPPGIPPGI
+      //
+      // GI                -> (signature) -> P
       expected.valid_gops = 0;
       expected.invalid_gops = 0;
-      expected.pending_nalus = 0;
-      expected.has_signature = 4;
+      expected.pending_nalus = 1;
+      expected.has_signature = 1;
       expected.has_no_timestamp = true;
     }
   }
@@ -736,23 +822,49 @@ START_TEST(remove_the_i_nalu)
   // gop_hashes. At GOP level the missing NALU will make the GOP invalid, but for Frame level we can
   // identify the missed NALU when the I NALU is not the reference, that is, the first GOP is valid
   // with missing info, whereas the second becomes invalid.
+  // GIPPGIPPGPPGIPPGI
+  //
+  // GI                ->   (valid) -> .P
+  //  IPPGI            ->   (valid) -> ....P
+  //      IPPGP        -> (invalid) -> NNNNP
+  //          PPGI     -> (invalid) -> MNNNP (1 missing)
+  //             IPPGI -> (invalid) -> N...P
   struct validation_stats expected = {
       .valid_gops = 2, .invalid_gops = 3, .missed_nalus = 1, .pending_nalus = 5};
   if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
+    // GI                ->   (valid) -> .P
+    //  IPPGI            ->   (valid) -> ....P
+    //      IPPGP        ->   (valid) -> ....P
+    //          PPGI     -> (invalid) -> MNNNP (1 missing)
+    //             IPPGI -> (invalid) -> N...P
     expected.valid_gops = 3;
     expected.invalid_gops = 2;
   }
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_GOP) {
-        expected.valid_gops = 0;
-        expected.pending_nalus = 3;
-        expected.has_signature = 2;
+        // GIPPGIPPG*PPGIPPGI
+        //
+        // G                 -> (signature) -> P
+        // GIPPGIPPG*        ->     (valid) -> .....PPPP
+        //      IPPG*P       ->   (invalid) -> NNNNP
+        //          PPGI     ->   (invalid) -> MNNNP (1 missing)
+        //             IPPGI ->   (invalid) -> N...P
+        expected.valid_gops = 1;
+        expected.pending_nalus = 8;
+        expected.has_signature = 1;
       }
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
-        expected.valid_gops = 1;
-        expected.pending_nalus = 3;
-        expected.has_signature = 2;
+        // GIPPGIPPG*PPGIPPGI
+        //
+        // G                 -> (signature) -> P
+        // GIPPGIPPG*        ->     (valid) -> .....PPPP
+        //      IPPG*P       ->     (valid) -> ....P
+        //          PPGI     ->   (invalid) -> MNNNP (1 missing)
+        //             IPPGI ->   (invalid) -> N...P
+        expected.valid_gops = 2;
+        expected.pending_nalus = 8;
+        expected.has_signature = 1;
       }
     }
   }
@@ -788,11 +900,13 @@ START_TEST(remove_the_gi_nalus)
       .valid_gops = 2, .invalid_gops = 2, .missed_nalus = -2, .pending_nalus = 4};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
+      // Note that the SEI including the Public Key is lost, hence there is only one validation
+      // performed.
       expected.valid_gops = 0;
       expected.invalid_gops = 0;
       expected.missed_nalus = 0;
-      expected.pending_nalus = 0;
-      expected.has_signature = 4;
+      expected.pending_nalus = 1;
+      expected.has_signature = 1;
       expected.has_no_timestamp = true;
     }
   }
@@ -829,9 +943,15 @@ START_TEST(sei_arrives_late)
   struct validation_stats expected = {.valid_gops = 4, .pending_nalus = 5};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 2;
-      expected.pending_nalus = 2;
-      expected.has_signature = 2;
+      // GIPPPIPGPPG*IPPPGI
+      //
+      // G                  -> (signature) -> P
+      // GIPPPIPGPPG*       ->     (valid) -> .....PP.PPP
+      //      IPGPPG*I      ->     (valid) -> ......P
+      //             IPPPGI ->     (valid) -> .....P
+      expected.valid_gops = 3;
+      expected.pending_nalus = 8;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -843,7 +963,7 @@ END_TEST
 // TODO: Generalize this function.
 /* Helper function that generates a fixed list with delayed SEIs. */
 static nalu_list_t *
-generate_delayed_sei_list(struct sv_setting setting)
+generate_delayed_sei_list(struct sv_setting setting, bool extra_delay)
 {
   // Make first GOP one P-frame longer to trigger recurrence on second I-frame.
   nalu_list_t *list = create_signed_nalus("IPPPPIPPPIPPPIPPPIP", setting);
@@ -851,23 +971,29 @@ generate_delayed_sei_list(struct sv_setting setting)
 
   // Remove each SEI in the list and append it 2 items later (which in practice becomes 1 item later
   // since we just removed the SEI).
+  int extra_offset = extra_delay ? 5 : 0;
+  int extra_correction = extra_delay ? 1 : 0;
   nalu_list_item_t *sei = nalu_list_remove_item(list, 1);
   nalu_list_item_check_str(sei, "G");
-  nalu_list_append_item(list, sei, 2);
-  sei = nalu_list_remove_item(list, 7);
+  nalu_list_append_item(list, sei, 2 + extra_offset);
+  sei = nalu_list_remove_item(list, 7 - extra_correction);
   nalu_list_item_check_str(sei, "G");
-  nalu_list_append_item(list, sei, 8);
-  sei = nalu_list_remove_item(list, 12);
+  nalu_list_append_item(list, sei, 8 + extra_offset);
+  sei = nalu_list_remove_item(list, 12 - extra_correction);
   nalu_list_item_check_str(sei, "G");
-  nalu_list_append_item(list, sei, 13);
-  sei = nalu_list_remove_item(list, 17);
+  nalu_list_append_item(list, sei, 13 + extra_offset);
+  sei = nalu_list_remove_item(list, 17 - extra_correction);
   nalu_list_item_check_str(sei, "G");
-  nalu_list_append_item(list, sei, 18);
-  sei = nalu_list_remove_item(list, 22);
+  nalu_list_append_item(list, sei, 18 + extra_offset);
+  sei = nalu_list_remove_item(list, 22 - extra_correction);
   nalu_list_item_check_str(sei, "G");
   nalu_list_append_item(list, sei, 23);
 
-  nalu_list_check_str(list, "IPGPPPIPGPPIPGPPIPGPPIPG");
+  if (extra_delay) {
+    nalu_list_check_str(list, "IPPPPIGPPPIPGPPIPGPPIPGG");
+  } else {
+    nalu_list_check_str(list, "IPGPPPIPGPPIPGPPIPGPPIPG");
+  };
   return list;
 }
 
@@ -880,16 +1006,31 @@ START_TEST(all_seis_arrive_late)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = generate_delayed_sei_list(settings[_i]);
+  nalu_list_t *list = generate_delayed_sei_list(settings[_i], true);
 
-  // The late arrival SEIs will introduce one pending NALU per GOP (the P frame right before the
-  // SEI) except the last GOP, where the SEI is NOT late.  5 GOPs * 2 pending NALUs/GOP = 10
-  // pending NALUs
-  struct validation_stats expected = {.valid_gops = 5, .pending_nalus = 10};
+  // IPPPPIGPPPIPGPPIPGPPIPGG
+  //
+  // IPPPPI                   -> (no signature) -> PPPPPP         6 pending
+  // IPPPPIG                  ->        (valid) -> PPPPPP.        6 pending
+  // IPPPPIGPPPIPG            ->        (valid) -> .....P.PPPPP.  6 pending
+  //      IGPPPIPGPPIPG       ->        (valid) -> .....PP.PPPP.  6 pending
+  //           IPGPPIPGPPIPG  ->        (valid) -> .....PP.PPPP.  6 pending
+  //                IPGPPIPGG ->        (valid) -> .....PP..      2 pending
+  //                                                32 pending
+  struct validation_stats expected = {.valid_gops = 5, .unsigned_gops = 1, .pending_nalus = 32};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
-    expected.valid_gops = 4;
-    expected.pending_nalus = 8;  // 2 * valid_gops
+    // IPPPPIGPPPIPG*PPIPGPPIPGG
+    //
+    // IPPPPI                    -> (no signature) -> PPPPPP         6 pending [first complete GOP]
+    // IPPPPIG                   ->    (signature) -> PPPPPPP        7 pending
+    // IPPPPIGPPPIPG*            ->        (valid) -> .....P.PPPPP.  6 pending
+    //      IGPPPIPG*PPIPG       ->        (valid) -> .....PP.PPPP.  6 pending
+    //           IPG*PPIPGPPIPG  ->        (valid) -> .....PP.PPPP.  6 pending
+    //                 IPGPPIPGG ->        (valid) -> .....PP..      2 pending
+    //                                                      33 pending
+    expected.valid_gops = 4;  // First two bundled together
     expected.has_signature = 1;  // First validation result
+    expected.pending_nalus = 33;
   }
   validate_nalu_list(NULL, list, expected);
 
@@ -924,22 +1065,24 @@ START_TEST(lost_g_before_late_sei_arrival)
   remove_item_then_check_and_free(list, 6, "G");
   nalu_list_check_str(list, "GIPPPIPPPIPGPPGIPPGI");
 
-  // We will get 10 pending nalus:
-  //
-  // GI           valid & 1 pending
-  // IPPPIPPPI  invalid & 5 pending (last IPPPI) since they will be validated next time
-  // IPPPIPG    invalid & 2 pending (last IP) since it will be validated next time, due
-  //                to late SEI. Invalid since the linked I-frame was not possible to
-  //                verify the first time
-  // IP(G)PPGI    valid & 1 pending
-  // IPPGI        valid & 1 pending
-  struct validation_stats expected = {.valid_gops = 3, .invalid_gops = 2, .pending_nalus = 10};
+  // GI                   ->   (valid) -> .P           1 pending
+  //  IPPPIPPPIPG         -> (invalid) -> NNNNN...PP.  2 pending (two GOPs in one validation)
+  //          IPGPPGI     ->   (valid) -> ......P      1 pending
+  //                IPPGI ->   (valid) -> ....P        1 pending
+  //                                             5 pending
+  struct validation_stats expected = {.valid_gops = 3, .invalid_gops = 1, .pending_nalus = 5};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 2;
-      expected.invalid_gops = 1;
-      expected.pending_nalus = 4;
-      expected.has_signature = 2;
+      // GIPPPIPPPIPG*PPGIPPGI
+      //
+      // G                     -> (signature)-> .P            1 pending
+      // GIPPPIPPPIPG*         ->   (invalid)-> .NNNNN...PP.  2 pending (two GOPs in one validation)
+      //          IPG*PPGI     ->     (valid)-> ......P       1 pending
+      //                 IPPGI ->     (valid)-> ....P         1 pending
+      //                                               5 pending
+      expected.valid_gops = 2;  // First two GOPs are bundled, only last GOP shows up in "latest".
+      expected.pending_nalus = 5;  // First two GOPs are bundled.
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -991,15 +1134,18 @@ START_TEST(lost_g_and_gop_with_late_sei_arrival)
   nalu_list_append_item(list, sei, 12);
   nalu_list_check_str(list, "IPGPPIPGPPIPG");
 
-  // We will get 6 pending nalus:
-  //
-  // IPG         has_signature & 2 pending (IP)
-  // IP(G)PPIPG  valid & 2 pending (last IP) since they will be validated next time
-  // IP(G)PPIPG  valid & 2 pending (last IP)
+  // IPG            -> (signature) -> PPU
+  // IPGPPIPG*      ->     (valid) -> ..U..PP.
+  //      IPG*PPIPG ->     (valid) -> .....PP.
   struct validation_stats expected = {.valid_gops = 2, .pending_nalus = 6, .has_signature = 1};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     // The two pending NALUs of the first validation will not be noticed.
-    expected.pending_nalus = 4;
+    // IPGPPIPG*PPIPG
+    //
+    // IPG            -> (signature) -> PPP
+    // IPGPPIPG*      ->     (valid) -> ..U..PP. TODO: Here we detect a missing SEI; signal invalid?
+    //      IPG*PPIPG ->     (valid) -> .....PP.
+    expected.pending_nalus = 7;
   }
   validate_nalu_list(NULL, list, expected);
 
@@ -1027,24 +1173,49 @@ START_TEST(lost_all_nalus_between_two_seis)
   // We have NALUs from 5 GOPs present and each GOP will produce one pending NALU. The lost NALUs
   // (IPPP) will be detected, but for SV_AUTHENTICITY_LEVEL_FRAME we will measure one extra missing
   // NALU. This is a descrepancy in the way we count NALUs by excluding SEIs.
-  // TODO: Fix the measured difference in missed_nalus.
+  //
+  // GIPPPGGIPPPGIPPGI
+  //
+  // GI                ->   (valid) -> .P
+  //  IPPPGG           -> (invalid) -> NNNNNP
+  //       GI          -> (invalid) -> MMMMNP (4 missed)
+  //        IPPPGI     -> (invalid) -> N....P
+  //             IPPGI ->   (valid) -> ....P
   struct validation_stats expected = {
       .valid_gops = 2, .invalid_gops = 3, .missed_nalus = 4, .pending_nalus = 5};
   if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
+    // GIPPPGGIPPPGIPPGI
+    //
+    // GI                ->   (valid) -> .P
+    //  IPPPGG           ->   (valid) -> .....P
+    //       GI          -> (invalid) -> MMMM.P (4 missed)
+    //        IPPPGI     -> (invalid) -> N....P
+    //             IPPGI ->   (valid) -> ....P
     expected.valid_gops = 3;
     expected.invalid_gops = 2;
-    expected.missed_nalus = 5;
   }
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_GOP) {
+        // GIPPPGG*IPPPGIPPGI
+        //
+        // G                  -> (signature) -> P
+        // GIPPPGG*           ->   (invalid) -> .NNNNNP
+        //       G*I          ->   (invalid) -> MMMMNP (4 missed)
+        //         IPPPGI     ->   (invalid) -> N....P
+        //              IPPGI ->     (valid) -> ....P
         expected.valid_gops = 1;
-        expected.pending_nalus = 4;
         expected.has_signature = 1;
       }
       if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
+        // GIPPPGG*IPPPGIPPGI
+        //
+        // G                  -> (signature) -> P
+        // GIPPPGG*           ->     (valid) -> ......P
+        //       G*I          ->   (invalid) -> MMMM.P (4 missed)
+        //         IPPPGI     ->   (invalid) -> N....P
+        //              IPPGI ->     (valid) -> ....P
         expected.valid_gops = 2;
-        expected.pending_nalus = 4;
         expected.has_signature = 1;
       }
     }
@@ -1079,9 +1250,15 @@ START_TEST(add_one_sei_nalu_after_signing)
   struct validation_stats expected = {.valid_gops = 4, .pending_nalus = 4};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 2;
-      expected.pending_nalus = 2;
-      expected.has_signature = 2;
+      // GIPPGIPPSPG*IPPGI
+      //
+      // G                 -> (signature) -> P
+      // GIPPGIPPSPG*      ->     (valid) -> .....PPP_PP
+      //      IPPSPG*I     ->     (valid) -> ..._..P
+      //             IPPGI ->     (valid) -> ....P
+      expected.valid_gops = 3;
+      expected.pending_nalus = 8;
+      expected.has_signature = 1;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -1211,10 +1388,12 @@ mimic_au_fast_forward_and_get_list(signed_video_t *sv, struct sv_setting setting
   // Total number of pending NALUs = 1 + 1 = 2
   struct validation_stats expected = {.valid_gops = 2, .pending_nalus = 2};
   if (setting.recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
-    // GI      -> UU          (SV_AUTH_RESULT_SIGNATURE_PRESENT)
-    // IPPPPGI -> ......P     (valid)
-    expected.valid_gops = 1;
-    expected.pending_nalus = 1;
+    // GIPPPPG*IP
+    //
+    // G         -> (signature) -> P
+    // GIPPPPG*  ->     (valid) -> .PPPPPP
+    //  IPPPPG*I ->     (valid) -> ......P
+    expected.pending_nalus = 8;
     expected.has_signature = 1;
   }
   validate_nalu_list(sv, pre_fast_forward, expected);
@@ -1293,7 +1472,7 @@ END_TEST
 static nalu_list_t *
 mimic_au_fast_forward_on_late_seis_and_get_list(signed_video_t *sv, struct sv_setting setting)
 {
-  nalu_list_t *list = generate_delayed_sei_list(setting);
+  nalu_list_t *list = generate_delayed_sei_list(setting, false);
   nalu_list_check_str(list, "IPGPPPIPGPPIPGPPIPGPPIPG");
 
   // Extract the first 9 NALUs from the list. This should be the empty GOP, a full GOP and in the
@@ -1311,10 +1490,12 @@ mimic_au_fast_forward_on_late_seis_and_get_list(signed_video_t *sv, struct sv_se
   // Total number of pending NALUs = 2 + 2 = 4
   struct validation_stats expected = {.valid_gops = 2, .pending_nalus = 4};
   if (setting.recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
-    // IPG       -> UUU         (SV_AUTH_RESULT_SIGNATURE_PRESENT)
-    // IPGPPPIPG -> ......PP.   (valid)
+    // IPGPPPIPG*
+    //
+    // IPG        -> (signature) -> PPP
+    // IPGPPPIPG* ->     (valid) -> ......PP.
     expected.valid_gops = 1;
-    expected.pending_nalus = 2;
+    expected.pending_nalus = 5;
     expected.has_signature = 1;
   }
   validate_nalu_list(sv, pre_fast_forward, expected);
@@ -1370,20 +1551,34 @@ END_TEST
  * As an additional piece, the stream starts with a PPS/SPS/VPS NALU, which is moved to the
  * beginning of the "file" as well. That should not affect the validation. */
 static nalu_list_t *
-mimic_file_export(struct sv_setting setting, bool include_i_nalu_at_end)
+mimic_file_export(struct sv_setting setting, bool include_i_nalu_at_end, bool delayed_seis)
 {
-  nalu_list_t *list = create_signed_nalus("VIPPIPPIPPIPPIPP", setting);
-  nalu_list_check_str(list, "VGIPPGIPPGIPPGIPPGIPP");
+  nalu_list_t *pre_export = NULL;
+  nalu_list_t *list = create_signed_nalus("VIPPIPPIPPIPPIPPIPP", setting);
+  nalu_list_check_str(list, "VGIPPGIPPGIPPGIPPGIPPGIPP");
 
   // Remove the initial PPS/SPS/VPS NALU to add back later
   nalu_list_item_t *ps = nalu_list_pop_first_item(list);
   nalu_list_item_check_str(ps, "V");
 
-  // Remove the first 4 NALUs from the list. This should be the first complete GOP: GIPP
-  // GIPPGIPPGIPPGIPP. These are the NALUs to be processed before the fast forward.
-  nalu_list_t *pre_export = nalu_list_pop(list, 4);
-  nalu_list_check_str(pre_export, "GIPP");
-  nalu_list_check_str(list, "GIPPGIPPGIPPGIPP");
+  if (delayed_seis) {
+    int out[4] = {1, 4, 7, 10};
+    for (int i = 0; i < 4; i++) {
+      nalu_list_item_t *sei = nalu_list_remove_item(list, out[i]);
+      nalu_list_item_check_str(sei, "G");
+      nalu_list_append_item(list, sei, 13);
+    }
+    nalu_list_check_str(list, "IPPIPPIPPIGGGGPPGIPPGIPP");
+    pre_export = nalu_list_pop(list, 6);
+    nalu_list_check_str(pre_export, "IPPIPP");
+    nalu_list_check_str(list, "IPPIGGGGPPGIPPGIPP");
+  } else {
+    // Remove the first 4 NALUs from the list. This should be the first complete GOP: GIPP
+    // GIPPGIPPGIPPGIPP. These are the NALUs to be processed before the fast forward.
+    pre_export = nalu_list_pop(list, 4);
+    nalu_list_check_str(pre_export, "GIPP");
+    nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGIPP");
+  }
 
   // Mimic end of file export by removing items at the end of the list. Here we can take two
   // approaches, that is, include the I-NALU at the end and not. The latter being the standard
@@ -1397,7 +1592,11 @@ mimic_file_export(struct sv_setting setting, bool include_i_nalu_at_end)
   // Prepend list with PPS/SPS/VPS NALU
   nalu_list_prepend_first_item(list, ps);
 
-  nalu_list_check_str(list, include_i_nalu_at_end ? "VGIPPGIPPGIPPGI" : "VGIPPGIPPGIPP");
+  if (delayed_seis) {
+    nalu_list_check_str(list, include_i_nalu_at_end ? "VIPPIGGGGPPGIPPGI" : "VIPPIGGGGPPGIPP");
+  } else {
+    nalu_list_check_str(list, include_i_nalu_at_end ? "VGIPPGIPPGIPPGIPPGI" : "VGIPPGIPPGIPPGIPP");
+  }
   nalu_list_free(pre_export);
 
   return list;
@@ -1408,23 +1607,43 @@ START_TEST(file_export_with_dangling_end)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = mimic_file_export(settings[_i], false);
+  nalu_list_t *list = mimic_file_export(settings[_i], false, false);
 
   // Create a new session and validate the authenticity of the file.
   signed_video_t *sv = signed_video_create(settings[_i].codec);
   ck_assert(sv);
+  // VGIPPGIPPGIPPGIPP
+  //
+  // VGI             -> (signature) -> _UP
+  //   IPPGI         ->     (valid) -> ....P
+  //       IPPGI     ->     (valid) -> ....P
+  //           IPPGI ->     (valid) -> ....P
+  //
   // One pending NALU per GOP.
-  struct validation_stats expected = {.valid_gops = 2, .pending_nalus = 3, .has_signature = 1};
+  struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 4, .has_signature = 1};
   if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
     if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_ZERO) {
-      expected.valid_gops = 1;
-      expected.pending_nalus = 1;
-      expected.has_signature = 2;
+      // VGIPPGIPPG*IPPGIPP
+      //
+      // VG               -> (signature) -> _P
+      //  GIPPGIPPG*      ->     (valid) -> U....PPPP
+      //       IPPG*I     ->     (valid) -> ....P
+      //            IPPGI ->     (valid) -> ....P
+      expected.valid_gops = 3;
+      expected.pending_nalus = 7;
+      expected.has_signature = 1;
     }
     if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
-      expected.valid_gops = 2;
-      expected.pending_nalus = 2;
-      expected.has_signature = 1;
+      // VGIPPG*IPPGIPPGIPP
+      //
+      // VG               -> (signature) -> _P
+      //  GIPPG*          -> (signature) -> UPPPP
+      //   IPPG*I         ->     (valid) -> ....P
+      //        IPPGI     ->     (valid) -> ....P
+      //            IPPGI ->     (valid) -> ....P
+      expected.valid_gops = 3;
+      expected.pending_nalus = 8;
+      expected.has_signature = 2;
     }
   }
 
@@ -1441,25 +1660,48 @@ START_TEST(file_export_without_dangling_end)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = mimic_file_export(settings[_i], true);
+  nalu_list_t *list = mimic_file_export(settings[_i], true, false);
 
   // Create a new session and validate the authenticity of the file.
   signed_video_t *sv = signed_video_create(settings[_i].codec);
   ck_assert(sv);
+  // VGIPPGIPPGIPPGIPPGI
+  //
+  // VGI                 -> (signature) -> _UP
+  //   IPPGI             ->     (valid) -> ....P
+  //       IPPGI         ->     (valid) -> ....P
+  //           IPPGI     ->     (valid) -> ....P
+  //               IPPGI ->     (valid) -> ....P
+  //
   // One pending NALU per GOP.
-  struct validation_stats expected = {.valid_gops = 3, .pending_nalus = 4, .has_signature = 1};
+  struct validation_stats expected = {.valid_gops = 4, .pending_nalus = 5, .has_signature = 1};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_ZERO) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 2;
-      expected.pending_nalus = 2;
-      expected.has_signature = 2;
+      // VGIPPGIPPG*IPPGIPPGI
+      //
+      // VG                   -> (signature) -> _P
+      //  GIPPGIPPG*          ->     (valid) -> U....PPPP
+      //       IPPG*I         ->     (valid) -> ....P
+      //            IPPGI     ->     (valid) -> ....P
+      //                IPPGI ->     (valid) -> ....P
+      expected.valid_gops = 4;
+      expected.pending_nalus = 8;
+      expected.has_signature = 1;
     }
   }
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
-      expected.valid_gops = 3;
-      expected.pending_nalus = 3;
-      expected.has_signature = 1;
+      // VGIPPG*IPPGIPPGIPPGI
+      //
+      // VG                   -> (signature) -> _P
+      //  GIPPG*              -> (signature) -> UPPPP
+      //   IPPG*I             ->     (valid) -> ....P
+      //        IPPGI         ->     (valid) -> ....P
+      //            IPPGI     ->     (valid) -> ....P
+      //                IPPGI ->     (valid) -> ....P
+      expected.valid_gops = 4;
+      expected.pending_nalus = 9;
+      expected.has_signature = 2;
     }
   }
   validate_nalu_list(sv, list, expected);
@@ -1485,15 +1727,15 @@ START_TEST(no_signature)
   // always have one GOP pending validation, since we wait for a potential SEI, and will validate
   // upon the 'next' GOP transition.
   //
-  // IPPI    -> (PPPP)  (pending, pending, pending, pending)
-  // IPPIPPI -> (UUUPPPP) (unsigned, unsigned, unsigned, pending, ...)
-  // IPPIPPI -> (UUUPPPP)
-  // IPPIPPI -> (UUUPPPP)
+  // IPPI          -> (PPPP)  (pending, pending, pending, pending)
+  // IPPIPPI       -> (PPPPPPP)
+  // IPPIPPIPPI    -> (PPPPPPPPPP)
+  // IPPIPPIPPIPPI -> (PPPPPPPPPPPPP)
   //
-  // pending_nalus = 4 * 4 = 16
+  // pending_nalus = 4 + 7 + 10 + 13 = 34
 
-  const struct validation_stats expected = {.unsigned_gops = 4, .pending_nalus = 16,
-    .has_no_timestamp = true};
+  const struct validation_stats expected = {
+      .unsigned_gops = 4, .pending_nalus = 34, .has_no_timestamp = true};
   validate_nalu_list(NULL, list, expected);
 
   nalu_list_free(list);
@@ -1511,15 +1753,15 @@ START_TEST(multislice_no_signature)
   // We will always have one GOP pending validation, since we wait for a potential SEI, and will
   // validate upon the 'next' GOP transition.
   //
-  // IiPpPpI      -> (PPPPPPP)  (pending, pending, pending, pending, pending, pending)
-  // IiPpPpIiPpPpI -> (UUUUUUPPPPPPP) (unsigned, ...)
-  // IiPpPpIiPpPpI -> (UUUUUUPPPPPPP)
-  // IiPpPpIiPpPpI -> (UUUUUUPPPPPPP)
+  // IiPpPpI                   -> (PPPPPPP)  (pending, pending, pending, pending, pending, pending)
+  // IiPpPpIiPpPpI             -> (PPPPPPPPPPPPP)
+  // IiPpPpIiPpPpIiPpPpI       -> (PPPPPPPPPPPPPPPPPPP)
+  // IiPpPpIiPpPpIiPpPpIiPpPpI -> (PPPPPPPPPPPPPPPPPPPPPPPPP)
   //
-  // pending_nalus = 4 * 7 = 28
+  // pending_nalus = 7 + 13 + 19 + 25 = 64
 
-  const struct validation_stats expected = {.unsigned_gops = 4, .pending_nalus = 28,
-    .has_no_timestamp = true};
+  const struct validation_stats expected = {
+      .unsigned_gops = 4, .pending_nalus = 64, .has_no_timestamp = true};
   validate_nalu_list(NULL, list, expected);
 
   nalu_list_free(list);
@@ -1552,9 +1794,18 @@ START_TEST(late_public_key_and_no_sei_before_key_arrives)
   struct validation_stats expected = {.valid_gops = 5, .invalid_gops = 2, .pending_nalus = 10};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
     if (settings[_i].recurrence == SV_RECURRENCE_EIGHT) {
+      // GIPPIPPG*IPPGIPPGIPPG*IPPGI
+      //
+      // G                           -> (signature) -> P
+      // GIPPIPPG*                   ->   (invalid) -> .NNNPPPP
+      //     IPPG*I                  ->   (invalid) -> N...P
+      //          IPPGI              ->     (valid) -> ....P
+      //              IPPGI          ->     (valid) -> ....P
+      //                  IPPG*I     ->     (valid) -> ....P
+      //                       IPPGI ->     (valid) -> ....P
       expected.valid_gops = 4;
       expected.invalid_gops = 2;
-      expected.pending_nalus = 9;
+      expected.pending_nalus = 10;
       expected.has_signature = 1;
     }
   }
@@ -1597,9 +1848,15 @@ START_TEST(fallback_to_gop_level)
   // One pending NALU per GOP.
   struct validation_stats expected = {.valid_gops = 4, .pending_nalus = 4};
   if (settings[_i].recurrence_offset == SV_RECURRENCE_OFFSET_THREE) {
-    expected.valid_gops = 2;
-    expected.pending_nalus = 2;
-    expected.has_signature = 2;
+    // GIPPGIPPPPPPPPPPPPPPPPPPPPPPPPG*IPPGI
+    //
+    // G                                     -> (signature) -> P
+    // GIPPGIPPPPPPPPPPPPPPPPPPPPPPPPG*      ->     (valid) -> .....PPPPPPPPPPPPPPPPPPPPPPPPPP
+    //      IPPPPPPPPPPPPPPPPPPPPPPPPG*I     ->     (valid) -> ..........................P
+    //                                 IPPGI ->     (valid) -> ....P
+    expected.valid_gops = 3;
+    expected.pending_nalus = 29;
+    expected.has_signature = 1;
   }
   validate_nalu_list(NULL, list, expected);
 


### PR DESCRIPTION
The nalu_list includes all the information necessary to validate GOPs.
After this commit, validation is now based on the nalu_list and keeps
validating until there are no more GOPs to validate. This changes the
behavior when recurrence is present. Upon the first SEI,
SV_AUTH_RESULT_SIGNATURE_PRESENT is signaled and when the Public Key
arrives, all pending NALUs are validated. All affected check tests
have been updated.

gop_state_t is still used to track some information while validating
a GOP, and flags like signing_present is moved to a new struct;
validation_flags_t.
