### PR TITLE
Adds hash size getter

### DIFF
--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -1181,6 +1181,9 @@ signed_video_create(SignedVideoCodec codec)
     // Setup crypto handle.
     self->crypto_handle = openssl_create_handle();
     SVI_THROW_IF(!self->crypto_handle, SVI_EXTERNAL_FAILURE);
+    self->signature_info->hash_size = openssl_get_hash_size(self->crypto_handle);
+    // The default hash algorithm is SHA256, hence the hash size should match that.
+    SVI_THROW_IF(self->signature_info->hash_size != SHA256_HASH_SIZE, SVI_EXTERNAL_FAILURE);
     SVI_THROW_WITH_MSG(reset_gop_hash(self), "Couldn't reset gop_hash");
 
     // Signing plugin is setup when the private key is set.

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -790,5 +790,16 @@ signed_video_set_hash_algo(signed_video_t *self, const char *name_or_oid)
   if (!self) return SV_INVALID_PARAMETER;
   if (self->signing_started) return SV_NOT_SUPPORTED;
 
-  return svi_rc_to_signed_video_rc(openssl_set_hash_algo(self->crypto_handle, name_or_oid));
+  size_t hash_size = 0;
+  svi_rc status = SVI_UNKNOWN;
+  SVI_TRY()
+    SVI_THROW(openssl_set_hash_algo(self->crypto_handle, name_or_oid));
+    hash_size = openssl_get_hash_size(self->crypto_handle);
+    SVI_THROW_IF(hash_size == 0, SVI_NOT_SUPPORTED);
+
+    self->signature_info->hash_size = hash_size;
+  SVI_CATCH()
+  SVI_DONE(status)
+
+  return svi_rc_to_signed_video_rc(status);
 }

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -97,6 +97,18 @@ const unsigned char *
 openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size);
 
 /**
+ * @brief Gets the hash size of the hashing algorithm
+ *
+ * Returns the hash size of the hashing algorithm and 0 upon failure.
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ *
+ * @returns The size of the hash.
+ */
+size_t
+openssl_get_hash_size(void *handle);
+
+/**
  * @brief Hashes data into a 256 bit hash
  *
  * Uses the OpenSSL SHA256() API to hash data. The hashed data has 256 bits, which needs to be


### PR DESCRIPTION
Since the hash algorithm can be arbitrary there is a need to know
the hash size when for example allocating memory.
A getter for this has been added and the size is extracted from
the EVP_MD when a hash algo is set.
