### PR TITLE
New version v1.1.12

### DIFF
--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -47,7 +47,7 @@ typedef struct _h26x_nalu_list_t h26x_nalu_list_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v1.1.11"
+#define SIGNED_VIDEO_VERSION "v1.1.12"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '1.1.11',
+  version : '1.1.12',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
Change in meson for tests. Now the authentication tests only run if the signing plugin is truly unthreaded.