### PR TITLE
Moves some openssl declarations to internal

### DIFF
--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -23,7 +23,7 @@
 #define __SIGNED_VIDEO_OPENSSL__
 
 #include <stdint.h>  // uint8_t
-#include <string.h>  // size_t, strcmp, strlen, strcpy, strcat
+#include <string.h>  // size_t
 
 #include "signed_video_common.h"  // SignedVideoReturnCode
 
@@ -72,128 +72,6 @@ typedef struct _pem_pkey_t {
 } pem_pkey_t;
 
 /**
- * @brief Create cryptographic handle
- *
- * Allocates the memory for a crypthographic |handle| holding specific OpenSSL information. This
- * handle should be created when starting the session and freed at teardown with
- * openssl_free_handle().
- *
- * @returns Pointer to the OpenSSL cryptographic handle.
- */
-void *
-openssl_create_handle(void);
-
-/**
- * @brief Free cryptographic handle
- *
- * Frees a crypthographic |handle| created with openssl_create_handle().
- *
- * @param handle Pointer to the OpenSSL cryptographic handle.
- */
-void
-openssl_free_handle(void *handle);
-
-/**
- * @brief Hashes data into a 256 bit hash
- *
- * Uses the OpenSSL SHA256() API to hash data. The hashed data has 256 bits, which needs to be
- * allocated in advance by the user.
- *
- * This is a simplification for calling openssl_init_hash(), openssl_update_hash() and
- * openssl_finalize_hash() done in one go.
- *
- * @param data Pointer to the data to hash.
- * @param data_size Size of the |data| to hash.
- * @param hash A pointer to the hashed output. This memory has to be pre-allocated.
- *
- * @returns SV_OK Successfully hashed |data|,
- *          SV_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
- *          SV_EXTERNAL_ERROR Failed to hash.
- */
-SignedVideoReturnCode
-openssl_hash_data(const uint8_t *data, size_t data_size, uint8_t *hash);
-
-/**
- * @brief Initiates the cryptographic handle for hashing data
- *
- * Uses the OpenSSL SHA256_Init() API to initiate an SHA256_CTX object in |handle|.
- *
- * @param handle Pointer to the OpenSSL cryptographic handle.
- *
- * @returns SV_OK Successfully initialized SHA256_CTX object in |handle|,
- *          SV_INVALID_PARAMETER Null pointer input,
- *          SV_EXTERNAL_ERROR Failed to initialize.
- */
-SignedVideoReturnCode
-openssl_init_hash(void *handle);
-
-/**
- * @brief Updates the cryptographic handle with |data| for hashing
- *
- * Uses the OpenSSL SHA256_Update() API to update the SHA256_CTX object in |handle| with |data|.
- *
- * @param handle Pointer to the OpenSSL cryptographic handle.
- * @param data Pointer to the data to update an ongoing hash.
- * @param data_size Size of the |data|.
- *
- * @returns SV_OK Successfully updated SHA256_CTX object in |handle|,
- *          SV_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
- *          SV_EXTERNAL_ERROR Failed to update.
- */
-SignedVideoReturnCode
-openssl_update_hash(void *handle, const uint8_t *data, size_t data_size);
-
-/**
- * @brief Finalizes the cryptographic handle and outputs the hash
- *
- * Uses the OpenSSL SHA256_Final() API to finalize the SHA256_CTX object in |handle| and get the
- * |hash|. The SHA256_CTX object in |handle| is reset afterwards.
- *
- * @param handle Pointer to the OpenSSL cryptographic handle.
- * @param hash A pointer to the hashed output. This memory has to be pre-allocated.
- *
- * @returns SV_OK Successfully wrote the final result of SHA256_CTX object in |handle| to |hash|,
- *          SV_INVALID_PARAMETER Null pointer inputs,
- *          SV_EXTERNAL_ERROR Failed to finalize.
- */
-SignedVideoReturnCode
-openssl_finalize_hash(void *handle, uint8_t *hash);
-
-/**
- * @brief Verifies a signature against a hash
- *
- * The |hash| is verified against the |signature| using the |public_key|, all located in the input
- * parameter |signature_info|.
- *
- * @param signature_info Pointer to the signature_info_t object in use.
- * @param verified_result Poiniter to the place where the verification result is written. The
- *   |verified_result| can either be 1 (success), 0 (failure), or < 0 (error).
- *
- * @returns SV_OK Successfully generated |signature|,
- *          SV_INVALID_PARAMETER Errors in |signature_info|, or null pointer inputs,
- *          SV_EXTERNAL_ERROR Failure in OpenSSL.
- */
-SignedVideoReturnCode
-openssl_verify_hash(const signature_info_t *signature_info, int *verified_result);
-
-/**
- * @brief Reads the public key from the private key
- *
- * This function extracts the public key from the |private_key| and writes it to |pem_pkey|. The
- * |private_key| is assumed to be on EVP_PKEY form.
- *
- * @param signature_info A pointer to the object holding the |private_key|.
- * @param pem_pkey A pointer to the object where the public key, on PEM format, will be written.
- *
- * @returns SV_OK Successfully written |pkey| to |pem_pkey|,
- *          SV_INVALID_PARAMETER Errors in |signature_info|, or no private key present,
- *          SV_MEMORY Could not allocate memory for |pkey|,
- *          SV_EXTERNAL_ERROR Failure in OpenSSL.
- */
-SignedVideoReturnCode
-openssl_read_pubkey_from_private_key(signature_info_t *signature_info, pem_pkey_t *pem_pkey);
-
-/**
  * @brief Signs a hash
  *
  * The function generates a signature of the |hash| in |singature_info| and stores the result in
@@ -231,23 +109,6 @@ SignedVideoReturnCode
 openssl_private_key_malloc(signature_info_t *signature_info,
     const char *private_key,
     size_t private_key_size);
-
-/**
- * @brief Turns a public key on PEM form to EVP_PKEY form
- *
- * The function takes the public key as a pem_pkey_t and stores it as |public_key| in
- * |signature_info| on the EVP_PKEY form.
- * Use openssl_free_key() to free the key.
- *
- * @param signature_info A pointer to the struct that holds all necessary information for signing.
- * @param pem_public_key A pointer to the PEM format struct.
- *
- * @returns SV_OK Successfully stored |public_key|,
- *          SV_INVALID_PARAMETER Missing inputs,
- *          SV_EXTERNAL_ERROR Failure in OpenSSL.
- */
-SignedVideoReturnCode
-openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_public_key);
 
 /**
  * @brief Frees the memory of a private/public key

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -25,12 +25,13 @@
 #include "axis-communications/sv_vendor_axis_communications_internal.h"
 #endif
 #include "includes/signed_video_auth.h"
-#include "includes/signed_video_openssl.h"  // openssl_verify_hash(), signature_info_t
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, signature_info_t
 #include "signed_video_authenticity.h"  // create_local_authenticity_report_if_needed()
 #include "signed_video_defines.h"  // svi_rc
 #include "signed_video_h26x_internal.h"  // gop_state_*(), update_gop_hash(), update_validation_flags()
 #include "signed_video_h26x_nalu_list.h"  // h26x_nalu_list_append()
 #include "signed_video_internal.h"  // gop_info_t, gop_state_t, reset_gop_hash()
+#include "signed_video_openssl_internal.h"  // openssl_{verify_hash, public_key_malloc}()
 #include "signed_video_tlv.h"  // tlv_find_tag()
 
 static svi_rc

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -29,12 +29,13 @@
 #include "axis-communications/sv_vendor_axis_communications_internal.h"
 #endif
 #include "includes/signed_video_common.h"
-#include "includes/signed_video_openssl.h"  // openssl_hash_data(), signature_info_t
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, signature_info_t
 #include "includes/signed_video_signing_plugin.h"
 #include "signed_video_authenticity.h"  // latest_validation_init()
 #include "signed_video_h26x_internal.h"  // h26x_nalu_list_item_t
 #include "signed_video_h26x_nalu_list.h"  // h26x_nalu_list_create()
 #include "signed_video_internal.h"  // gop_info_t, gop_state_t, HASH_DIGEST_SIZE
+#include "signed_video_openssl_internal.h"
 #include "signed_video_tlv.h"  // read_32bits()
 
 #define USER_DATA_UNREGISTERED 5

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -23,13 +23,14 @@
 #include <stdlib.h>  // free, malloc
 #include <string.h>  // size_t
 
-#include "includes/signed_video_openssl.h"  // openssl_read_pubkey_from_private_key()
+#include "includes/signed_video_openssl.h"  // pem_pkey_t
 #include "includes/signed_video_sign.h"
 #include "includes/signed_video_signing_plugin.h"
 #include "signed_video_authenticity.h"  // allocate_memory_and_copy_string
 #include "signed_video_defines.h"  // svi_rc, sv_tlv_tag_t
 #include "signed_video_h26x_internal.h"  // parse_nalu_info()
 #include "signed_video_internal.h"  // gop_info_t, reset_gop_hash(), sv_rc_to_svi_rc()
+#include "signed_video_openssl_internal.h"
 #include "signed_video_tlv.h"  // tlv_list_encode_or_get_size()
 
 static void

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -27,6 +27,7 @@
 
 #include "includes/signed_video_auth.h"  // signed_video_product_info_t
 #include "includes/signed_video_common.h"  // signed_video_t
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, signature_info_t
 #include "includes/signed_video_sign.h"  // SignedVideoAuthenticityLevel
 #include "signed_video_defines.h"  // svi_rc, sv_tlv_tag_t
 

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -22,6 +22,149 @@
 #ifndef __SIGNED_VIDEO_OPENSSL_INTERNAL_H__
 #define __SIGNED_VIDEO_OPENSSL_INTERNAL_H__
 
-/* NOTE: The header file is kept empty, since it will be filled with content. */
+#include <stdint.h>  // uint8_t
+#include <string.h>  // size_t
+
+#include "includes/signed_video_common.h"  // SignedVideoReturnCode
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, signature_info_t
+
+/**
+ * @brief Create cryptographic handle
+ *
+ * Allocates the memory for a crypthographic |handle| holding specific OpenSSL information. This
+ * handle should be created when starting the session and freed at teardown with
+ * openssl_free_handle().
+ *
+ * @returns Pointer to the OpenSSL cryptographic handle.
+ */
+void *
+openssl_create_handle(void);
+
+/**
+ * @brief Free cryptographic handle
+ *
+ * Frees a crypthographic |handle| created with openssl_create_handle().
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ */
+void
+openssl_free_handle(void *handle);
+
+/**
+ * @brief Hashes data into a 256 bit hash
+ *
+ * Uses the OpenSSL SHA256() API to hash data. The hashed data has 256 bits, which needs to be
+ * allocated in advance by the user.
+ *
+ * This is a simplification for calling openssl_init_hash(), openssl_update_hash() and
+ * openssl_finalize_hash() done in one go.
+ *
+ * @param data Pointer to the data to hash.
+ * @param data_size Size of the |data| to hash.
+ * @param hash A pointer to the hashed output. This memory has to be pre-allocated.
+ *
+ * @returns SV_OK Successfully hashed |data|,
+ *          SV_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
+ *          SV_EXTERNAL_ERROR Failed to hash.
+ */
+SignedVideoReturnCode
+openssl_hash_data(const uint8_t *data, size_t data_size, uint8_t *hash);
+
+/**
+ * @brief Initiates the cryptographic handle for hashing data
+ *
+ * Uses the OpenSSL SHA256_Init() API to initiate an SHA256_CTX object in |handle|.
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ *
+ * @returns SV_OK Successfully initialized SHA256_CTX object in |handle|,
+ *          SV_INVALID_PARAMETER Null pointer input,
+ *          SV_EXTERNAL_ERROR Failed to initialize.
+ */
+SignedVideoReturnCode
+openssl_init_hash(void *handle);
+
+/**
+ * @brief Updates the cryptographic handle with |data| for hashing
+ *
+ * Uses the OpenSSL SHA256_Update() API to update the SHA256_CTX object in |handle| with |data|.
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ * @param data Pointer to the data to update an ongoing hash.
+ * @param data_size Size of the |data|.
+ *
+ * @returns SV_OK Successfully updated SHA256_CTX object in |handle|,
+ *          SV_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
+ *          SV_EXTERNAL_ERROR Failed to update.
+ */
+SignedVideoReturnCode
+openssl_update_hash(void *handle, const uint8_t *data, size_t data_size);
+
+/**
+ * @brief Finalizes the cryptographic handle and outputs the hash
+ *
+ * Uses the OpenSSL SHA256_Final() API to finalize the SHA256_CTX object in |handle| and get the
+ * |hash|. The SHA256_CTX object in |handle| is reset afterwards.
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ * @param hash A pointer to the hashed output. This memory has to be pre-allocated.
+ *
+ * @returns SV_OK Successfully wrote the final result of SHA256_CTX object in |handle| to |hash|,
+ *          SV_INVALID_PARAMETER Null pointer inputs,
+ *          SV_EXTERNAL_ERROR Failed to finalize.
+ */
+SignedVideoReturnCode
+openssl_finalize_hash(void *handle, uint8_t *hash);
+
+/**
+ * @brief Verifies a signature against a hash
+ *
+ * The |hash| is verified against the |signature| using the |public_key|, all located in the input
+ * parameter |signature_info|.
+ *
+ * @param signature_info Pointer to the signature_info_t object in use.
+ * @param verified_result Poiniter to the place where the verification result is written. The
+ *   |verified_result| can either be 1 (success), 0 (failure), or < 0 (error).
+ *
+ * @returns SV_OK Successfully generated |signature|,
+ *          SV_INVALID_PARAMETER Errors in |signature_info|, or null pointer inputs,
+ *          SV_EXTERNAL_ERROR Failure in OpenSSL.
+ */
+SignedVideoReturnCode
+openssl_verify_hash(const signature_info_t *signature_info, int *verified_result);
+
+/**
+ * @brief Reads the public key from the private key
+ *
+ * This function extracts the public key from the |private_key| and writes it to |pem_pkey|. The
+ * |private_key| is assumed to be on EVP_PKEY form.
+ *
+ * @param signature_info A pointer to the object holding the |private_key|.
+ * @param pem_pkey A pointer to the object where the public key, on PEM format, will be written.
+ *
+ * @returns SV_OK Successfully written |pkey| to |pem_pkey|,
+ *          SV_INVALID_PARAMETER Errors in |signature_info|, or no private key present,
+ *          SV_MEMORY Could not allocate memory for |pkey|,
+ *          SV_EXTERNAL_ERROR Failure in OpenSSL.
+ */
+SignedVideoReturnCode
+openssl_read_pubkey_from_private_key(signature_info_t *signature_info, pem_pkey_t *pem_pkey);
+
+/**
+ * @brief Turns a public key on PEM form to EVP_PKEY form
+ *
+ * The function takes the public key as a pem_pkey_t and stores it as |public_key| in
+ * |signature_info| on the EVP_PKEY form.
+ * Use openssl_free_key() to free the key.
+ *
+ * @param signature_info A pointer to the struct that holds all necessary information for signing.
+ * @param pem_public_key A pointer to the PEM format struct.
+ *
+ * @returns SV_OK Successfully stored |public_key|,
+ *          SV_INVALID_PARAMETER Missing inputs,
+ *          SV_EXTERNAL_ERROR Failure in OpenSSL.
+ */
+SignedVideoReturnCode
+openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_public_key);
 
 #endif  // __SIGNED_VIDEO_OPENSSL_INTERNAL__

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -26,8 +26,9 @@
 #include "axis-communications/sv_vendor_axis_communications_internal.h"
 #endif
 #include "includes/signed_video_auth.h"  // signed_video_product_info_t
-#include "includes/signed_video_openssl.h"  // signature_info_t
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, signature_info_t
 #include "signed_video_authenticity.h"  // transfer_product_info()
+#include "signed_video_openssl_internal.h"  // openssl_public_key_malloc()
 
 /**
  * Encoder and decoder interfaces

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -25,12 +25,13 @@
 
 #include "lib/src/includes/signed_video_auth.h"  // signed_video_authenticity_t
 #include "lib/src/includes/signed_video_common.h"  // signed_video_t
-#include "lib/src/includes/signed_video_openssl.h"  // signed_video_generate_private_key()
+#include "lib/src/includes/signed_video_openssl.h"  // pem_pkey_t, signed_video_generate_private_key()
 #include "lib/src/includes/signed_video_sign.h"  // signed_video_set_authenticity_level()
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
 #include "lib/src/includes/sv_vendor_axis_communications.h"
 #endif
 #include "lib/src/signed_video_internal.h"  // set_hash_list_size()
+#include "lib/src/signed_video_openssl_internal.h"  // openssl_read_pubkey_from_private_key()
 #include "lib/src/signed_video_tlv.h"  // write_byte_many()
 #include "nalu_list.h"  // nalu_list_create()
 #include "signed_video_helpers.h"  // sv_setting, create_signed_nalus()


### PR DESCRIPTION
The public header file signed_video_openssl.h is primarily meant
for signing plugins + signing users that need a helper function
to generate a software private key for testing. Everything else
are APIs used by the library, hence can/should be placed in an
internal header file.
