### PR TITLE
Removes unused functions

### DIFF
--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -260,25 +260,6 @@ void
 openssl_free_key(void *pkey);
 
 /**
- * @brief Allocates memory for a key
- *
- * This is a helper function to allocate memory for a key. If a new key size is detected memory is
- * re-allocated. The API applies to both public and private keys.
- *
- * @param key A pointer to the memory which should be (re-)allocated.
- * @param key_size A pointer to which the size of the allocated memory is written. If a key already
- *   exists, the pointer should hold the current size of the key.
- * @param new_key_size The desired size of the key.
- *
- * @returns SV_OK Successfully allocated memory for the |key|,
- *          SV_INVALID_PARAMETER Null pointers,
- *          SV_NOT_SUPPORTED Invalid |new_key_size|,
- *          SV_MEMORY Could not allocate memory for the |key|,
- */
-SignedVideoReturnCode
-openssl_key_memory_allocated(void **key, size_t *key_size, size_t new_key_size);
-
-/**
  * @brief Helper function to generate a private key
  *
  * By specifying a location and a signing algorithm (RSA, or ECDSA) a PEM file is generated and

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -22,11 +22,6 @@
 #ifndef __SIGNED_VIDEO_OPENSSL_INTERNAL_H__
 #define __SIGNED_VIDEO_OPENSSL_INTERNAL_H__
 
-#include "includes/signed_video_openssl.h"  // sign_algo_t
-#include "signed_video_defines.h"  // svi_rc
-
-/* Extracts the algorithm from the public key */
-svi_rc
-openssl_get_algo_of_public_key(const char *public_key, size_t public_key_size, sign_algo_t *algo);
+/* NOTE: The header file is kept empty, since it will be filled with content. */
 
 #endif  // __SIGNED_VIDEO_OPENSSL_INTERNAL__

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -26,7 +26,7 @@
 #include "axis-communications/sv_vendor_axis_communications_internal.h"
 #endif
 #include "includes/signed_video_auth.h"  // signed_video_product_info_t
-#include "includes/signed_video_openssl.h"  // openssl_key_memory_allocated(), signature_info_t
+#include "includes/signed_video_openssl.h"  // signature_info_t
 #include "signed_video_authenticity.h"  // transfer_product_info()
 
 /**


### PR DESCRIPTION
This commit removes two functions; openssl_key_memory_allocated()
and openssl_get_algo_of_public_key(). It is safe to remove
the first one from the public header file since it by nature is
a helper function.
