### PR TITLE
Adds a setter to write SEIs w/wo emulation prevention

### DIFF
--- a/lib/src/includes/signed_video_sign.h
+++ b/lib/src/includes/signed_video_sign.h
@@ -378,6 +378,26 @@ signed_video_set_authenticity_level(signed_video_t *self,
 SignedVideoReturnCode
 signed_video_set_recurrence_interval_frames(signed_video_t *self, unsigned recurrence);
 
+/**
+ * @brief Configures Signed Video to generate the SEI NAL Units with/without emulation prevention
+ *
+ * Emulation prevention bytes (EPB) are used to prevent the decoder from detecting the start code
+ * sequence in the middle of a NAL Unit. By default, the framework generates SEI frames with EPB
+ * written to the payload. With this API, the user can select to have Signed Video generate SEI
+ * frames with or without EPBs.
+
+ * If this API is not used, SEI payload is written with EPBs, hence equivalent with setting
+ * |sei_epb| to True.
+ *
+ * @param self Session struct pointer
+ * @param sei_epb SEI payload written with EPB (default True)
+ *
+ * @returns SV_OK SEI w/o EPB was successfully set,
+ *          SV_INVALID_PARAMETER Invalid parameter.
+ */
+SignedVideoReturnCode
+signed_video_set_sei_epb(signed_video_t *self, bool sei_epb);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -968,7 +968,7 @@ update_hashable_data(h26x_nalu_t *nalu)
   // emulation prevention bytes) coresponding to that tag. This is done by scanning the TLV for that
   // tag.
   const uint8_t *signature_tag_ptr =
-      tlv_find_tag(nalu->tlv_start_in_nalu_data, nalu->tlv_size, SIGNATURE_TAG, true);
+      tlv_find_tag(nalu->tlv_start_in_nalu_data, nalu->tlv_size, SIGNATURE_TAG, nalu->with_epb);
 
   if (signature_tag_ptr) nalu->hashable_data_size = signature_tag_ptr - nalu->hashable_data;
 }
@@ -1023,7 +1023,7 @@ signed_video_add_h26x_nalu(signed_video_t *self, const uint8_t *nalu_data, size_
   status = (status == SVI_OK) ? copy_nalu_status : status;
   if (status != SVI_OK) nalu_list->last_item->validation_status = 'E';
 
-  free(nalu.tmp_tlv_memory);
+  free(nalu.nalu_data_wo_epb);
 
   return status;
 }

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -129,7 +129,7 @@ struct _h26x_nalu_t {
   const uint8_t *tlv_start_in_nalu_data;  // Points to beginning of the TLV data in the |nalu_data|
   const uint8_t *tlv_data;  // Points to the TLV data after removing emulation prevention bytes
   size_t tlv_size;  // Total size of the |tlv_data|
-  uint8_t *tmp_tlv_memory;  // Temporary memory used if there are emulation prevention bytes
+  uint8_t *nalu_data_wo_epb;  // Temporary memory used if there are emulation prevention bytes
   uint32_t start_code;  // Start code or replaced by NALU data size
   int emulation_prevention_bytes;  // Computed emulation prevention bytes
   bool is_primary_slice;  // The first slice in the NALU or not
@@ -137,6 +137,7 @@ struct _h26x_nalu_t {
   bool is_gop_sei;  // True if this is a Signed Video generated SEI NALU
   bool is_first_nalu_part;  // True if the |nalu_data| includes the first part
   bool is_last_nalu_part;  // True if the |nalu_data| includes the last part
+  bool with_epb;  // Hashable data may include emulation prevention bytes
 };
 
 /* Internal APIs for gop_state_t functions */

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -322,7 +322,6 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
     h26x_set_nal_uuid_type(self, &payload_ptr, UUID_TYPE_SIGNED_VIDEO);
 
     // Add reserved byte(s).
-    // *payload_ptr++ = SV_RESERVED_BYTE;
     uint8_t reserved_byte = self->sei_epb << 7;
     *payload_ptr++ = reserved_byte;
 

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -322,7 +322,9 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
     h26x_set_nal_uuid_type(self, &payload_ptr, UUID_TYPE_SIGNED_VIDEO);
 
     // Add reserved byte(s).
-    *payload_ptr++ = SV_RESERVED_BYTE;
+    // *payload_ptr++ = SV_RESERVED_BYTE;
+    uint8_t reserved_byte = self->sei_epb << 7;
+    *payload_ptr++ = reserved_byte;
 
     size_t written_size =
         tlv_list_encode_or_get_size(self, document_encoders, num_doc_encoders, payload_ptr);
@@ -358,7 +360,7 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
       // need to do this for SV_AUTHENTICITY_LEVEL_FRAME, but for simplicity we always copy it.
       memcpy(self->gop_info->document_hash, self->gop_info->nalu_hash, HASH_DIGEST_SIZE);
       // Free the memory allocated when parsing the NALU.
-      free(nalu_without_signature_data.tmp_tlv_memory);
+      free(nalu_without_signature_data.nalu_data_wo_epb);
     }
 
     gop_info_t *gop_info = self->gop_info;
@@ -609,7 +611,7 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
   SVI_CATCH()
   SVI_DONE(status)
 
-  free(nalu.tmp_tlv_memory);
+  free(nalu.nalu_data_wo_epb);
 
   if (signing_present > self->signing_present) self->signing_present = signing_present;
 
@@ -794,3 +796,12 @@ signed_video_set_recurrence_offset(signed_video_t *self, unsigned offset)
   return SV_OK;
 }
 #endif
+
+SignedVideoReturnCode
+signed_video_set_sei_epb(signed_video_t *self, bool sei_epb)
+{
+  if (!self) return SV_INVALID_PARAMETER;
+
+  self->sei_epb = sei_epb;
+  return SV_OK;
+}

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -63,7 +63,6 @@ typedef struct _h26x_nalu_t h26x_nalu_t;
 #endif
 
 #define UUID_LEN 16
-#define SV_RESERVED_BYTE 0x80  // First bit should be marked as 1
 #define MAX_NALUS_TO_PREPEND 5  // This means that there is room to prepend 4 additional nalus.
 #define LAST_TWO_BYTES_INIT_VALUE 0x0101  // Anything but 0x00 are proper inits
 #define STOP_BYTE_VALUE 0x80

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -117,6 +117,7 @@ struct _signed_video_t {
   gop_info_t *gop_info;
   SignedVideoAuthenticityLevel authenticity_level;
   bool add_public_key_to_sei;
+  bool sei_epb;  // Flag that tells whether to generate SEI frames w/wo emulation prevention bytes
 
   // Frames to prepend list
   signed_video_nalu_to_prepend_t nalus_to_prepend_list[MAX_NALUS_TO_PREPEND];

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -215,35 +215,36 @@ encode_general(signed_video_t *self, uint8_t *data)
 
   uint8_t *data_ptr = data;
   uint16_t *last_two_bytes = &self->last_two_bytes;
+  bool epb = self->sei_epb;
   // Fill Camera Info data
   // Version
-  write_byte(last_two_bytes, &data_ptr, version, true);
+  write_byte(last_two_bytes, &data_ptr, version, epb);
   // GOP counter; 4 bytes
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 24) & 0x000000ff), true);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 16) & 0x000000ff), true);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 8) & 0x000000ff), true);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter)&0x000000ff), true);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 24) & 0x000000ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 16) & 0x000000ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 8) & 0x000000ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter)&0x000000ff), epb);
   // Write num_nalus_in_gop_hash; 2 bytes
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((num_nalus_in_gop_hash >> 8) & 0x00ff), true);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((num_nalus_in_gop_hash)&0x00ff), true);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((num_nalus_in_gop_hash >> 8) & 0x00ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((num_nalus_in_gop_hash)&0x00ff), epb);
 
   for (int i = 0; i < SV_VERSION_BYTES; i++) {
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)self->code_version[i], true);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)self->code_version[i], epb);
   }
 
   // Write bool flags; 1 byte
   flags |= (gop_info->has_timestamp << 0) & 0x01;
-  write_byte(last_two_bytes, &data_ptr, flags, true);
+  write_byte(last_two_bytes, &data_ptr, flags, epb);
   if (gop_info->has_timestamp) {
     // Write timestamp; 8 bytes
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 56) & 0x000000ff), true);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 48) & 0x000000ff), true);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 40) & 0x000000ff), true);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 32) & 0x000000ff), true);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 24) & 0x000000ff), true);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 16) & 0x000000ff), true);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 8) & 0x000000ff), true);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp)&0x000000ff), true);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 56) & 0x000000ff), epb);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 48) & 0x000000ff), epb);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 40) & 0x000000ff), epb);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 32) & 0x000000ff), epb);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 24) & 0x000000ff), epb);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 16) & 0x000000ff), epb);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 8) & 0x000000ff), epb);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp)&0x000000ff), epb);
   }
 
   gop_info->global_gop_counter = gop_counter;
@@ -367,63 +368,64 @@ encode_product_info(signed_video_t *self, uint8_t *data)
 
   uint8_t *data_ptr = data;
   uint16_t *last_two_bytes = &self->last_two_bytes;
+  bool epb = self->sei_epb;
   uint8_t str_end_byte = '\0';
   // Version
-  write_byte(last_two_bytes, &data_ptr, version, true);
+  write_byte(last_two_bytes, &data_ptr, version, epb);
 
   // Write |hardware_id|.
-  write_byte(last_two_bytes, &data_ptr, hardware_id_size_onebyte, true);
+  write_byte(last_two_bytes, &data_ptr, hardware_id_size_onebyte, epb);
   // Write all but the last character.
   write_byte_many(
-      &data_ptr, product_info->hardware_id, hardware_id_size_onebyte - 1, last_two_bytes, true);
+      &data_ptr, product_info->hardware_id, hardware_id_size_onebyte - 1, last_two_bytes, epb);
   // Determine and write the last character.
   str_end_byte = (hardware_id_too_long || !product_info->hardware_id)
       ? '\0'
       : product_info->hardware_id[hardware_id_size_onebyte - 1];
-  write_byte(last_two_bytes, &data_ptr, str_end_byte, true);
+  write_byte(last_two_bytes, &data_ptr, str_end_byte, epb);
 
   // Write |firmware_version|.
-  write_byte(last_two_bytes, &data_ptr, firmware_version_size_onebyte, true);
+  write_byte(last_two_bytes, &data_ptr, firmware_version_size_onebyte, epb);
   // Write all but the last character.
   write_byte_many(&data_ptr, product_info->firmware_version, firmware_version_size_onebyte - 1,
-      last_two_bytes, true);
+      last_two_bytes, epb);
   // Determine and write the last character.
   str_end_byte = (firmware_version_too_long || !product_info->firmware_version)
       ? '\0'
       : product_info->firmware_version[firmware_version_size_onebyte - 1];
-  write_byte(last_two_bytes, &data_ptr, str_end_byte, true);
+  write_byte(last_two_bytes, &data_ptr, str_end_byte, epb);
 
   // Write |serial_number|.
-  write_byte(last_two_bytes, &data_ptr, serial_number_size_onebyte, true);
+  write_byte(last_two_bytes, &data_ptr, serial_number_size_onebyte, epb);
   // Write all but the last character.
   write_byte_many(
-      &data_ptr, product_info->serial_number, serial_number_size_onebyte - 1, last_two_bytes, true);
+      &data_ptr, product_info->serial_number, serial_number_size_onebyte - 1, last_two_bytes, epb);
   // Determine and write the last character.
   str_end_byte = (serial_number_too_long || !product_info->serial_number)
       ? '\0'
       : product_info->serial_number[serial_number_size_onebyte - 1];
-  write_byte(last_two_bytes, &data_ptr, str_end_byte, true);
+  write_byte(last_two_bytes, &data_ptr, str_end_byte, epb);
 
   // Write |manufacturer|.
-  write_byte(last_two_bytes, &data_ptr, manufacturer_size_onebyte, true);
+  write_byte(last_two_bytes, &data_ptr, manufacturer_size_onebyte, epb);
   // Write all but the last character.
   write_byte_many(
-      &data_ptr, product_info->manufacturer, manufacturer_size_onebyte - 1, last_two_bytes, true);
+      &data_ptr, product_info->manufacturer, manufacturer_size_onebyte - 1, last_two_bytes, epb);
   // Determine and write the last character.
   str_end_byte = (manufacturer_too_long || !product_info->manufacturer)
       ? '\0'
       : product_info->manufacturer[manufacturer_size_onebyte - 1];
-  write_byte(last_two_bytes, &data_ptr, str_end_byte, true);
+  write_byte(last_two_bytes, &data_ptr, str_end_byte, epb);
 
   // Write |address|.
-  write_byte(last_two_bytes, &data_ptr, address_size_onebyte, true);
+  write_byte(last_two_bytes, &data_ptr, address_size_onebyte, epb);
   // Write all but the last character.
-  write_byte_many(&data_ptr, product_info->address, address_size_onebyte - 1, last_two_bytes, true);
+  write_byte_many(&data_ptr, product_info->address, address_size_onebyte - 1, last_two_bytes, epb);
   // Determine and write the last character.
   str_end_byte = (address_too_long || !product_info->address)
       ? '\0'
       : product_info->address[address_size_onebyte - 1];
-  write_byte(last_two_bytes, &data_ptr, str_end_byte, true);
+  write_byte(last_two_bytes, &data_ptr, str_end_byte, epb);
 
   return (data_ptr - data);
 }
@@ -503,11 +505,12 @@ encode_arbitrary_data(signed_video_t *self, uint8_t *data)
 
   uint8_t *data_ptr = data;
   uint16_t *last_two_bytes = &self->last_two_bytes;
+  bool epb = self->sei_epb;
   // Version
-  write_byte(last_two_bytes, &data_ptr, version, true);
+  write_byte(last_two_bytes, &data_ptr, version, epb);
 
   for (size_t ii = 0; ii < self->arbitrary_data_size; ++ii) {
-    write_byte(last_two_bytes, &data_ptr, self->arbitrary_data[ii], true);
+    write_byte(last_two_bytes, &data_ptr, self->arbitrary_data[ii], epb);
   }
 
   return (data_ptr - data);
@@ -578,16 +581,17 @@ encode_public_key(signed_video_t *self, uint8_t *data)
 
   uint8_t *data_ptr = data;
   uint16_t *last_two_bytes = &self->last_two_bytes;
+  bool epb = self->sei_epb;
   uint8_t *public_key = signature_info->public_key;
 
   // Fill Camera Info data
   // Version
-  write_byte(last_two_bytes, &data_ptr, version, true);
-  write_byte(last_two_bytes, &data_ptr, signature_info->algo, true);
+  write_byte(last_two_bytes, &data_ptr, version, epb);
+  write_byte(last_two_bytes, &data_ptr, signature_info->algo, epb);
 
   // public_key; public_key_size (451) bytes
   for (size_t ii = 0; ii < signature_info->public_key_size; ++ii) {
-    write_byte(last_two_bytes, &data_ptr, public_key[ii], true);
+    write_byte(last_two_bytes, &data_ptr, public_key[ii], epb);
   }
 
   return (data_ptr - data);
@@ -667,11 +671,12 @@ encode_hash_list(signed_video_t *self, uint8_t *data)
 
   uint8_t *data_ptr = data;
   uint16_t *last_two_bytes = &self->last_two_bytes;
+  bool epb = self->sei_epb;
   // Write version
-  write_byte(last_two_bytes, &data_ptr, version, true);
+  write_byte(last_two_bytes, &data_ptr, version, epb);
   // Write hash_list data
   for (int i = 0; i < gop_info->list_idx; i++) {
-    write_byte(last_two_bytes, &data_ptr, gop_info->hash_list[i], true);
+    write_byte(last_two_bytes, &data_ptr, gop_info->hash_list[i], epb);
   }
 
   // Having successfully encoded the hash_list means we should sign the document_hash and not the
@@ -748,24 +753,25 @@ encode_signature(signed_video_t *self, uint8_t *data)
 
   uint8_t *data_ptr = data;
   uint16_t *last_two_bytes = &self->last_two_bytes;
+  bool epb = self->sei_epb;
   uint16_t signature_size = (uint16_t)signature_info->signature_size;
   // Write version
-  write_byte(last_two_bytes, &data_ptr, version, true);
+  write_byte(last_two_bytes, &data_ptr, version, epb);
   // Write info field
-  write_byte(last_two_bytes, &data_ptr, gop_info->encoding_status, true);
+  write_byte(last_two_bytes, &data_ptr, gop_info->encoding_status, epb);
   // Write hash type
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)gop_info->signature_hash_type, true);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)gop_info->signature_hash_type, epb);
   // Write actual signature size (2 bytes)
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size >> 8) & 0x00ff), true);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size)&0x00ff), true);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size >> 8) & 0x00ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size)&0x00ff), epb);
   // Write signature
   size_t i = 0;
   for (; i < signature_info->signature_size; i++) {
-    write_byte(last_two_bytes, &data_ptr, signature_info->signature[i], true);
+    write_byte(last_two_bytes, &data_ptr, signature_info->signature[i], epb);
   }
   for (; i < signature_info->max_signature_size; i++) {
     // Write 1's in the unused bytes to avoid emulation prevention bytes.
-    write_byte(last_two_bytes, &data_ptr, 1, true);
+    write_byte(last_two_bytes, &data_ptr, 1, epb);
   }
 
   return (data_ptr - data);
@@ -889,13 +895,14 @@ tlv_encode_or_get_size_generic(signed_video_t *self, const sv_tlv_tuple_t tlv, u
 
   uint8_t *data_ptr = data;
   uint16_t *last_two_bytes = &self->last_two_bytes;
+  bool epb = self->sei_epb;
   // Write Tag
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)tlv.tag, true);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)tlv.tag, epb);
   // Write length
   if (tlv.bytes_for_length == 2) {
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((v_size >> 8) & 0x000000ff), true);
+    write_byte(last_two_bytes, &data_ptr, (uint8_t)((v_size >> 8) & 0x000000ff), epb);
   }
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)(v_size & 0x000000ff), true);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)(v_size & 0x000000ff), epb);
 
   // Write value, i.e. the actual data of the TLV
   size_t v_size_written = tlv.encoder(self, data_ptr);

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -839,7 +839,8 @@ static size_t
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
 encode_axis_communications(signed_video_t *self, uint8_t *data)
 {
-  return encode_axis_communications_handle(self->vendor_handle, &self->last_two_bytes, data);
+  bool epb = self->sei_epb;
+  return encode_axis_communications_handle(self->vendor_handle, &self->last_two_bytes, epb, data);
 #else
 encode_axis_communications(signed_video_t ATTR_UNUSED *self, uint8_t ATTR_UNUSED *data)
 {
@@ -1030,7 +1031,7 @@ tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bo
       read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
     }
   }
-  DEBUG_LOG("Never found the tag");
+  DEBUG_LOG("Never found the tag %d", tag);
 
   return NULL;
 }

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -563,7 +563,7 @@ get_untrusted_certificates_size(const sv_vendor_axis_communications_t *self)
 
 /* Encodes the handle data into the TLV tag VENDOR_AXIS_COMMUNICATIONS_TAG. */
 size_t
-encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, uint8_t *data)
+encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, bool epb, uint8_t *data)
 {
   if (!handle) return 0;
 
@@ -596,16 +596,16 @@ encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, uint8_
   uint8_t *attestation = self->attestation;
 
   // Write version.
-  write_byte(last_two_bytes, &data_ptr, version, true);
+  write_byte(last_two_bytes, &data_ptr, version, epb);
   // Write |attestation_size|.
-  write_byte(last_two_bytes, &data_ptr, self->attestation_size, true);
+  write_byte(last_two_bytes, &data_ptr, self->attestation_size, epb);
   // Write |attestation|.
   for (size_t jj = 0; jj < self->attestation_size; ++jj) {
-    write_byte(last_two_bytes, &data_ptr, attestation[jj], true);
+    write_byte(last_two_bytes, &data_ptr, attestation[jj], epb);
   }
   // Write |certificate_chain|.
   write_byte_many(
-      &data_ptr, self->certificate_chain, certificate_chain_encode_size, last_two_bytes, true);
+      &data_ptr, self->certificate_chain, certificate_chain_encode_size, last_two_bytes, epb);
 
   return (data_ptr - data);
 }

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
@@ -70,13 +70,14 @@ sv_vendor_axis_communications_teardown(void *handle);
  * @param handle The handle to encode.
  * @param last_two_bytes Pointer to the last two bytes in process of writing. Needed for proper
  *   emulation prevention handling.
+ * @param epb Flag to write data with emulation prevention bytes (EPB).
  * @param data Pointer to which data is written. A NULL pointer will return the size the data in
  *   |handle| requires.
  *
  * @returns The size written.
  */
 size_t
-encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, uint8_t *data);
+encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, bool epb, uint8_t *data);
 
 /**
  * @brief Decodes data to |handle|.

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -34,6 +34,7 @@
 #include "lib/src/signed_video_h26x_internal.h"  // signed_video_set_recurrence_offset()
 #endif
 #include "lib/src/signed_video_internal.h"  // set_hash_list_size()
+#include "lib/src/signed_video_tlv.h"  // write_byte_many()
 #include "nalu_list.h"  // nalu_list_create()
 #include "signed_video_helpers.h"  // sv_setting, create_signed_nalus()
 
@@ -2459,6 +2460,119 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
 }
 END_TEST
 
+/* Test validation if emulation prevention bytes are added later, by for example an encoder.
+ * We only run the case where emulation prevention bytes are not added when writing the SEI, since
+ * the other case is the default and executed for all other tests. */
+START_TEST(no_emulation_prevention_bytes)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+  if (settings[_i].recurrence != SV_RECURRENCE_ONE) return;
+
+  SignedVideoCodec codec = settings[_i].codec;
+  SignedVideoReturnCode sv_rc;
+
+  // Create a video with a single I-frame, and a SEI (to be created later).
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+  nalu_list_item_t *sei = NULL;
+
+  // Signing side
+  // Generate a Private key.
+  char *private_key = NULL;
+  size_t private_key_size = 0;
+  sv_rc =
+      signed_video_generate_private_key(settings[_i].algo, "./", &private_key, &private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Create a session.
+  signed_video_t *sv = signed_video_create(codec);
+  ck_assert(sv);
+
+  // Apply settings to session.
+  sv_rc = signed_video_set_private_key(sv, settings[_i].algo, private_key, private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_sei_epb(sv, false);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Add I-frame for signing and get SEI frame.
+  sv_rc = signed_video_add_nalu_for_signing_with_timestamp(
+      sv, i_nalu->data, i_nalu->data_size, &g_testTimestamp);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  signed_video_nalu_to_prepend_t nalu_to_prepend = {0};
+  sv_rc = signed_video_get_nalu_to_prepend(sv, &nalu_to_prepend);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(nalu_to_prepend.prepend_instruction != SIGNED_VIDEO_PREPEND_NOTHING);
+
+  // Allocate memory for a new buffer to write to, and add emulation prevention bytes.
+  uint8_t *sei_data = malloc(nalu_to_prepend.nalu_data_size * 4 / 3);
+  uint8_t *sei_p = sei_data;
+  uint16_t last_two_bytes = LAST_TWO_BYTES_INIT_VALUE;
+  memcpy(sei_p, nalu_to_prepend.nalu_data, 4);
+  sei_p += 4;  // Move past the start code to avoid an incorrect emulation prevention byte.
+  char *src = (char *)(nalu_to_prepend.nalu_data + 4);
+  size_t src_size = nalu_to_prepend.nalu_data_size - 4;
+  write_byte_many(&sei_p, src, src_size, &last_two_bytes, true);
+  size_t sei_data_size = sei_p - sei_data;
+  signed_video_nalu_data_free(nalu_to_prepend.nalu_data);
+
+  // Create a SEI NAL Unit.
+  sei = nalu_list_create_item(sei_data, sei_data_size, codec);
+  sv_rc = signed_video_get_nalu_to_prepend(sv, &nalu_to_prepend);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(nalu_to_prepend.prepend_instruction == SIGNED_VIDEO_PREPEND_NOTHING);
+
+  // Close signing side.
+  signed_video_free(sv);
+  sv = NULL;
+
+  // End of signing side. Start a new session on the validation side.
+  sv = signed_video_create(codec);
+  ck_assert(sv);
+
+  // Validate this first GOP.
+  signed_video_authenticity_t *auth_report = NULL;
+  signed_video_latest_validation_t *latest = NULL;
+
+  // Assume we receive a single AU with a SEI and an I-frame.
+  // Pass in the SEI.
+  sv_rc = signed_video_add_nalu_and_authenticate(sv, sei->data, sei->data_size, &auth_report);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(!auth_report);
+  // Pass in the I-frame.
+  sv_rc = signed_video_add_nalu_and_authenticate(sv, i_nalu->data, i_nalu->data_size, &auth_report);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  // Read the authenticity report.
+  if (auth_report) {
+    latest = &(auth_report->latest_validation);
+    ck_assert(latest);
+    ck_assert_int_eq(strcmp(latest->validation_str, ".P"), 0);
+    ck_assert_int_eq(latest->public_key_validation, SV_PUBKEY_VALIDATION_NOT_FEASIBLE);
+    ck_assert_int_eq(auth_report->accumulated_validation.authenticity, SV_AUTH_RESULT_OK);
+    ck_assert_int_eq(auth_report->accumulated_validation.public_key_has_changed, false);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_received_nalus, 2);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_validated_nalus, 1);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_pending_nalus, 1);
+    ck_assert_int_eq(auth_report->accumulated_validation.public_key_validation,
+        SV_PUBKEY_VALIDATION_NOT_FEASIBLE);
+    // We are done with auth_report.
+    latest = NULL;
+    signed_video_authenticity_report_free(auth_report);
+    auth_report = NULL;
+  } else {
+    ck_assert(false);
+  }
+
+  // End of validation, free memory.
+  nalu_list_free_item(sei);
+  nalu_list_free_item(i_nalu);
+  signed_video_free(sv);
+  free(private_key);
+}
+END_TEST
+
 static Suite *
 signed_video_suite(void)
 {
@@ -2513,6 +2627,7 @@ signed_video_suite(void)
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
   tcase_add_loop_test(tc, vendor_axis_communications_operation, s, e);
 #endif
+  tcase_add_loop_test(tc, no_emulation_prevention_bytes, s, e);
 
   // Add test case to suit
   suite_add_tcase(suite, tc);

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -2495,6 +2495,15 @@ START_TEST(no_emulation_prevention_bytes)
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_set_sei_epb(sv, false);
   ck_assert_int_eq(sv_rc, SV_OK);
+#ifdef SV_VENDOR_AXIS_COMMUNICATIONS
+  const size_t attestation_size = 2;
+  void *attestation = calloc(1, attestation_size);
+  // Setting |attestation| and |certificate_chain|.
+  sv_rc = sv_vendor_axis_communications_set_attestation_report(
+      sv, attestation, attestation_size, axisDummyCertificateChain);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  free(attestation);
+#endif
 
   // Add I-frame for signing and get SEI frame.
   sv_rc = signed_video_add_nalu_for_signing_with_timestamp(
@@ -2549,6 +2558,7 @@ START_TEST(no_emulation_prevention_bytes)
     latest = &(auth_report->latest_validation);
     ck_assert(latest);
     ck_assert_int_eq(strcmp(latest->validation_str, ".P"), 0);
+    // Public key validation is not feasible since there is no Product information.
     ck_assert_int_eq(latest->public_key_validation, SV_PUBKEY_VALIDATION_NOT_FEASIBLE);
     ck_assert_int_eq(auth_report->accumulated_validation.authenticity, SV_AUTH_RESULT_OK);
     ck_assert_int_eq(auth_report->accumulated_validation.public_key_has_changed, false);

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -761,6 +761,15 @@ START_TEST(w_wo_emulation_prevention_bytes)
     ck_assert_int_eq(sv_rc, SV_OK);
     sv_rc = signed_video_set_sei_epb(sv, with_emulation_prevention[ii]);
     ck_assert_int_eq(sv_rc, SV_OK);
+#ifdef SV_VENDOR_AXIS_COMMUNICATIONS
+    const size_t attestation_size = 2;
+    void *attestation = calloc(1, attestation_size);
+    // Setting |attestation| and |certificate_chain|.
+    sv_rc = sv_vendor_axis_communications_set_attestation_report(
+        sv, attestation, attestation_size, axisDummyCertificateChain);
+    ck_assert_int_eq(sv_rc, SV_OK);
+    free(attestation);
+#endif
 
     // Add I-frame for signing and get SEI frame
     sv_rc = signed_video_add_nalu_for_signing_with_timestamp(

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -31,7 +31,6 @@
 #include "lib/src/signed_video_defines.h"  // svi_rc, sv_tlv_tag_t
 #include "lib/src/signed_video_h26x_internal.h"  // h26x_nalu_t
 #include "lib/src/signed_video_internal.h"  // set_hash_list_size()
-#include "lib/src/signed_video_tlv.h"  // tlv_find_tag()
 #include "nalu_list.h"
 #include "signed_video_helpers.h"
 
@@ -144,6 +143,14 @@ START_TEST(api_inputs)
   sv_rc = signed_video_set_authenticity_level(sv, SV_AUTHENTICITY_LEVEL_FRAME);
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_set_authenticity_level(sv, SV_AUTHENTICITY_LEVEL_GOP);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Setting emulation prevention.
+  sv_rc = signed_video_set_sei_epb(NULL, false);
+  ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
+  sv_rc = signed_video_set_sei_epb(sv, false);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_sei_epb(sv, true);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   // Prepare for next iteration of tests.
@@ -689,8 +696,8 @@ START_TEST(correct_timestamp)
   ck_assert(nalu.hashable_data_size > 0);
   ck_assert(!memcmp(nalu.hashable_data, nalu_ts.hashable_data, nalu.hashable_data_size));
 
-  free(nalu.tmp_tlv_memory);
-  free(nalu_ts.tmp_tlv_memory);
+  free(nalu.nalu_data_wo_epb);
+  free(nalu_ts.nalu_data_wo_epb);
   signed_video_nalu_data_free(nalu_to_prepend.nalu_data);
   signed_video_nalu_data_free(nalu_to_prepend_ts.nalu_data);
   nalu_list_free_item(i_nalu);
@@ -711,6 +718,83 @@ START_TEST(correct_signing_nalus_in_parts)
   nalu_list_t *list = create_signed_splitted_nalus("IPPIPP", settings[_i]);
   nalu_list_check_str(list, "GIPPGIPP");
   nalu_list_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify the setter for generating SEI frames with or without emulation prevention bytes.
+ */
+#define NUM_EPB_CASES 2
+START_TEST(w_wo_emulation_prevention_bytes)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  // No need to run this with recurrence.
+  if (settings[_i].recurrence != SV_RECURRENCE_ONE) return;
+
+  SignedVideoCodec codec = settings[_i].codec;
+  SignedVideoReturnCode sv_rc;
+
+  h26x_nalu_t nalus[NUM_EPB_CASES] = {0};
+  uint8_t *sei[NUM_EPB_CASES] = {NULL, NULL};
+  size_t sei_size[NUM_EPB_CASES] = {0, 0};
+  bool with_emulation_prevention[NUM_EPB_CASES] = {true, false};
+  char *private_key = NULL;
+  size_t private_key_size = 0;
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+
+  // Generate a Private key.
+  sv_rc =
+      signed_video_generate_private_key(settings[_i].algo, "./", &private_key, &private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  for (size_t ii = 0; ii < NUM_EPB_CASES; ii++) {
+    signed_video_nalu_to_prepend_t nalu_to_prepend = {0};
+    signed_video_t *sv = signed_video_create(codec);
+    ck_assert(sv);
+
+    // Apply settings to session.
+    sv_rc = signed_video_set_private_key(sv, settings[_i].algo, private_key, private_key_size);
+    ck_assert_int_eq(sv_rc, SV_OK);
+    sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
+    ck_assert_int_eq(sv_rc, SV_OK);
+    sv_rc = signed_video_set_sei_epb(sv, with_emulation_prevention[ii]);
+    ck_assert_int_eq(sv_rc, SV_OK);
+
+    // Add I-frame for signing and get SEI frame
+    sv_rc = signed_video_add_nalu_for_signing_with_timestamp(
+        sv, i_nalu->data, i_nalu->data_size, &g_testTimestamp);
+    ck_assert_int_eq(sv_rc, SV_OK);
+    sv_rc = signed_video_get_nalu_to_prepend(sv, &nalu_to_prepend);
+    ck_assert_int_eq(sv_rc, SV_OK);
+    ck_assert(nalu_to_prepend.prepend_instruction != SIGNED_VIDEO_PREPEND_NOTHING);
+
+    ck_assert(nalu_to_prepend.nalu_data_size > 0);
+    sei[ii] = malloc(nalu_to_prepend.nalu_data_size);
+    ck_assert(sei[ii]);
+    sei_size[ii] = nalu_to_prepend.nalu_data_size;
+    memcpy(sei[ii], nalu_to_prepend.nalu_data, nalu_to_prepend.nalu_data_size);
+    signed_video_nalu_data_free(nalu_to_prepend.nalu_data);
+
+    nalus[ii] = parse_nalu_info(sei[ii], sei_size[ii], codec, false, true);
+    update_hashable_data(&nalus[ii]);
+
+    signed_video_free(sv);
+    sv = NULL;
+  }
+
+  // Verify that hashable data sizes and data contents are not identical
+  ck_assert(nalus[0].hashable_data_size > nalus[1].hashable_data_size);
+  ck_assert(nalus[1].hashable_data_size > 0);
+  ck_assert(memcmp(nalus[0].hashable_data, nalus[1].hashable_data, nalus[1].hashable_data_size));
+
+  for (size_t ii = 0; ii < NUM_EPB_CASES; ii++) {
+    free(nalus[ii].nalu_data_wo_epb);
+    free(sei[ii]);
+  }
+  nalu_list_free_item(i_nalu);
+  free(private_key);
 }
 END_TEST
 
@@ -744,6 +828,7 @@ signed_video_suite(void)
   tcase_add_loop_test(tc, recurrence, s, e);
   tcase_add_loop_test(tc, correct_timestamp, s, e);
   tcase_add_loop_test(tc, correct_signing_nalus_in_parts, s, e);
+  tcase_add_loop_test(tc, w_wo_emulation_prevention_bytes, s, e);
 
   // Add test case to suit
   suite_add_tcase(suite, tc);

--- a/tests/check/nalu_list.c
+++ b/tests/check/nalu_list.c
@@ -111,7 +111,7 @@ get_str_code(const uint8_t *data, size_t data_size, SignedVideoCodec codec)
       break;
   }
 
-  free(nalu.tmp_tlv_memory);
+  free(nalu.nalu_data_wo_epb);
 
   return str;
 }

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -327,7 +327,7 @@ tag_is_present(nalu_list_item_t *item, SignedVideoCodec codec, sv_tlv_tag_t tag)
   void *tag_ptr = (void *)tlv_find_tag(nalu.tlv_data, nalu.tlv_size, tag, false);
   found_tag = (tag_ptr != NULL);
   // Free tempory data slot used if emulation prevention bytes are present.
-  free(nalu.tmp_tlv_memory);
+  free(nalu.nalu_data_wo_epb);
 
   return found_tag;
 }


### PR DESCRIPTION
This is a new API for the signing side which configures the Signed
Video session to produce SEIs with or without emulation prevention.
The default behavior is with emulation prevention turned on.

Two new tests have been added; one on the signing side to compare
SEIs w/wo emulation prevention, and one on the validation side to
verify that validation works even if emulation prevention bytes are
added later.

In addition, a name change of a member is done from tmp_tlv_memory
to nalu_data_wo_epb, since the entire nalu_data is copied instead
of just the tlv part.
