### PR TITLE
Stores the private key in EVP_PKEY format

### DIFF
--- a/lib/src/includes/signed_video_signing_plugin.h
+++ b/lib/src/includes/signed_video_signing_plugin.h
@@ -120,6 +120,9 @@ sv_signing_plugin_session_teardown(void *handle);
  */
 int
 sv_signing_plugin_init(void *user_data);
+/* Temporary function for backwards compatibility while re-interpreting |user_data|. */
+int
+sv_signing_plugin_init_new(void *user_data);
 
 /**
  * @brief Plugin termination

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -199,7 +199,7 @@ signature_free(signature_info_t *self)
 {
   if (!self) return;
 
-  free(self->private_key);
+  openssl_free_key(self->private_key);
   free(self->public_key);
   free(self->hash);
   free(self->signature);

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -111,8 +111,6 @@ openssl_private_key_malloc(signature_info_t *signature_info,
   EVP_PKEY *signing_key = NULL;
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
-    SVI_THROW_IF(!private_key, SVI_INVALID_PARAMETER);
-
     // Read private key
     BIO *bp = BIO_new_mem_buf(private_key, private_key_size);
     signing_key = PEM_read_bio_PrivateKey(bp, NULL, NULL, NULL);


### PR DESCRIPTION
instead of PEM format. This saves some operations when signing a
hash, since the EVP_PKEY otherwise has to be created from the PEM
format for every signature.

At the same time as the conversion is done, memory for the largest
possible signature is allocated.

A new struct pem_pkey_t to store a private or public key in PEM
format has been added. This struct is used in the new version of
threaded signing plugin at init (optional by user).

Further, two new openssl helpers are added openssl_free_key() and
openssl_private_key_malloc(), where the latter more or less
replaces openssl_signature_malloc() (now removed).
