### PR TITLE
Replaces character strings with single char

### DIFF
--- a/lib/src/signed_video_h26x_nalu_list.c
+++ b/lib/src/signed_video_h26x_nalu_list.c
@@ -518,7 +518,7 @@ h26x_nalu_list_get_str(const h26x_nalu_list_t *list, NaluListStringType str_type
         src = item->validation_status;
         break;
     }
-    memcpy(dst_str + idx, &src, 1);
+    dst_str[idx] = src;
     item = item->next;
     idx++;
   }

--- a/lib/src/signed_video_h26x_nalu_list.h
+++ b/lib/src/signed_video_h26x_nalu_list.h
@@ -166,9 +166,11 @@ h26x_nalu_list_num_pending_items(const h26x_nalu_list_t* list);
 /**
  * @brief Returns a string with all authentication statuses of the items
  *
- * Transforms all |validation_status| characters of the items in the |list| into a char string.
+ * Transforms all |validation_status| characters, or NAL Unit character, of the items in
+ * the |list| into a char string.
  *
- * @param list The list to clean from validated items.
+ * @param list The list to get string from.
+ * @param str_type The type of string data to get (validation or nalu).
  *
  * @returns The validation string, and a '\0' upon failure.
  */

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -277,8 +277,8 @@ START_TEST(invalid_api_inputs)
 
   signed_video_t *sv = signed_video_create(codec);
   ck_assert(sv);
-  nalu_list_item_t *p_nalu = nalu_list_item_create_and_set_id("P", 0, codec);
-  nalu_list_item_t *invalid = nalu_list_item_create_and_set_id("X", 0, codec);
+  nalu_list_item_t *p_nalu = nalu_list_item_create_and_set_id('P', 0, codec);
+  nalu_list_item_t *invalid = nalu_list_item_create_and_set_id('X', 0, codec);
   // signed_video_add_nalu_and_authenticate()
   // NULL pointers are invalid, as well as zero sized nalus.
   SignedVideoReturnCode sv_rc =
@@ -1125,7 +1125,7 @@ START_TEST(add_one_sei_nalu_after_signing)
   nalu_list_check_str(list, "SIPPSIPPPSIPPSI");
 
   const uint8_t id = 0;
-  nalu_list_item_t *sei = nalu_list_item_create_and_set_id("Z", id, settings[_i].codec);
+  nalu_list_item_t *sei = nalu_list_item_create_and_set_id('Z', id, settings[_i].codec);
 
   // Middle P-NALU in second non-empty GOP: SIPPSIP P(Z) PSIPPSI
   const int append_nalu_number = 8;
@@ -1716,7 +1716,7 @@ START_TEST(vendor_axis_communications_operation)
   sign_algo_t algo = settings[_i].algo;
   SignedVideoAuthenticityLevel auth_level = settings[_i].auth_level;
   signed_video_nalu_to_prepend_t nalu_to_prepend = {0};
-  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id('I', 0, codec);
   nalu_list_item_t *sei = NULL;
   char *private_key = NULL;
   size_t private_key_size = 0;
@@ -1810,7 +1810,7 @@ generate_and_set_private_key_on_camera_side(struct sv_setting setting,
   char *private_key = NULL;
   size_t private_key_size = 0;
   signed_video_nalu_to_prepend_t nalu_to_prepend = {0};
-  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, setting.codec);
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id('I', 0, setting.codec);
 
   signed_video_t *sv = signed_video_create(setting.codec);
   ck_assert(sv);
@@ -1857,7 +1857,7 @@ validate_public_key_scenario(signed_video_t *sv,
   signed_video_authenticity_t *auth_report = NULL;
   signed_video_latest_validation_t *latest = NULL;
 
-  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id('I', 0, codec);
   sv_rc = signed_video_add_nalu_and_authenticate(sv, sei->data, sei->data_size, &auth_report);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(!auth_report);
@@ -1996,7 +1996,7 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   SignedVideoReturnCode sv_rc;
   SignedVideoCodec codec = settings[_i].codec;
   sign_algo_t algo = settings[_i].algo;
-  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id('I', 0, codec);
   nalu_list_item_t *sei = NULL;
   signed_video_t *sv_camera = NULL;
 
@@ -2054,7 +2054,7 @@ START_TEST(no_emulation_prevention_bytes)
   SignedVideoReturnCode sv_rc;
 
   // Create a video with a single I-frame, and a SEI (to be created later).
-  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id('I', 0, codec);
   nalu_list_item_t *sei = NULL;
 
   // Signing side

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -86,8 +86,8 @@ START_TEST(api_inputs)
   SignedVideoCodec codec = settings[_i].codec;
   sign_algo_t algo = settings[_i].algo;
   signed_video_nalu_to_prepend_t nalu_to_prepend = {0};
-  nalu_list_item_t *p_nalu = nalu_list_item_create_and_set_id("P", 0, codec);
-  nalu_list_item_t *invalid = nalu_list_item_create_and_set_id("X", 0, codec);
+  nalu_list_item_t *p_nalu = nalu_list_item_create_and_set_id('P', 0, codec);
+  nalu_list_item_t *invalid = nalu_list_item_create_and_set_id('X', 0, codec);
   char *private_key = NULL;
   size_t private_key_size = 0;
 
@@ -258,8 +258,8 @@ START_TEST(incorrect_operation)
   ck_assert(sv);
   char *private_key = NULL;
   size_t private_key_size = 0;
-  nalu_list_item_t *p_nalu = nalu_list_item_create_and_set_id("P", 0, codec);
-  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+  nalu_list_item_t *p_nalu = nalu_list_item_create_and_set_id('P', 0, codec);
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id('I', 0, codec);
   // The path to openssl keys has to be set before start of signing.
   SignedVideoReturnCode sv_rc =
       signed_video_add_nalu_for_signing(sv, i_nalu->data, i_nalu->data_size);
@@ -317,7 +317,7 @@ START_TEST(vendor_axis_communications_operation)
   sign_algo_t algo = settings[_i].algo;
   SignedVideoAuthenticityLevel auth_level = settings[_i].auth_level;
   signed_video_nalu_to_prepend_t nalu_to_prepend = {0};
-  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id('I', 0, codec);
   nalu_list_item_t *sei = NULL;
   char *private_key = NULL;
   size_t private_key_size = 0;
@@ -604,7 +604,7 @@ START_TEST(correct_timestamp)
   ck_assert(sv_ts);
   char *private_key = NULL;
   size_t private_key_size = 0;
-  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id('I', 0, codec);
 
   // Setup the key
   sv_rc =
@@ -699,7 +699,7 @@ START_TEST(w_wo_emulation_prevention_bytes)
   bool with_emulation_prevention[NUM_EPB_CASES] = {true, false};
   char *private_key = NULL;
   size_t private_key_size = 0;
-  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id("I", 0, codec);
+  nalu_list_item_t *i_nalu = nalu_list_item_create_and_set_id('I', 0, codec);
 
   // Generate a Private key.
   sv_rc =
@@ -784,7 +784,7 @@ START_TEST(limited_sei_payload_size)
   int sei_idx[3] = {13, 5, 1};
   for (int ii = 0; ii < 3; ii++) {
     nalu_list_item_t *sei = nalu_list_remove_item(list, sei_idx[ii]);
-    ck_assert_str_eq(sei->str_code, "S");
+    ck_assert_int_eq(sei->str_code, 'S');
     ck_assert_uint_le(sei->data_size, max_sei_payload_size);
     nalu_list_free_item(sei);
     sei = NULL;

--- a/tests/check/nalu_list.h
+++ b/tests/check/nalu_list.h
@@ -49,7 +49,7 @@ extern const uint8_t sei_nalu_h265[DUMMY_SEI_NALU_SIZE];
 typedef struct _nalu_list_item_t {
   uint8_t *data;  // Pointer to NALU data
   size_t data_size;  // Size of NALU data
-  char str_code[2];  // One character representation of NALU + null termination
+  char str_code;  // One character representation of NALU + null termination
   struct _nalu_list_item_t *prev;  // Previous item
   struct _nalu_list_item_t *next;  // Next item
 } nalu_list_item_t;
@@ -67,7 +67,6 @@ typedef struct _nalu_list_t {
   char str_code[MAX_NUM_ITEMS + 1];  // One extra for null termination.
   SignedVideoCodec codec;  // H264 or H265
 } nalu_list_t;
-
 
 /**
  * nalu_list_t functions
@@ -95,8 +94,7 @@ nalu_list_append_and_free(nalu_list_t *list, nalu_list_t *list_to_append);
 /* Appends the list item with position item_number with a new item.
  */
 void
-nalu_list_append_item(nalu_list_t *list, nalu_list_item_t *new_item,
-    int item_number_to_append);
+nalu_list_append_item(nalu_list_t *list, nalu_list_item_t *new_item, int item_number_to_append);
 
 /* Appends the last_item of a list with a new_item.
  */
@@ -122,14 +120,13 @@ nalu_list_check_str(const nalu_list_t *list, const char *str);
 void
 nalu_list_print(nalu_list_t *list);
 
-
 /**
  * nalu_list_item_t functions
  **/
 
 /* Creates a nalu_list_item_t from a |str| and |codec|. Then sets the |id|. */
 nalu_list_item_t *
-nalu_list_item_create_and_set_id(const char *str, uint8_t id, SignedVideoCodec codec);
+nalu_list_item_create_and_set_id(char str, uint8_t id, SignedVideoCodec codec);
 
 /* Creates a new NALU list item. Takes pointers to the NALU data, the nalu data size. Memory
  * ownership is transfered.
@@ -167,13 +164,11 @@ nalu_list_pop_last_item(nalu_list_t *list);
 
 /* Appends a list item with a new item. Assumes list_item exists. */
 void
-nalu_list_item_append_item(nalu_list_item_t *list_item,
-    nalu_list_item_t *new_item);
+nalu_list_item_append_item(nalu_list_item_t *list_item, nalu_list_item_t *new_item);
 
 /* Prepends a list item with a new item. Assumes list_item exists. */
 void
-nalu_list_item_prepend_item(nalu_list_item_t *list_item,
-    nalu_list_item_t *new_item);
+nalu_list_item_prepend_item(nalu_list_item_t *list_item, nalu_list_item_t *new_item);
 
 /* Checks the NALU |item| against the expected |str|. */
 void


### PR DESCRIPTION
In many places the strings are single characters and there is no
point in overdoing things to keep them as strings.
