### PR TITLE
Stores the public key in EVP_PKEY format

### DIFF
--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -56,6 +56,7 @@ typedef struct _signature_info_t {
   // Internally used as EVP_PKEY.
   size_t private_key_size;  // The size of the |private_key| if pem file format.
   void *public_key;  // The public key used for validation in a pem file format.
+  // Internally used as EVP_PKEY.
   size_t public_key_size;  // The size of the |public_key|.
   uint8_t *signature;  // The signature of the |hash|.
   size_t signature_size;  // The size of the |signature|.
@@ -178,18 +179,19 @@ openssl_verify_hash(const signature_info_t *signature_info, int *verified_result
 /**
  * @brief Reads the public key from the private key
  *
- * This function extracts the public key from the |private_key| and writes it to |public_key|. The
+ * This function extracts the public key from the |private_key| and writes it to |pem_pkey|. The
  * |private_key| is assumed to be on EVP_PKEY form.
  *
- * @param signature_info A pointer to the object holding all information of the keys.
+ * @param signature_info A pointer to the object holding the |private_key|.
+ * @param pem_pkey A pointer to the object where the public key, on PEM format, will be written.
  *
- * @returns SV_OK Successfully written |public_key| to |signature_info|,
+ * @returns SV_OK Successfully written |pkey| to |pem_pkey|,
  *          SV_INVALID_PARAMETER Errors in |signature_info|, or no private key present,
- *          SV_MEMORY Could not allocate memory for |public_key|,
+ *          SV_MEMORY Could not allocate memory for |pkey|,
  *          SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
 SignedVideoReturnCode
-openssl_read_pubkey_from_private_key(signature_info_t *signature_info);
+openssl_read_pubkey_from_private_key(signature_info_t *signature_info, pem_pkey_t *pem_pkey);
 
 /**
  * @brief Signs a hash
@@ -214,6 +216,7 @@ openssl_sign_hash(signature_info_t *signature_info);
  * and allocates memory for a signature
  *
  * The function allocates enough memory for a signature given the |private_key|.
+ * Use openssl_free_key() to free the key.
  *
  * @param signature_info A pointer to the struct that holds all necessary information for signing.
  * @param private_key The content of the private key PEM file.
@@ -228,6 +231,23 @@ SignedVideoReturnCode
 openssl_private_key_malloc(signature_info_t *signature_info,
     const char *private_key,
     size_t private_key_size);
+
+/**
+ * @brief Turns a public key on PEM form to EVP_PKEY form
+ *
+ * The function takes the public key as a pem_pkey_t and stores it as |public_key| in
+ * |signature_info| on the EVP_PKEY form.
+ * Use openssl_free_key() to free the key.
+ *
+ * @param signature_info A pointer to the struct that holds all necessary information for signing.
+ * @param pem_public_key A pointer to the PEM format struct.
+ *
+ * @returns SV_OK Successfully stored |public_key|,
+ *          SV_INVALID_PARAMETER Missing inputs,
+ *          SV_EXTERNAL_ERROR Failure in OpenSSL.
+ */
+SignedVideoReturnCode
+openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_public_key);
 
 /**
  * @brief Frees the memory of a private/public key

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -200,7 +200,7 @@ signature_free(signature_info_t *self)
   if (!self) return;
 
   openssl_free_key(self->private_key);
-  free(self->public_key);
+  openssl_free_key(self->public_key);
   free(self->hash);
   free(self->signature);
   free(self);
@@ -1261,6 +1261,7 @@ signed_video_free(signed_video_t *self)
   product_info_free(self->product_info);
   gop_info_free(self->gop_info);
   signature_free(self->signature_info);
+  free(self->pem_public_key.pkey);
 
   free(self);
 }

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -588,6 +588,9 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
 #ifdef SIGNED_VIDEO_DEBUG
         // TODO: This might not work for blocked signatures, that is if the hash in
         // |signature_info| does not correspond to the copied |signature|.
+        // Convert the public key to EVP_PKEY for verification. Normally done upon validation.
+        SVI_THROW(
+            sv_rc_to_svi_rc(openssl_public_key_malloc(signature_info, &self->pem_public_key)));
         // Verify the just signed hash.
         int verified = -1;
         SVI_THROW_WITH_MSG(sv_rc_to_svi_rc(openssl_verify_hash(signature_info, &verified)),
@@ -708,7 +711,8 @@ signed_video_set_private_key_new(signed_video_t *self,
     // Temporally turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
     SVI_THROW(sv_rc_to_svi_rc(
         openssl_private_key_malloc(self->signature_info, private_key, private_key_size)));
-    SVI_THROW(sv_rc_to_svi_rc(openssl_read_pubkey_from_private_key(self->signature_info)));
+    SVI_THROW(sv_rc_to_svi_rc(
+        openssl_read_pubkey_from_private_key(self->signature_info, &self->pem_public_key)));
 
     self->plugin_handle = sv_signing_plugin_session_setup(private_key, private_key_size);
     SVI_THROW_IF(!self->plugin_handle, SVI_EXTERNAL_FAILURE);

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -168,6 +168,7 @@ struct _signed_video_t {
   // For signing plugin
   void *plugin_handle;
   signature_info_t *signature_info;  // Pointer to all necessary information to sign in a plugin.
+  pem_pkey_t pem_public_key;  // Public key in PEM form for writing/reading to/from SEIs
 
   // Arbitrary data
   uint8_t *arbitrary_data;  // Enables the user to transmit user specific data and is automatically

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -155,6 +155,8 @@ openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_publ
     BIO_free(bp);
 
     SVI_THROW_IF(!verify_key, SVI_EXTERNAL_FAILURE);
+    // Free any existing key
+    EVP_PKEY_free(signature_info->public_key);
     signature_info->public_key = verify_key;
   SVI_CATCH()
   SVI_DONE(status)

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
@@ -99,8 +99,7 @@ decode_axis_communications_handle(void *handle, const uint8_t *data, size_t data
  * A reference to the |public_key| is stored, hence memory is not transferred.
  *
  * @param handle The handle to which the Public key is set.
- * @param public_key Pointer to the Public key data to set.
- * @param public_key_size Size of Public key data.
+ * @param public_key Pointer to the Public key data on EVP_PKEY form to set.
  * @param public_key_has_changed Flag to indicate if the Public key has changed.
  *
  * @returns An internal return code to catch potential errors.
@@ -108,7 +107,6 @@ decode_axis_communications_handle(void *handle, const uint8_t *data, size_t data
 svi_rc
 set_axis_communications_public_key(void *handle,
     void const *public_key,
-    size_t public_key_size,
     bool public_key_has_changed);
 
 /**


### PR DESCRIPTION
instead of PEM format in the signature_info struct. This saves some
operations when verifying a signature, since the EVP_PKEY otherwise
has to be created from the PEM format for every verification.

The PEM format public key is intermediately stored in the pem_public_key
member of signed_video_t since the PEM format is written to/read from
the SEIs.

Further, a new openssl helpers are added openssl_public_key_malloc(),
where the latter turns a PEM public key into an EVP_PKEY object.
