### PR TITLE
First preparation for arbitrary hash algo

### DIFF
--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -50,7 +50,7 @@ typedef enum { SIGN_ALGO_RSA = 0, SIGN_ALGO_ECDSA = 1, SIGN_ALGO_NUM } sign_algo
  */
 typedef struct _signature_info_t {
   uint8_t *hash;  // The hash to be signed, or to verify the signature.
-  size_t hash_size;  // The size of the |hash|. For now with a fixed size of HASH_DIGEST_SIZE.
+  size_t hash_size;  // The size of the |hash|. For now with a fixed size of SHA256_HASH_SIZE.
   sign_algo_t algo;  // The algorithm used to sign the |hash|. NOT USED ANYMORE
   void *private_key;  // The private key used for signing in a pem file format.
   // Internally used as EVP_PKEY_CTX.

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -134,7 +134,7 @@ verify_hashes_with_hash_list(signed_video_t *self, int *num_expected_nalus, int 
 
   // Expected hashes.
   uint8_t *expected_hashes = self->gop_info->hash_list;
-  const int num_expected_hashes = self->gop_info->list_idx / HASH_DIGEST_SIZE;
+  const int num_expected_hashes = self->gop_info->list_idx / SHA256_HASH_SIZE;
 
   h26x_nalu_list_t *nalu_list = self->nalu_list;
   h26x_nalu_list_item_t *last_used_item = NULL;
@@ -215,9 +215,9 @@ verify_hashes_with_hash_list(signed_video_t *self, int *num_expected_nalus, int 
     compare_idx = latest_match_idx + 1;
     // This while-loop searches for a match among the feasible hashes in |hash_list|.
     while (compare_idx < num_expected_hashes) {
-      uint8_t *expected_hash = &expected_hashes[compare_idx * HASH_DIGEST_SIZE];
+      uint8_t *expected_hash = &expected_hashes[compare_idx * SHA256_HASH_SIZE];
 
-      if (memcmp(hash_to_verify, expected_hash, HASH_DIGEST_SIZE) == 0) {
+      if (memcmp(hash_to_verify, expected_hash, SHA256_HASH_SIZE) == 0) {
         // We have a match. Set validation_status and add missing nalus if we have detected any.
         if (item->second_hash && !item->need_second_verification &&
             item->nalu->is_first_nalu_in_gop) {
@@ -665,7 +665,7 @@ compute_gop_hash(signed_video_t *self, h26x_nalu_list_item_t *sei)
       // ones in verification we use the |second_hash|.
       hash_to_add = item->need_second_verification ? item->second_hash : item->hash;
       // Copy to the |nalu_hash| slot in the memory and update the gop_hash.
-      memcpy(nalu_hash, hash_to_add, HASH_DIGEST_SIZE);
+      memcpy(nalu_hash, hash_to_add, SHA256_HASH_SIZE);
       SVI_THROW(update_gop_hash(self->crypto_handle, gop_info));
 
       // Mark the item and move to next.
@@ -674,7 +674,7 @@ compute_gop_hash(signed_video_t *self, h26x_nalu_list_item_t *sei)
     }
 
     // Complete the gop_hash with the hash of the SEI.
-    memcpy(nalu_hash, sei->hash, HASH_DIGEST_SIZE);
+    memcpy(nalu_hash, sei->hash, SHA256_HASH_SIZE);
     SVI_THROW(update_gop_hash(self->crypto_handle, gop_info));
     sei->used_in_gop_hash = true;
 
@@ -717,7 +717,7 @@ prepare_for_validation(signed_video_t *self)
       SVI_THROW(decode_sei_data(self, tlv_data, tlv_size));
       sei->has_been_decoded = true;
       if (self->gop_info->signature_hash_type == DOCUMENT_HASH) {
-        memcpy(signature_info->hash, sei->hash, HASH_DIGEST_SIZE);
+        memcpy(signature_info->hash, sei->hash, SHA256_HASH_SIZE);
       }
     }
     // Check if we should compute the gop_hash.
@@ -725,7 +725,7 @@ prepare_for_validation(signed_video_t *self)
         self->gop_info->signature_hash_type == GOP_HASH) {
       SVI_THROW(compute_gop_hash(self, sei));
       // TODO: Is it possible to avoid a memcpy by using a pointer strategy?
-      memcpy(signature_info->hash, self->gop_info->gop_hash, HASH_DIGEST_SIZE);
+      memcpy(signature_info->hash, self->gop_info->gop_hash, SHA256_HASH_SIZE);
     }
 
     SVI_THROW_IF_WITH_MSG(validation_flags->signing_present && !self->has_public_key,

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -24,7 +24,7 @@
 #include <stdbool.h>  // bool
 
 #include "signed_video_defines.h"  // svi_rc
-#include "signed_video_internal.h"  // gop_info_t, gop_state_t, HASH_DIGEST_SIZE
+#include "signed_video_internal.h"  // gop_info_t, gop_state_t, MAX_HASH_SIZE
 
 typedef struct _h26x_nalu_list_item_t h26x_nalu_list_item_t;
 
@@ -87,7 +87,7 @@ struct _h26x_nalu_list_item_t {
   //       changing the order of NALUs will detect a missing NALU and an invalid NALU.
   // 'E' : An error occurred and validation could not be performed. This should be treated as an
   //       invalid NALU.
-  uint8_t hash[HASH_DIGEST_SIZE];  // The hash of the NALU is stored in this memory slot, if it is
+  uint8_t hash[MAX_HASH_SIZE];  // The hash of the NALU is stored in this memory slot, if it is
   // hashable that is.
   uint8_t *second_hash;  // The hash used for a second verification. Some NALUs, for example the
   // first NALU in a GOP is used in two neighboring GOPs, but with different hashes. The NALU might

--- a/lib/src/signed_video_h26x_nalu_list.c
+++ b/lib/src/signed_video_h26x_nalu_list.c
@@ -22,7 +22,7 @@
 #ifdef SIGNED_VIDEO_DEBUG
 #include <stdio.h>  // printf
 
-#include "signed_video_internal.h"  // HASH_DIGEST_SIZE
+#include "signed_video_internal.h"  // SHA_HASH_SIZE
 #endif
 #include <stdint.h>
 #include <stdlib.h>  // calloc, malloc, free, size_t
@@ -150,7 +150,7 @@ h26x_nalu_list_item_print(const h26x_nalu_list_item_t *item)
 {
   // h26x_nalu_t *nalu;
   // char validation_status;
-  // uint8_t hash[HASH_DIGEST_SIZE];
+  // uint8_t hash[MAX_HASH_SIZE];
   // uint8_t *second_hash;
   // bool taken_ownership_of_nalu;
   // bool need_second_verification;
@@ -174,12 +174,12 @@ h26x_nalu_list_item_print(const h26x_nalu_list_item_t *item)
       (item->has_been_decoded ? ", has_been_decoded" : ""),
       (item->used_in_gop_hash ? ", used_in_gop_hash" : ""));
   printf("item->hash     ");
-  for (int i = 0; i < HASH_DIGEST_SIZE; i++) {
+  for (int i = 0; i < SHA256_HASH_SIZE; i++) {
     printf("%02x", item->hash[i]);
   }
   if (item->second_hash) {
     printf("\nitem->second_hash ");
-    for (int i = 0; i < HASH_DIGEST_SIZE; i++) {
+    for (int i = 0; i < SHA256_HASH_SIZE; i++) {
       printf("%02x", item->second_hash[i]);
     }
   }

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -350,16 +350,16 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
 
       // The current |nalu_hash| is the document hash. Copy to |document_hash|. In principle we only
       // need to do this for SV_AUTHENTICITY_LEVEL_FRAME, but for simplicity we always copy it.
-      memcpy(self->gop_info->document_hash, self->gop_info->nalu_hash, HASH_DIGEST_SIZE);
+      memcpy(self->gop_info->document_hash, self->gop_info->nalu_hash, SHA256_HASH_SIZE);
       // Free the memory allocated when parsing the NALU.
       free(nalu_without_signature_data.nalu_data_wo_epb);
     }
 
     gop_info_t *gop_info = self->gop_info;
     if (gop_info->signature_hash_type == DOCUMENT_HASH) {
-      memcpy(signature_info->hash, gop_info->document_hash, HASH_DIGEST_SIZE);
+      memcpy(signature_info->hash, gop_info->document_hash, SHA256_HASH_SIZE);
     } else {
-      memcpy(signature_info->hash, gop_info->gop_hash, HASH_DIGEST_SIZE);
+      memcpy(signature_info->hash, gop_info->gop_hash, SHA256_HASH_SIZE);
     }
 
     // Reset the gop_hash since we start a new GOP.

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -45,8 +45,10 @@ typedef struct _h26x_nalu_t h26x_nalu_t;
 #else
 #define ATTR_UNUSED __attribute__((unused))
 #endif
-// Currently only support SHA-256 which produces hashes of size 256 bits.
-#define HASH_DIGEST_SIZE (256 / 8)
+// Currently the SHA-512 produces maximum hashe sizes.
+#define MAX_HASH_SIZE (512 / 8)
+// Currently only support SHA-256 (default hash) which produces hashes of size 256 bits.
+#define SHA256_HASH_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
 #define SIGNED_VIDEO_VERSION "v1.1.29"
@@ -71,7 +73,7 @@ typedef struct _h26x_nalu_t h26x_nalu_t;
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #endif
 
-#define HASH_LIST_SIZE (HASH_DIGEST_SIZE * MAX_GOP_LENGTH)
+#define HASH_LIST_SIZE (MAX_HASH_SIZE * MAX_GOP_LENGTH)
 
 struct _validation_flags_t {
   bool has_auth_result;  // Indicates that an authenticity result is available for the user.
@@ -196,10 +198,10 @@ typedef enum { GOP_HASH = 0, DOCUMENT_HASH = 1, NUM_HASH_TYPES } hash_type_t;
  */
 struct _gop_info_t {
   uint8_t version;  // Version of this struct.
-  uint8_t hash_buddies[2 * HASH_DIGEST_SIZE];  // Memory for two hashes organized as
+  uint8_t hash_buddies[2 * MAX_HASH_SIZE];  // Memory for two hashes organized as
   // [reference_hash, nalu_hash].
   bool has_reference_hash;  // Flags if the reference hash in |hash_buddies| is valid.
-  uint8_t hashes[2 * HASH_DIGEST_SIZE];  // Memory for storing, in order, the gop_hash and
+  uint8_t hashes[2 * MAX_HASH_SIZE];  // Memory for storing, in order, the gop_hash and
   // 'latest hash'.
   uint8_t *gop_hash;  // Pointing to the memory slot of the gop_hash in |hashes|.
   uint8_t hash_list[HASH_LIST_SIZE];  // Pointer to the list of hashes used for
@@ -209,9 +211,9 @@ struct _gop_info_t {
   // like exceeding available memory, |list_idx| = -1.
   uint8_t gop_hash_init;  // The initialization value for the |gop_hash|.
   uint8_t *nalu_hash;  // Pointing to the memory slot of the NALU hash in |hashes|.
-  uint8_t document_hash[HASH_DIGEST_SIZE];  // Memory for storing the document hash to be signed
+  uint8_t document_hash[MAX_HASH_SIZE];  // Memory for storing the document hash to be signed
   // when SV_AUTHENTICITY_LEVEL_FRAME.
-  uint8_t tmp_hash[HASH_DIGEST_SIZE];  // Memory for storing a temporary hash needed when a NALU is
+  uint8_t tmp_hash[MAX_HASH_SIZE];  // Memory for storing a temporary hash needed when a NALU is
   // split in parts.
   uint8_t *tmp_hash_ptr;
   uint8_t encoding_status;  // Stores potential errors when encoding, to transmit to the client

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -79,7 +79,7 @@ static const uint8_t kFreshness[FRESHNESS_LENGTH] = {
 #define TIMESTAMP_SIZE 12
 #define STATIC_BYTES_SIZE 22  // Bytes in signed data with unknown meaning
 #define SIGNED_DATA_SIZE \
-  (HASH_DIGEST_SIZE + PUBLIC_KEY_UNCOMPRESSED_SIZE + CHIP_ID_SIZE + ATTRIBUTES_LENGTH + \
+  (SHA256_HASH_SIZE + PUBLIC_KEY_UNCOMPRESSED_SIZE + CHIP_ID_SIZE + ATTRIBUTES_LENGTH + \
       TIMESTAMP_SIZE + STATIC_BYTES_SIZE)
 
 #define OBJECT_ID_SIZE 4
@@ -409,7 +409,7 @@ verify_axis_communications_public_key(sv_vendor_axis_communications_t *self)
     // Add Freshness at positions 24-39.
     memcpy(&binary_raw_data[24], kFreshness, FRESHNESS_LENGTH);
     // Hash |binary_raw_data|.
-    uint8_t binary_raw_data_hash[HASH_DIGEST_SIZE] = {0};
+    uint8_t binary_raw_data_hash[SHA256_HASH_SIZE] = {0};
     SHA256(binary_raw_data, BINARY_RAW_DATA_SIZE, binary_raw_data_hash);
 
     // Create and fill in |signed_data|.
@@ -417,8 +417,8 @@ verify_axis_communications_public_key(sv_vendor_axis_communications_t *self)
     uint8_t *sd_ptr = signed_data;
 
     // Add hash of |binary_raw_data|.
-    memcpy(sd_ptr, binary_raw_data_hash, HASH_DIGEST_SIZE);
-    sd_ptr += HASH_DIGEST_SIZE;
+    memcpy(sd_ptr, binary_raw_data_hash, SHA256_HASH_SIZE);
+    sd_ptr += SHA256_HASH_SIZE;
     *sd_ptr++ = 0x41;
     *sd_ptr++ = 0x82;
 

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1685,7 +1685,7 @@ START_TEST(fallback_to_gop_level)
   signed_video_t *sv = get_initialized_signed_video(settings[_i].codec, settings[_i].algo, false);
   ck_assert(sv);
   ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
-  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * HASH_DIGEST_SIZE), SVI_OK);
+  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * SHA256_HASH_SIZE), SVI_OK);
 
   // Create a list of NALUs given the input string.
   nalu_list_t *list = create_signed_nalus_with_sv(sv, "IPPIPPPPPPPPPPPPPPPPPPPPPPPPIPPI", false);

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -560,7 +560,7 @@ START_TEST(fallback_to_gop_level)
   signed_video_t *sv = get_initialized_signed_video(settings[_i].codec, settings[_i].algo, false);
   ck_assert(sv);
   ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
-  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * HASH_DIGEST_SIZE), SVI_OK);
+  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * SHA256_HASH_SIZE), SVI_OK);
 
   // Create a list of NALUs given the input string.
   nalu_list_t *list = create_signed_nalus_with_sv(sv, "IPPIPPPPPPPPPPPPPPPPPPPPPPPPI", false);

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -66,14 +66,16 @@ char private_key_ecdsa[ECDSA_PRIVATE_KEY_ALLOC_BYTES];
 size_t private_key_size_ecdsa;
 
 struct sv_setting settings[NUM_SETTINGS] = {
-    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_GOP, SIGN_ALGO_RSA, 0},
-    {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_GOP, SIGN_ALGO_RSA, 0},
-    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_RSA, 0},
-    {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_RSA, 0},
-    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_GOP, SIGN_ALGO_ECDSA, 0},
-    {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_GOP, SIGN_ALGO_ECDSA, 0},
-    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0},
-    {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0},
+    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_GOP, SIGN_ALGO_RSA, 0, NULL},
+    {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_GOP, SIGN_ALGO_RSA, 0, NULL},
+    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_RSA, 0, NULL},
+    {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_RSA, 0, NULL},
+    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_GOP, SIGN_ALGO_ECDSA, 0, NULL},
+    {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_GOP, SIGN_ALGO_ECDSA, 0, NULL},
+    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, NULL},
+    {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, NULL},
+    // Special cases
+    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, "sha256"},
 };
 
 /* Pull NALUs to prepend from the signed_video_t session (sv) and prepend, or append, them to the
@@ -185,6 +187,7 @@ create_signed_splitted_nalus_int(const char *str,
   ck_assert(sv);
   ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings.auth_level), SV_OK);
   ck_assert_int_eq(signed_video_set_max_sei_payload_size(sv, settings.max_sei_payload_size), SV_OK);
+  ck_assert_int_eq(signed_video_set_hash_algo(sv, settings.hash_algo_name), SV_OK);
 
   // Create a list of NALUs given the input string.
   nalu_list_t *list = create_signed_nalus_with_sv(sv, str, split_nalus);

--- a/tests/check/signed_video_helpers.h
+++ b/tests/check/signed_video_helpers.h
@@ -45,9 +45,10 @@ struct sv_setting {
   SignedVideoAuthenticityLevel auth_level;
   sign_algo_t algo;
   size_t max_sei_payload_size;
+  const char *hash_algo_name;
 };
 
-#define NUM_SETTINGS 8
+#define NUM_SETTINGS 9
 extern struct sv_setting settings[NUM_SETTINGS];
 
 extern const char *axisDummyCertificateChain;


### PR DESCRIPTION
As a first step to support other hashing algorithms than SHA256
a split of the macro HASH_DIGEST_SIZE into a MAX_HASH_SIZE and
SHA256_HASH_SIZE is done. One is used for allocating enough
memory and the other to control the actual hash size (currently
fixed to SHA256_HASH_SIZE).

A new setting member (hash_algo_name) has been added as well as
an extra setting covering non-custom configurations.
