### PR TITLE
Removes uses of OPENSSL_malloc

### DIFF
--- a/lib/plugins/threaded-signing/plugin.c
+++ b/lib/plugins/threaded-signing/plugin.c
@@ -176,7 +176,7 @@ signature_info_create(const signature_info_t *signature_info)
 
   if (signature_info->max_signature_size) {
     // Allocate memory for the |signature|.
-    tmp_signature_info->signature = openssl_malloc(signature_info->max_signature_size);
+    tmp_signature_info->signature = malloc(signature_info->max_signature_size);
     if (!tmp_signature_info->signature) goto catch_error;
     tmp_signature_info->max_signature_size = signature_info->max_signature_size;
   } else {
@@ -883,7 +883,7 @@ sv_interface_teardown(void *plugin_handle)
 uint8_t *
 sv_interface_malloc(size_t data_size)
 {
-  return openssl_malloc(data_size);
+  return malloc(data_size);
 }
 
 /* TO BE DEPRECATED */

--- a/lib/plugins/unthreaded-signing/plugin.c
+++ b/lib/plugins/unthreaded-signing/plugin.c
@@ -198,7 +198,7 @@ sv_interface_teardown(void *plugin_handle)
 uint8_t *
 sv_interface_malloc(size_t data_size)
 {
-  return openssl_malloc(data_size);
+  return malloc(data_size);
 }
 
 void

--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -55,18 +55,6 @@ void
 openssl_free_handle(void *handle);
 
 /**
- * @brief Malloc data
- *
- * Allocates the memory for data.
- *
- * @param size Data size.
- *
- * @returns Pointer to allocated memory.
- */
-uint8_t *
-openssl_malloc(size_t size);
-
-/**
  * @brief Frees data
  *
  * Free the allocated data memory.

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -261,7 +261,7 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
 
       signature_info->signature_size = 0;
       signature_info->max_signature_size = 0;
-      signature_info->signature = sv_interface_malloc(max_signature_size);
+      signature_info->signature = malloc(max_signature_size);
       SVI_THROW_IF(!signature_info->signature, SVI_MEMORY);
       signature_info->max_signature_size = max_signature_size;
     }

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -90,13 +90,6 @@ openssl_create_private_key(sign_algo_t algo, const char *path_to_key, key_paths_
 #define PRIVATE_RSA_KEY_FILE "private_rsa_key.pem"
 #define PRIVATE_ECDSA_KEY_FILE "private_ecdsa_key.pem"
 
-/* Allocate data using OpenSSL API. */
-uint8_t *
-openssl_malloc(size_t size)
-{
-  return OPENSSL_malloc(size);
-}
-
 /* Free the data allocated by OpenSSL. */
 void
 openssl_free(uint8_t *data)
@@ -127,7 +120,7 @@ openssl_signature_malloc(signature_info_t *signature_info)
     size_t max_signature_size = EVP_PKEY_size(signing_key);
     EVP_PKEY_free(signing_key);
     SVI_THROW_IF(max_signature_size == 0, SVI_EXTERNAL_FAILURE);
-    signature_info->signature = openssl_malloc(max_signature_size);
+    signature_info->signature = malloc(max_signature_size);
     SVI_THROW_IF(!signature_info->signature, SVI_MEMORY);
     signature_info->max_signature_size = max_signature_size;
   SVI_CATCH()

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -809,7 +809,7 @@ decode_signature(signed_video_t *self, const uint8_t *data, size_t data_size)
       signature_info->max_signature_size = 0;
       signature_info->signature_size = 0;
       // Allocate enough space for future signatures as well, that is, max_signature_size.
-      *signature_ptr = sv_interface_malloc(max_signature_size);
+      *signature_ptr = malloc(max_signature_size);
       SVI_THROW_IF(!*signature_ptr, SVI_MEMORY);
       // Set memory size.
       signature_info->max_signature_size = max_signature_size;


### PR DESCRIPTION
since it is simply a macro that adds debug info __FUNC__ and
__LINE__ to a normal malloc() call.
The code now use malloc throughout.
