### PR TITLE
Uses define to separate deprecated OpenSSL code

### DIFF
--- a/.github/workflows/meson-build.yml
+++ b/.github/workflows/meson-build.yml
@@ -12,10 +12,6 @@ jobs:
     steps:
     - name: Update system
       run: sudo apt-get update
-    - name: Fetch openssl-1.1.1n manually
-      run: git clone --depth 1 --branch OpenSSL_1_1_1n https://github.com/openssl/openssl.git
-    - name: Build and install
-      run: cd openssl && ./config zlib '-Wl,-rpath,$(LIBRPATH)' && make && sudo make install && sudo ldconfig -v
     - name: Install check manually
       run: sudo apt-get install check
     - uses: actions/checkout@v2

--- a/.github/workflows/meson-full-build.yml
+++ b/.github/workflows/meson-full-build.yml
@@ -12,10 +12,6 @@ jobs:
     steps:
     - name: Update system
       run: sudo apt-get update
-    - name: Fetch openssl-1.1.1n manually
-      run: git clone --depth 1 --branch OpenSSL_1_1_1n https://github.com/openssl/openssl.git
-    - name: Build and install
-      run: cd openssl && ./config zlib '-Wl,-rpath,$(LIBRPATH)' && make && sudo make install && sudo ldconfig -v
     - name: Install check manually
       run: sudo apt-get install check
     - uses: actions/checkout@v2

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -473,7 +473,7 @@ void
 openssl_free_handle(void *handle)
 {
   openssl_crypto_t *self = (openssl_crypto_t *)handle;
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
   if (self->ctx) EVP_MD_CTX_free(self->ctx);
 #endif
   free(self);

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -713,8 +713,8 @@ set_axis_communications_public_key(void *handle,
         public_key_validation = 0;
       }
 #else
+      // OpenSSL 3.0 and newer not yet supported. Mark Public key as not valid.
       public_key_validation = 0;
-      SVI_THROW_WITH_MSG(SVI_VENDOR, "OpenSSL 3.0 and newer not yet supported");
 #endif
     }
 

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <openssl/bio.h>  // BIO_*
 #include <openssl/evp.h>  // EVP_*
+#include <openssl/opensslv.h>  // OPENSSL_VERSION_*
 #include <openssl/pem.h>  // PEM_*
 #include <openssl/sha.h>  // SHA256
 #include <openssl/x509.h>  // X509_*
@@ -47,6 +48,12 @@ static const sv_tlv_tag_t axis_communications_encoders[AXIS_COMMUNICATIONS_NUM_E
 #define PUBLIC_KEY_UNCOMPRESSED_SIZE 65
 #define PUBLIC_KEY_UNCOMPRESSED_PREFIX 0x04
 #define BINARY_RAW_DATA_SIZE 40
+
+#ifndef OPENSSL_VERSION_MAJOR
+// OPENSSL_VERSION_MAJOR exists from OpenSSL 3.0
+// Parse major (most significant 4 bits) from version number
+#define OPENSSL_VERSION_MAJOR (OPENSSL_VERSION_NUMBER >> 28)
+#endif
 
 static const char *kTrustedAxisRootCA =
     "-----BEGIN CERTIFICATE-----\n"


### PR DESCRIPTION
Some APIs have been deprecated in OpenSSL 3.0. In selected places,
the deprecated APIs have been replaced under a define to make it build
also in older versions.

The temporary OpenSSL build in workflow is removed.
