### PR TITLE
Removes usage of sign_algo_t in code

### DIFF
--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -50,7 +50,7 @@ typedef enum { SIGN_ALGO_RSA = 0, SIGN_ALGO_ECDSA = 1, SIGN_ALGO_NUM } sign_algo
 typedef struct _signature_info_t {
   uint8_t *hash;  // The hash to be signed, or to verify the signature.
   size_t hash_size;  // The size of the |hash|. For now with a fixed size of HASH_DIGEST_SIZE.
-  sign_algo_t algo;  // The algorithm used to sign the |hash|.
+  sign_algo_t algo;  // The algorithm used to sign the |hash|. NOT USED ANYMORE
   void *private_key;  // The private key used for signing in a pem file format.
   size_t private_key_size;  // The size of the |private_key|.
   void *public_key;  // The public key used for validation in a pem file format.
@@ -236,7 +236,7 @@ openssl_key_memory_allocated(void **key, size_t *key_size, size_t new_key_size);
  *
  * By specifying a location and a signing algorithm (RSA, or ECDSA) a PEM file is generated and
  * stored as private_rsa_key.pem or private_ecdsa_key.pem. The user can then read this file and
- * pass the content to Signed Video through signed_video_set_private_key().
+ * pass the content to Signed Video through signed_video_set_private_key_new().
  * If no |path_to_key| is passed in, memory is allocated for |private_key| and the content of
  * |private_key_size| is written. Note that the ownership is transferred.
  *

--- a/lib/src/includes/signed_video_sign.h
+++ b/lib/src/includes/signed_video_sign.h
@@ -120,7 +120,7 @@ typedef enum {
  * @param is_last_part Flag to mark the last part of the NALU data.
  *
  * @returns SV_OK            - the NALU was processed successfully.
- *          SV_NOT_SUPPORTED - signed_video_set_private_key(...) has not been set
+ *          SV_NOT_SUPPORTED - signed_video_set_private_key_new(...) has not been set
  *                             OR
  *                             there are generated NALUs waiting to be pulled. Use
  *                             signed_video_get_nalu_to_prepend(...) to fetch them. Then call this
@@ -181,8 +181,7 @@ signed_video_add_nalu_for_signing(signed_video_t *self,
  *   if (!sv) {
  *     // Handle error
  *   }
- *   if (signed_video_set_private_key(sv, SIGN_ALGO_ECDSA, private_key, private_key_size)
- *       != SV_OK) {
+ *   if (signed_video_set_private_key_new(sv, private_key, private_key_size) != SV_OK) {
  *     // Handle error
  *   }
  *   SignedVideoReturnCode status;
@@ -299,17 +298,19 @@ signed_video_set_product_info(signed_video_t *self,
  * then be able to take necessary actions on their side before verifying the signature.
  *
  * @param self Pointer to the signed_video_t object session.
- * @param algo Enum type of sign_algo_t specifying the algorithm use to generate the
- *   private key.
  * @param private_key The content of the private key pem file.
  * @param private_key_size The size of the |private_key|.
  *
- * @return SV_OK If the |algo| is supported and set,
+ * @return SV_OK If the |private_key| is set,
  *         SV_INVALID_PARAMETER Invalid input parameter(s),
- *         SV_NOT_SUPPORTED If the algo is not supported,
  *         SV_MEMORY If failed allocating memory for the private key,
  *         SV_EXTERNAL_ERROR The public key could not be extracted.
  */
+SignedVideoReturnCode
+signed_video_set_private_key_new(signed_video_t *self,
+    const char *private_key,
+    size_t private_key_size);
+/* TO BE REPLACED BY signed_video_set_private_key_new(). */
 SignedVideoReturnCode
 signed_video_set_private_key(signed_video_t *self,
     sign_algo_t algo,

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -31,7 +31,6 @@
 #include "signed_video_h26x_internal.h"  // gop_state_*(), update_gop_hash(), update_validation_flags()
 #include "signed_video_h26x_nalu_list.h"  // h26x_nalu_list_append()
 #include "signed_video_internal.h"  // gop_info_t, gop_state_t, reset_gop_hash()
-#include "signed_video_openssl_internal.h"  // openssl_get_algo_of_public_key()
 #include "signed_video_tlv.h"  // tlv_find_tag()
 
 static svi_rc
@@ -1080,10 +1079,8 @@ signed_video_set_public_key(signed_video_t *self, const char *public_key, size_t
   if (self->signature_info->public_key) return SV_NOT_SUPPORTED;
   if (self->authentication_started) return SV_NOT_SUPPORTED;
 
-  sign_algo_t *algo = &(self->signature_info->algo);
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
-    SVI_THROW(openssl_get_algo_of_public_key(public_key, public_key_size, algo));
     // Allocate memory and copy |public_key|.
     self->signature_info->public_key = malloc(public_key_size);
     SVI_THROW_IF(!self->signature_info->public_key, SVI_MEMORY);

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -216,7 +216,7 @@ openssl_verify_hash(const signature_info_t *signature_info, int *verified_result
     ctx = EVP_PKEY_CTX_new(verify_key, NULL /* No engine */);
     SVI_THROW_IF(!ctx, SVI_EXTERNAL_FAILURE);
     SVI_THROW_IF(EVP_PKEY_verify_init(ctx) <= 0, SVI_EXTERNAL_FAILURE);
-    if (signature_info->algo == SIGN_ALGO_RSA) {
+    if (EVP_PKEY_base_id(verify_key) == EVP_PKEY_RSA) {
       SVI_THROW_IF(EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_PADDING) <= 0, SVI_EXTERNAL_FAILURE);
     }
     SVI_THROW_IF(EVP_PKEY_CTX_set_signature_md(ctx, EVP_sha256()) <= 0, SVI_EXTERNAL_FAILURE);

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1727,7 +1727,7 @@ START_TEST(vendor_axis_communications_operation)
   // Read and set content of private_key.
   sv_rc = signed_video_generate_private_key(algo, "./", &private_key, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_set_private_key(sv, algo, private_key, private_key_size);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   // Check setting attestation report.
@@ -1817,7 +1817,7 @@ generate_and_set_private_key_on_camera_side(struct sv_setting setting,
   // Read and set content of private_key.
   sv_rc = signed_video_generate_private_key(setting.algo, "./", &private_key, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_set_private_key(sv, setting.algo, private_key, private_key_size);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   sv_rc = signed_video_add_public_key_to_sei(sv, add_public_key_to_sei);
@@ -2070,7 +2070,7 @@ START_TEST(no_emulation_prevention_bytes)
   ck_assert(sv);
 
   // Apply settings to session.
-  sv_rc = signed_video_set_private_key(sv, settings[_i].algo, private_key, private_key_size);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
   ck_assert_int_eq(sv_rc, SV_OK);

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -124,11 +124,17 @@ START_TEST(api_inputs)
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
   sv_rc = signed_video_set_private_key(sv, algo, private_key, 0);
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
+  sv_rc = signed_video_set_private_key_new(NULL, private_key, private_key_size);
+  ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
+  sv_rc = signed_video_set_private_key_new(sv, NULL, private_key_size);
+  ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, 0);
+  ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
   // Adding nalu for signing without setting private key is invalid.
   sv_rc = signed_video_add_nalu_for_signing(sv, p_nalu->data, p_nalu->data_size);
   ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
   // Will set keys.
-  sv_rc = signed_video_set_private_key(sv, algo, private_key, private_key_size);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   // Check setting recurrence
@@ -267,7 +273,7 @@ START_TEST(incorrect_operation)
   sv_rc =
       signed_video_generate_private_key(settings[_i].algo, "./", &private_key, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_set_private_key(sv, settings[_i].algo, private_key, private_key_size);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -328,7 +334,7 @@ START_TEST(vendor_axis_communications_operation)
   // Read and set content of private_key.
   sv_rc = signed_video_generate_private_key(algo, "./", &private_key, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_set_private_key(sv, algo, private_key, private_key_size);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   // Exercise two byte string in product info to catch potential errors.
@@ -611,12 +617,12 @@ START_TEST(correct_timestamp)
       signed_video_generate_private_key(settings[_i].algo, "./", &private_key, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
-  sv_rc = signed_video_set_private_key(sv, settings[_i].algo, private_key, private_key_size);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
   ck_assert_int_eq(sv_rc, SV_OK);
 
-  sv_rc = signed_video_set_private_key(sv_ts, settings[_i].algo, private_key, private_key_size);
+  sv_rc = signed_video_set_private_key_new(sv_ts, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_set_authenticity_level(sv_ts, settings[_i].auth_level);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -712,7 +718,7 @@ START_TEST(w_wo_emulation_prevention_bytes)
     ck_assert(sv);
 
     // Apply settings to session.
-    sv_rc = signed_video_set_private_key(sv, settings[_i].algo, private_key, private_key_size);
+    sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
     ck_assert_int_eq(sv_rc, SV_OK);
     sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
     ck_assert_int_eq(sv_rc, SV_OK);

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -226,7 +226,7 @@ get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo, bool new_
       memcpy(private_key_rsa, private_key, private_key_size);
       private_key_size_rsa = private_key_size;
     }
-    rc = signed_video_set_private_key(sv, algo, private_key_rsa, private_key_size_rsa);
+    rc = signed_video_set_private_key_new(sv, private_key_rsa, private_key_size_rsa);
     ck_assert_int_eq(rc, SV_OK);
   }
   if (algo == SIGN_ALGO_ECDSA) {
@@ -238,7 +238,7 @@ get_initialized_signed_video(SignedVideoCodec codec, sign_algo_t algo, bool new_
       memcpy(private_key_ecdsa, private_key, private_key_size);
       private_key_size_ecdsa = private_key_size;
     }
-    rc = signed_video_set_private_key(sv, algo, private_key_ecdsa, private_key_size_ecdsa);
+    rc = signed_video_set_private_key_new(sv, private_key_ecdsa, private_key_size_ecdsa);
     ck_assert_int_eq(rc, SV_OK);
   }
 


### PR DESCRIPTION
More precisely, removes usage of the algo member in
signature_info_t since that information can be extracted from the
key pair. The member itself is NOT removed due to backward
compatibility.

A new function for setting the private key has been added
temporarily until the old one is deprecated.
