### PR TITLE
Adds a queue in threaded-signing/plugin

### DIFF
--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -417,8 +417,8 @@ START_TEST(correct_nalu_sequence_without_eos)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  nalu_list_t *list = create_signed_nalus("IPPIPP", settings[_i]);
-  nalu_list_check_str(list, "GIPPGIPP");
+  nalu_list_t *list = create_signed_nalus("IPPIPPIPPIPPIPPIPP", settings[_i]);
+  nalu_list_check_str(list, "GIPPGIPPGIPPGIPPGIPPGIPP");
   nalu_list_free(list);
 }
 END_TEST


### PR DESCRIPTION
This solves the issue of failed signing if the signing
functionality was temporarily blocked when Signed Video made
the request.
Now incoming hashes are put in a queue, from which the signing
thread picks hash by hash.

A test has been added for this case.
