### PR TITLE
Fixes potential segfault

### DIFF
--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -234,6 +234,11 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
     return SVI_OK;
   }
 
+  if (self->sei_data_buffer_idx >= MAX_NALUS_TO_PREPEND) {
+    // Not enough space for this payload.
+    return SVI_NOT_SUPPORTED;
+  }
+
   // Reset |signature_hash_type| to |GOP_HASH|. If the |hash_list| is successfully added,
   // |signature_hash_type| is changed to |DOCUMENT_HASH|.
   self->gop_info->signature_hash_type = GOP_HASH;

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -48,7 +48,7 @@ typedef struct _h26x_nalu_t h26x_nalu_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v1.1.27"
+#define SIGNED_VIDEO_VERSION "v1.1.28"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '1.1.27',
+  version : '1.1.28',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
when tearing down a signing thread. If signing is active when
closing down the plugin, memory might be freed that later is used.
This commit waits for an ongoing signing to complete before
freeing memory.
