### PR TITLE
Prepares for arbitrary hash algorithm

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -666,7 +666,7 @@ compute_gop_hash(signed_video_t *self, h26x_nalu_list_item_t *sei)
       hash_to_add = item->need_second_verification ? item->second_hash : item->hash;
       // Copy to the |nalu_hash| slot in the memory and update the gop_hash.
       memcpy(nalu_hash, hash_to_add, HASH_DIGEST_SIZE);
-      SVI_THROW(update_gop_hash(gop_info));
+      SVI_THROW(update_gop_hash(self->crypto_handle, gop_info));
 
       // Mark the item and move to next.
       item->used_in_gop_hash = true;
@@ -675,7 +675,7 @@ compute_gop_hash(signed_video_t *self, h26x_nalu_list_item_t *sei)
 
     // Complete the gop_hash with the hash of the SEI.
     memcpy(nalu_hash, sei->hash, HASH_DIGEST_SIZE);
-    SVI_THROW(update_gop_hash(gop_info));
+    SVI_THROW(update_gop_hash(self->crypto_handle, gop_info));
     sei->used_in_gop_hash = true;
 
   SVI_CATCH()

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -172,7 +172,7 @@ void
 update_num_nalus_in_gop_hash(signed_video_t *signed_video, const h26x_nalu_t *nalu);
 
 svi_rc
-update_gop_hash(gop_info_t *gop_info);
+update_gop_hash(void *crypto_handle, gop_info_t *gop_info);
 
 void
 check_and_copy_hash_to_hash_list(signed_video_t *signed_video, const uint8_t *nalu_hash);

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -68,7 +68,7 @@ openssl_free_handle(void *handle);
  *          SVI_EXTERNAL_FAILURE Failed to hash.
  */
 svi_rc
-openssl_hash_data(const uint8_t *data, size_t data_size, uint8_t *hash);
+openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *hash);
 
 /**
  * @brief Initiates the cryptographic handle for hashing data


### PR DESCRIPTION
To be able to support arbitrary hash algorithms when hashing NAL
Units, the library needs to use EVP_MD_CTX. If so, it is
possible to set the EVP_MD to use, for example, EVP_sha256().

The context is stored in the |crypto_handle|. Separate calls for
openssl 3.0 or openssl 1.1 was used, but the openssl 3.0
functions already existed in openssl 1.1, hence they can be used
for both. This change is made in this commit.

To use the context, every hash needs to do init/update/finalize
instead of the short-cut function SHA256(). Using short-cut
functions will not scale to arbitrary hashing algorithms.
Some internal functions needed the |crypto_handle| as input and
that change is made in this commit.
