### PR TITLE
Removes uses of OPENSSL_free

### DIFF
--- a/lib/plugins/threaded-signing/plugin.c
+++ b/lib/plugins/threaded-signing/plugin.c
@@ -117,7 +117,7 @@ signature_info_free(signature_info_t *signature_info)
   if (!signature_info) return;
 
   free(signature_info->private_key);
-  if (signature_info->signature) openssl_free(signature_info->signature);
+  free(signature_info->signature);
   free(signature_info->hash);
   free(signature_info);
 }
@@ -890,7 +890,7 @@ sv_interface_malloc(size_t data_size)
 void
 sv_interface_free(uint8_t *data)
 {
-  openssl_free(data);
+  free(data);
 }
 
 /* This plugin initializer expects the |user_data| to be a signature_info_t struct. Only the

--- a/lib/plugins/unthreaded-signing/plugin.c
+++ b/lib/plugins/unthreaded-signing/plugin.c
@@ -184,7 +184,7 @@ sv_signing_plugin_session_teardown(void *handle)
   if (!self) return;
 
   free(self->signature_info.private_key);
-  if (self->signature_info.signature) openssl_free(self->signature_info.signature);
+  free(self->signature_info.signature);
   free(self);
 }
 
@@ -204,7 +204,7 @@ sv_interface_malloc(size_t data_size)
 void
 sv_interface_free(uint8_t *data)
 {
-  openssl_free(data);
+  free(data);
 }
 
 int

--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -55,16 +55,6 @@ void
 openssl_free_handle(void *handle);
 
 /**
- * @brief Frees data
- *
- * Free the allocated data memory.
- *
- * @param data Pointer to the data.
- */
-void
-openssl_free(uint8_t *data);
-
-/**
  * @brief Hashes data into a 256 bit hash
  *
  * Uses the OpenSSL SHA256() API to hash data. The hashed data has 256 bits, which needs to be

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -202,7 +202,7 @@ signature_free(signature_info_t *self)
   free(self->private_key);
   free(self->public_key);
   free(self->hash);
-  sv_interface_free(self->signature);
+  free(self->signature);
   free(self);
 }
 

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -90,13 +90,6 @@ openssl_create_private_key(sign_algo_t algo, const char *path_to_key, key_paths_
 #define PRIVATE_RSA_KEY_FILE "private_rsa_key.pem"
 #define PRIVATE_ECDSA_KEY_FILE "private_ecdsa_key.pem"
 
-/* Free the data allocated by OpenSSL. */
-void
-openssl_free(uint8_t *data)
-{
-  OPENSSL_free(data);
-}
-
 /* Allocates enough memory for the signature when using the |private_key| in |signature_info|. */
 SignedVideoReturnCode
 openssl_signature_malloc(signature_info_t *signature_info)


### PR DESCRIPTION
since it is simply a macro that adds debug info __FUNC__ and
__LINE__ to a normal free() call.
The code now use free() throughout.
