### PR TITLE
Refactoring signed_video_openssl

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -762,8 +762,7 @@ prepare_for_validation(signed_video_t *self)
 
     // If we have received a SEI there is a signature to use for verification.
     if (self->gop_state.has_gop_sei) {
-      SVI_THROW(sv_rc_to_svi_rc(
-          openssl_verify_hash(signature_info, &self->gop_info->verified_signature_hash)));
+      SVI_THROW(openssl_verify_hash(signature_info, &self->gop_info->verified_signature_hash));
     }
 
   SVI_CATCH()
@@ -1088,8 +1087,7 @@ signed_video_set_public_key(signed_video_t *self, const char *public_key, size_t
     memcpy(self->pem_public_key.pkey, public_key, public_key_size);
     self->pem_public_key.pkey_size = public_key_size;
     // Turn the public key from PEM to EVP_PKEY form.
-    SVI_THROW(
-        sv_rc_to_svi_rc(openssl_public_key_malloc(self->signature_info, &self->pem_public_key)));
+    SVI_THROW(openssl_public_key_malloc(self->signature_info, &self->pem_public_key));
     self->has_public_key = true;
 
   SVI_CATCH()

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -590,12 +590,11 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
         // TODO: This might not work for blocked signatures, that is if the hash in
         // |signature_info| does not correspond to the copied |signature|.
         // Convert the public key to EVP_PKEY for verification. Normally done upon validation.
-        SVI_THROW(
-            sv_rc_to_svi_rc(openssl_public_key_malloc(signature_info, &self->pem_public_key)));
+        SVI_THROW(openssl_public_key_malloc(signature_info, &self->pem_public_key));
         // Verify the just signed hash.
         int verified = -1;
-        SVI_THROW_WITH_MSG(sv_rc_to_svi_rc(openssl_verify_hash(signature_info, &verified)),
-            "Verification test had errors");
+        SVI_THROW_WITH_MSG(
+            openssl_verify_hash(signature_info, &verified), "Verification test had errors");
         SVI_THROW_IF_WITH_MSG(verified != 1, SVI_EXTERNAL_FAILURE, "Verification test failed");
 #endif
         SVI_THROW(complete_sei_nalu_and_add_to_prepend(self));
@@ -712,8 +711,7 @@ signed_video_set_private_key_new(signed_video_t *self,
     // Temporally turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
     SVI_THROW(sv_rc_to_svi_rc(
         openssl_private_key_malloc(self->signature_info, private_key, private_key_size)));
-    SVI_THROW(sv_rc_to_svi_rc(
-        openssl_read_pubkey_from_private_key(self->signature_info, &self->pem_public_key)));
+    SVI_THROW(openssl_read_pubkey_from_private_key(self->signature_info, &self->pem_public_key));
 
     self->plugin_handle = sv_signing_plugin_session_setup(private_key, private_key_size);
     SVI_THROW_IF(!self->plugin_handle, SVI_EXTERNAL_FAILURE);

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -25,8 +25,8 @@
 #include <stdint.h>  // uint8_t
 #include <string.h>  // size_t
 
-#include "includes/signed_video_common.h"  // SignedVideoReturnCode
 #include "includes/signed_video_openssl.h"  // pem_pkey_t, signature_info_t
+#include "signed_video_defines.h"  // svi_rc
 
 /**
  * @brief Create cryptographic handle
@@ -63,11 +63,11 @@ openssl_free_handle(void *handle);
  * @param data_size Size of the |data| to hash.
  * @param hash A pointer to the hashed output. This memory has to be pre-allocated.
  *
- * @returns SV_OK Successfully hashed |data|,
- *          SV_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
- *          SV_EXTERNAL_ERROR Failed to hash.
+ * @returns SVI_OK Successfully hashed |data|,
+ *          SVI_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
+ *          SVI_EXTERNAL_FAILURE Failed to hash.
  */
-SignedVideoReturnCode
+svi_rc
 openssl_hash_data(const uint8_t *data, size_t data_size, uint8_t *hash);
 
 /**
@@ -77,11 +77,11 @@ openssl_hash_data(const uint8_t *data, size_t data_size, uint8_t *hash);
  *
  * @param handle Pointer to the OpenSSL cryptographic handle.
  *
- * @returns SV_OK Successfully initialized SHA256_CTX object in |handle|,
- *          SV_INVALID_PARAMETER Null pointer input,
- *          SV_EXTERNAL_ERROR Failed to initialize.
+ * @returns SVI_OK Successfully initialized SHA256_CTX object in |handle|,
+ *          SVI_INVALID_PARAMETER Null pointer input,
+ *          SVI_EXTERNAL_FAILURE Failed to initialize.
  */
-SignedVideoReturnCode
+svi_rc
 openssl_init_hash(void *handle);
 
 /**
@@ -93,11 +93,11 @@ openssl_init_hash(void *handle);
  * @param data Pointer to the data to update an ongoing hash.
  * @param data_size Size of the |data|.
  *
- * @returns SV_OK Successfully updated SHA256_CTX object in |handle|,
- *          SV_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
- *          SV_EXTERNAL_ERROR Failed to update.
+ * @returns SVI_OK Successfully updated SHA256_CTX object in |handle|,
+ *          SVI_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
+ *          SVI_EXTERNAL_FAILURE Failed to update.
  */
-SignedVideoReturnCode
+svi_rc
 openssl_update_hash(void *handle, const uint8_t *data, size_t data_size);
 
 /**
@@ -109,11 +109,11 @@ openssl_update_hash(void *handle, const uint8_t *data, size_t data_size);
  * @param handle Pointer to the OpenSSL cryptographic handle.
  * @param hash A pointer to the hashed output. This memory has to be pre-allocated.
  *
- * @returns SV_OK Successfully wrote the final result of SHA256_CTX object in |handle| to |hash|,
- *          SV_INVALID_PARAMETER Null pointer inputs,
- *          SV_EXTERNAL_ERROR Failed to finalize.
+ * @returns SVI_OK Successfully wrote the final result of SHA256_CTX object in |handle| to |hash|,
+ *          SVI_INVALID_PARAMETER Null pointer inputs,
+ *          SVI_EXTERNAL_FAILURE Failed to finalize.
  */
-SignedVideoReturnCode
+svi_rc
 openssl_finalize_hash(void *handle, uint8_t *hash);
 
 /**
@@ -126,11 +126,10 @@ openssl_finalize_hash(void *handle, uint8_t *hash);
  * @param verified_result Poiniter to the place where the verification result is written. The
  *   |verified_result| can either be 1 (success), 0 (failure), or < 0 (error).
  *
- * @returns SV_OK Successfully generated |signature|,
- *          SV_INVALID_PARAMETER Errors in |signature_info|, or null pointer inputs,
- *          SV_EXTERNAL_ERROR Failure in OpenSSL.
+ * @returns SVI_OK Successfully generated |signature|,
+ *          SVI_INVALID_PARAMETER Errors in |signature_info|, or null pointer inputs,
  */
-SignedVideoReturnCode
+svi_rc
 openssl_verify_hash(const signature_info_t *signature_info, int *verified_result);
 
 /**
@@ -142,12 +141,12 @@ openssl_verify_hash(const signature_info_t *signature_info, int *verified_result
  * @param signature_info A pointer to the object holding the |private_key|.
  * @param pem_pkey A pointer to the object where the public key, on PEM format, will be written.
  *
- * @returns SV_OK Successfully written |pkey| to |pem_pkey|,
- *          SV_INVALID_PARAMETER Errors in |signature_info|, or no private key present,
- *          SV_MEMORY Could not allocate memory for |pkey|,
- *          SV_EXTERNAL_ERROR Failure in OpenSSL.
+ * @returns SVI_OK Successfully written |pkey| to |pem_pkey|,
+ *          SVI_INVALID_PARAMETER Errors in |signature_info|, or no private key present,
+ *          SVI_MEMORY Could not allocate memory for |pkey|,
+ *          SVI_EXTERNAL_FAILURE Failure in OpenSSL.
  */
-SignedVideoReturnCode
+svi_rc
 openssl_read_pubkey_from_private_key(signature_info_t *signature_info, pem_pkey_t *pem_pkey);
 
 /**
@@ -160,11 +159,11 @@ openssl_read_pubkey_from_private_key(signature_info_t *signature_info, pem_pkey_
  * @param signature_info A pointer to the struct that holds all necessary information for signing.
  * @param pem_public_key A pointer to the PEM format struct.
  *
- * @returns SV_OK Successfully stored |public_key|,
- *          SV_INVALID_PARAMETER Missing inputs,
- *          SV_EXTERNAL_ERROR Failure in OpenSSL.
+ * @returns SVI_OK Successfully stored |public_key|,
+ *          SVI_INVALID_PARAMETER Missing inputs,
+ *          SVI_EXTERNAL_FAILURE Failure in OpenSSL.
  */
-SignedVideoReturnCode
+svi_rc
 openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_public_key);
 
 #endif  // __SIGNED_VIDEO_OPENSSL_INTERNAL__

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -633,8 +633,7 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
     data_ptr += pubkey_size;
 
     // Convert to EVP_PKEY
-    SVI_THROW(
-        sv_rc_to_svi_rc(openssl_public_key_malloc(self->signature_info, &self->pem_public_key)));
+    SVI_THROW(openssl_public_key_malloc(self->signature_info, &self->pem_public_key));
 
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
     // If "Axis Communications AB" can be identified from the |product_info|, set |public_key| to

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1966,8 +1966,7 @@ START_TEST(test_public_key_scenarios)
     signed_video_generate_private_key(algo, NULL, &tmp_private_key, &tmp_private_key_size);
     sv_rc = openssl_private_key_malloc(&sign_info_wrong_key, tmp_private_key, tmp_private_key_size);
     ck_assert_int_eq(sv_rc, SV_OK);
-    sv_rc = openssl_read_pubkey_from_private_key(&sign_info_wrong_key, &wrong_public_key);
-    ck_assert_int_eq(sv_rc, SV_OK);
+    openssl_read_pubkey_from_private_key(&sign_info_wrong_key, &wrong_public_key);
 
     pem_pkey_t *public_key = &sv_camera->pem_public_key;
     if (pk_tests[j].use_wrong_pk) {


### PR DESCRIPTION
Internal functions should return svi_rc instead of
SignedVideoReturnCode.
