### PR TITLE
Adds first and last timestamps to the accumulated authenticity

### DIFF
--- a/lib/src/includes/signed_video_auth.h
+++ b/lib/src/includes/signed_video_auth.h
@@ -121,7 +121,7 @@ typedef struct {
   bool has_timestamp;
   // True if the timestamp member is valid to look at, false otherwise.
   int64_t timestamp;
-  // Unix epoch UTC timestamp of the latest signed NALU.
+  // Unix epoch UTC timestamp in microseconds of the latest signed NALU.
 } signed_video_latest_validation_t;
 
 /**
@@ -145,6 +145,12 @@ typedef struct {
   // The result of the Public key validation. If the Public key is present in the SEI, it has to be
   // validated to associate the video with a source. If it is not feasible to validate the Public
   // key, it should be validated manually to secure proper video authenticity.
+  bool has_timestamp;
+  // True if the session included timestamps.
+  int64_t first_timestamp;
+  // Unix epoch UTC timestamp in microseconds of the first signed NALU.
+  int64_t last_timestamp;
+  // Unix epoch UTC timestamp in microseconds of the last signed NALU.
 } signed_video_accumulated_validation_t;
 
 /**

--- a/lib/src/signed_video_authenticity.c
+++ b/lib/src/signed_video_authenticity.c
@@ -140,6 +140,9 @@ transfer_accumulated_validation(signed_video_accumulated_validation_t *dst,
   dst->number_of_validated_nalus = src->number_of_validated_nalus;
   dst->number_of_pending_nalus = src->number_of_pending_nalus;
   dst->public_key_validation = src->public_key_validation;
+  dst->has_timestamp = src->has_timestamp;
+  dst->first_timestamp = src->first_timestamp;
+  dst->last_timestamp = src->last_timestamp;
 }
 
 static svi_rc
@@ -197,6 +200,9 @@ accumulated_validation_init(signed_video_accumulated_validation_t *self)
   self->number_of_validated_nalus = 0;
   self->number_of_pending_nalus = 0;
   self->public_key_validation = SV_PUBKEY_VALIDATION_NOT_FEASIBLE;
+  self->has_timestamp = false;
+  self->first_timestamp = 0;
+  self->last_timestamp = 0;
 }
 
 static void
@@ -230,6 +236,16 @@ update_accumulated_validation(const signed_video_latest_validation_t *latest,
 
   if (accumulated->public_key_validation != SV_PUBKEY_VALIDATION_NOT_OK) {
     accumulated->public_key_validation = latest->public_key_validation;
+  }
+
+  // Update timestamps if possible.
+  if (latest->has_timestamp) {
+    if (!accumulated->has_timestamp) {
+      // No previous timestamp has been set.
+      accumulated->first_timestamp = latest->timestamp;
+    }
+    accumulated->last_timestamp = latest->timestamp;
+    accumulated->has_timestamp = true;
   }
 }
 

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -254,6 +254,8 @@ validate_nalu_list(signed_video_t *sv, nalu_list_t *list, struct validation_stat
         expected.final_validation->number_of_pending_nalus);
     ck_assert_int_eq(auth_report->accumulated_validation.public_key_validation,
         expected.final_validation->public_key_validation);
+    ck_assert_int_eq(auth_report->accumulated_validation.has_timestamp,
+        expected.final_validation->has_timestamp);
     signed_video_authenticity_report_free(auth_report);
   }
 
@@ -314,7 +316,7 @@ START_TEST(intact_stream)
 
   // All NALUs but the last 'I' are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 26, 25, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 26, 25, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 7, .pending_nalus = 7, .final_validation = &final_validation};
@@ -341,7 +343,7 @@ START_TEST(intact_multislice_stream)
 
   // All NALUs but the last 'I' and 'i' are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 17, 15, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 17, 15, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
@@ -371,7 +373,7 @@ START_TEST(intact_stream_with_pps_nalu_stream)
 
   // All NALUs but the last 'I' are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 11, 10, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 11, 10, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
@@ -405,7 +407,7 @@ START_TEST(intact_stream_with_pps_bytestream)
 
   // All NALUs but the last 'I' are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 11, 10, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 11, 10, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
@@ -432,7 +434,7 @@ START_TEST(intact_ms_stream_with_pps_nalu_stream)
 
   // All NALUs but the last 'I' and 'i' are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 18, 16, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 18, 16, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
@@ -466,7 +468,7 @@ START_TEST(intact_ms_stream_with_pps_bytestream)
 
   // All NALUs but the last 'I' and 'i' are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 18, 16, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 18, 16, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
@@ -501,7 +503,7 @@ START_TEST(intact_with_undefined_nalu_in_stream)
 
   // All NALUs but the last 'I' are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 11, 10, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 11, 10, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
@@ -528,7 +530,7 @@ START_TEST(intact_with_undefined_multislice_nalu_in_stream)
 
   // All NALUs but the last 'I' and 'i' are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 18, 16, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 18, 16, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
@@ -567,7 +569,7 @@ START_TEST(remove_one_p_nalu)
   // All NALUs but the last 'I' are validated and since one NALU has been removed the authenticity
   // is NOT OK.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 14, 13, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 14, 13, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {.valid_gops = 2,
       .invalid_gops = 2,
@@ -627,7 +629,7 @@ START_TEST(interchange_two_p_nalus)
   // All NALUs but the last 'I' are validated and since two NALUs have been moved the authenticity
   // is NOT OK.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {.valid_gops = 2,
       .invalid_gops = 2,
@@ -680,7 +682,7 @@ START_TEST(modify_one_p_nalu)
   // All NALUs but the last 'I' are validated and since one NALU has been modified the authenticity
   // is NOT OK.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {.valid_gops = 2,
       .invalid_gops = 2,
@@ -728,7 +730,7 @@ START_TEST(modify_one_i_nalu)
   // All NALUs but the last 'I' are validated and since one I-NALU has been modified the
   // authenticity is NOT OK.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP. Note that a modified I-nalu affects two GOPs due to linked hashes,
   // but it will also affect a third if we validate with a gop_hash.
   struct validation_stats expected = {.valid_gops = 1,
@@ -786,7 +788,7 @@ START_TEST(remove_the_g_nalu)
   // All NALUs but the last 'I' are validated and since one SEI has been removed the authenticity
   // is NOT OK.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // We will get 8 pending nalus:
   //
   // GI        valid & 1 pending
@@ -808,6 +810,7 @@ START_TEST(remove_the_g_nalu)
       expected.final_validation->authenticity = SV_AUTH_RESULT_SIGNATURE_PRESENT;
       expected.final_validation->number_of_validated_nalus = 0;
       expected.final_validation->number_of_pending_nalus = 17;
+      expected.final_validation->has_timestamp = false;
     }
   }
 
@@ -833,7 +836,7 @@ START_TEST(remove_the_i_nalu)
   // All NALUs but the last 'I' are validated and since one I-NALU has been removed the authenticity
   // is NOT OK.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP. A missing I NALU will affect two GOPs, since it is part of two
   // gop_hashes. At GOP level the missing NALU will make the GOP invalid, but for Frame level we can
   // identify the missed NALU when the I NALU is not the reference, that is, the first GOP is valid
@@ -886,7 +889,7 @@ START_TEST(remove_the_gi_nalus)
   // All NALUs but the last 'I' are validated and since one couple of SEI and I-NALU have been
   // removed the authenticity is NOT OK.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 16, 15, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 16, 15, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per detected GOP. Note that we lose one 'true' GOP since the transition is
   // lost. We have now two incomplete GOPs; second (missing G) and third (missing I). In fact, we
   // miss the transition between GOP two and three, but will detect it later through the gop
@@ -909,6 +912,7 @@ START_TEST(remove_the_gi_nalus)
       expected.final_validation->authenticity = SV_AUTH_RESULT_SIGNATURE_PRESENT;
       expected.final_validation->number_of_validated_nalus = 0;
       expected.final_validation->number_of_pending_nalus = 16;
+      expected.final_validation->has_timestamp = false;
     }
   }
   validate_nalu_list(NULL, list, expected);
@@ -941,7 +945,7 @@ START_TEST(sei_arrives_late)
 
   // All NALUs but the last 'I' are validated as OK, which is pending.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP + the extra P before (G). The late arrival SEI will introduce one
   // pending NALU (the P frame right before).
   struct validation_stats expected = {
@@ -1003,7 +1007,7 @@ START_TEST(all_seis_arrive_late)
 
   // All NALUs but the last 'I', 'P' and SEI are validated as OK, hence three pending NALUs.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 24, 21, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 24, 21, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // The late arrival SEIs will introduce one pending NALU per GOP (the P frame right before the
   // SEI) except the last GOP, where the SEI is NOT late.  5 GOPs * 2 pending NALUs/GOP = 10
   // pending NALUs
@@ -1049,7 +1053,7 @@ START_TEST(lost_g_before_late_sei_arrival)
 
   // All NALUs but the last 'I' are validated. Since a SEI is lost the authenticity is NOT OK.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 20, 19, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 20, 19, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // We will get 10 pending nalus:
   //
   // GI           valid & 1 pending
@@ -1122,7 +1126,7 @@ START_TEST(lost_g_and_gop_with_late_sei_arrival)
 
   // All NALUs but the last three NALUs are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 13, 10, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 13, 10, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // We will get 6 pending nalus:
   //
   // IPG         has_signature & 2 pending (IP)
@@ -1162,7 +1166,7 @@ START_TEST(lost_all_nalus_between_two_seis)
   // All NALUs but the last 'I' are validated. Since all NALUs between two SEIs are lost the
   // authenticity is NOT OK.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // We have NALUs from 5 GOPs present and each GOP will produce one pending NALU. The lost NALUs
   // (IPPP) will be detected, but for SV_AUTHENTICITY_LEVEL_FRAME we will measure one extra missing
   // NALU. This is a descrepancy in the way we count NALUs by excluding SEIs.
@@ -1219,7 +1223,7 @@ START_TEST(add_one_sei_nalu_after_signing)
 
   // All NALUs but the last 'I' are validated as OK. The last one is pending.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 16, 15, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 16, 15, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 4, .pending_nalus = 4, .final_validation = &final_validation};
@@ -1266,7 +1270,7 @@ START_TEST(camera_reset_on_signing_side)
 
   // Final validation is NOT OK and all received NALUs, but the last, are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, true, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, true, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP. Note that the mid GOP (IPPGI) includes the reset on the camera. It
   // will be marked as invalid and compute 3 more NALUs than expected. In G it is communicated
   // there is only 2 NALUs present (GI). So missed NALUs equals -3 (IPP).
@@ -1309,7 +1313,7 @@ START_TEST(detect_change_of_public_key)
   // Final validation is NOT OK and all received NALUs, but the last, are validated. The
   // |public_key_has_changed| flag has been set.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, true, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, true, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // The list will be validated successfully up to the third SEI (G) which has the new Public key.
   //
   //   GI      -> .P     (valid, 1 pending, public_key_has_changed = false)
@@ -1361,7 +1365,7 @@ mimic_au_fast_forward_and_get_list(signed_video_t *sv, struct sv_setting setting
   // Final validation of |pre_fast_forward| is OK and all received NALUs, but the last two, are
   // validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 9, 7, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 9, 7, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // Validate the video before fast forward using the user created session |sv|.
   //
   // GI      -> .P          (valid)
@@ -1408,7 +1412,7 @@ START_TEST(fast_forward_stream_with_reset)
 
   // Final validation is OK and all received NALUs, but the last one, are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 12, 11, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 12, 11, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // Validate GIPPPGIPPPGI:
   //
   // GI      -> UP           (SV_AUTH_RESULT_SIGNATURE_PRESENT)
@@ -1441,7 +1445,7 @@ START_TEST(fast_forward_stream_without_reset)
 
   // Final validation is NOT OK and all received NALUs, but the last one, are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 21, 20, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 21, 20, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // Validate IP GIPPPGIPPPGI (without reset, i.e., started with IP before fast forward):
   //
   // GI      -> NMMUP           (invalid, 2 missing)
@@ -1479,7 +1483,7 @@ mimic_au_fast_forward_on_late_seis_and_get_list(signed_video_t *sv, struct sv_se
   // Final validation of |pre_fast_forward| is OK and all received NALUs, but the last three, are
   // validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 9, 6, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 9, 6, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // Validate the video before fast forward using the user created session |sv|.
   //
   // IPG         -> PP.         (valid)
@@ -1526,7 +1530,7 @@ START_TEST(fast_forward_stream_with_delayed_seis)
 
   // Final validation is OK and all received NALUs, but the last three, are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 8, 5, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 8, 5, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // Validate IPGPPIPG:
   //
   // IPG      -> PPU           (SV_AUTH_RESULT_SIGNATURE_PRESENT)
@@ -1601,7 +1605,7 @@ START_TEST(file_export_with_dangling_end)
 
   // Final validation is OK and all received NALUs, but the last three, are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 13, 10, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 13, 10, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {.valid_gops = 2,
       .pending_nalus = 3,
@@ -1641,7 +1645,7 @@ START_TEST(file_export_without_dangling_end)
 
   // Final validation is OK and all received NALUs, but the last one, are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {.valid_gops = 3,
       .pending_nalus = 4,
@@ -1681,7 +1685,7 @@ START_TEST(no_signature)
 
   // Video is not signed, hence all NALUs are pending.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_SIGNED, false, 13, 0, 13, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_SIGNED, false, 13, 0, 13, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, false, 0, 0};
   // Note that we are one frame off. The start of a GOP (the I) is reported as end of the previous
   // GOP. This is not a big deal, since the message is still clear; We have no signed video. We will
   // always have one GOP pending validation, since we wait for a potential SEI, and will validate
@@ -1693,11 +1697,12 @@ START_TEST(no_signature)
   // IPPIPPI -> (UUUPPPP)
   //
   // pending_nalus = 4 * 4 = 16
-  const struct validation_stats expected = {
-    .unsigned_gops = 4, .pending_nalus = 16, .has_no_timestamp = true,
-    .final_validation = &final_validation};
+  const struct validation_stats expected = {.unsigned_gops = 4,
+      .pending_nalus = 16,
+      .has_no_timestamp = true,
+      .final_validation = &final_validation};
 
-validate_nalu_list(NULL, list, expected);
+  validate_nalu_list(NULL, list, expected);
 
   nalu_list_free(list);
 }
@@ -1713,7 +1718,7 @@ START_TEST(multislice_no_signature)
 
   // Video is not signed, hence all NALUs are pending.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_SIGNED, false, 26, 0, 26, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_SIGNED, false, 26, 0, 26, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, false, 0, 0};
   // We will always have one GOP pending validation, since we wait for a potential SEI, and will
   // validate upon the 'next' GOP transition.
   //
@@ -1723,11 +1728,12 @@ START_TEST(multislice_no_signature)
   // IiPpPpIiPpPpI -> (UUUUUUPPPPPPP)
   //
   // pending_nalus = 4 * 7 = 28
-  const struct validation_stats expected = {
-      .unsigned_gops = 4, .pending_nalus = 28, .has_no_timestamp = true,
+  const struct validation_stats expected = {.unsigned_gops = 4,
+      .pending_nalus = 28,
+      .has_no_timestamp = true,
       .final_validation = &final_validation};
 
-validate_nalu_list(NULL, list, expected);
+  validate_nalu_list(NULL, list, expected);
 
   nalu_list_free(list);
 }
@@ -1757,7 +1763,7 @@ START_TEST(late_public_key_and_no_sei_before_key_arrives)
 
   // Final validation is NOT OK and all received NALUs, but the last one, are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_NOT_OK, false, 25, 24, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_NOT_OK, false, 25, 24, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {.valid_gops = 5,
       .invalid_gops = 2,
@@ -1809,7 +1815,7 @@ START_TEST(fallback_to_gop_level)
 
   // Final validation is OK and all received NALUs, but the last one, are validated.
   signed_video_accumulated_validation_t final_validation = {
-      SV_AUTH_RESULT_OK, false, 36, 35, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE};
+      SV_AUTH_RESULT_OK, false, 36, 35, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
   // One pending NALU per GOP.
   struct validation_stats expected = {
       .valid_gops = 4, .pending_nalus = 4, .final_validation = &final_validation};


### PR DESCRIPTION
and explicity states, in the description, that the timestamps are
measured in microseconds. The check tests have been updated accordingly.
