### PR TITLE
Adds all intermediate certificates

### DIFF
--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -48,7 +48,7 @@ typedef struct _h26x_nalu_t h26x_nalu_t;
 #define HASH_DIGEST_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v1.1.28"
+#define SIGNED_VIDEO_VERSION "v1.1.29"
 #define SV_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -552,9 +552,9 @@ get_untrusted_certificates_size(const sv_vendor_axis_communications_t *self)
     certs_left--;
     cert_chain_ptr = cert_ptr + 1;
   }
-  // Check if |cert_ptr| is the third certificate and compare it against expected
-  // |kTrustedAxisRootCA|.
-  if ((certs_left == 0) && cert_ptr && (strcmp(cert_ptr, kTrustedAxisRootCA) == 0)) {
+  // Check if |cert_ptr| points at the third (last) certificate. If not, the certificate chain is
+  // incomplete.
+  if ((certs_left == 0) && cert_ptr) {
     certificate_chain_encode_size = cert_ptr - self->certificate_chain;
   }
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '1.1.28',
+  version : '1.1.29',
   meson_version : '>= 0.47.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
For vendor Axis Communications, two intermediate certificates
are expected and a third root CA. Before this commit a check
for bitexactness of the root CA certificate was done, which
could cause missing out the certificate chain, even though
validation would pass.
Now the check only verifies there are in total three
certificates in the chain and the first two are added to the
SEI.

Bumps version to v1.1.29.
