### PR TITLE
Signing side can handle arbitrary hashes

### DIFF
--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -50,7 +50,7 @@ typedef enum { SIGN_ALGO_RSA = 0, SIGN_ALGO_ECDSA = 1, SIGN_ALGO_NUM } sign_algo
  */
 typedef struct _signature_info_t {
   uint8_t *hash;  // The hash to be signed, or to verify the signature.
-  size_t hash_size;  // The size of the |hash|. For now with a fixed size of SHA256_HASH_SIZE.
+  size_t hash_size;  // The size of the |hash|.
   sign_algo_t algo;  // The algorithm used to sign the |hash|. NOT USED ANYMORE
   void *private_key;  // The private key used for signing in a pem file format.
   // Internally used as EVP_PKEY_CTX.

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -34,7 +34,7 @@
 #include "signed_video_authenticity.h"  // latest_validation_init()
 #include "signed_video_h26x_internal.h"  // h26x_nalu_list_item_t
 #include "signed_video_h26x_nalu_list.h"  // h26x_nalu_list_create()
-#include "signed_video_internal.h"  // gop_info_t, gop_state_t, MAX_HASH_SIZE, SHA256_HASH_SIZE
+#include "signed_video_internal.h"  // gop_info_t, gop_state_t, MAX_HASH_SIZE, DEFAULT_HASH_SIZE
 #include "signed_video_openssl_internal.h"
 #include "signed_video_tlv.h"  // read_32bits()
 
@@ -189,7 +189,7 @@ signature_create()
       free(self);
       self = NULL;
     } else {
-      self->hash_size = SHA256_HASH_SIZE;
+      self->hash_size = DEFAULT_HASH_SIZE;
     }
   }
   return self;
@@ -277,7 +277,7 @@ gop_info_create(void)
 
   // Set shortcut pointers to the gop_hash and NALU hash parts of the memory.
   gop_info->gop_hash = gop_info->hashes;
-  gop_info->nalu_hash = gop_info->hashes + SHA256_HASH_SIZE;
+  gop_info->nalu_hash = gop_info->hashes + DEFAULT_HASH_SIZE;
 
   // Set hash_list_size to same as what is allocated.
   if (set_hash_list_size(gop_info, HASH_LIST_SIZE) != SVI_OK) {
@@ -860,20 +860,21 @@ update_gop_hash(void *crypto_handle, gop_info_t *gop_info)
 {
   if (!gop_info) return SVI_INVALID_PARAMETER;
 
+  size_t hash_size = openssl_get_hash_size(crypto_handle);
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
     // Update the gop_hash, that is, hash the memory (both hashes) in hashes = [gop_hash, latest
     // nalu_hash] and replace the gop_hash part with the new hash.
-    SVI_THROW(openssl_hash_data(
-        crypto_handle, gop_info->hashes, 2 * SHA256_HASH_SIZE, gop_info->gop_hash));
+    SVI_THROW(
+        openssl_hash_data(crypto_handle, gop_info->hashes, 2 * hash_size, gop_info->gop_hash));
 
 #ifdef SIGNED_VIDEO_DEBUG
     printf("Latest NALU hash ");
-    for (int i = 0; i < SHA256_HASH_SIZE; i++) {
+    for (size_t i = 0; i < hash_size; i++) {
       printf("%02x", gop_info->nalu_hash[i]);
     }
     printf("\nCurrent gop_hash ");
-    for (int i = 0; i < SHA256_HASH_SIZE; i++) {
+    for (size_t i = 0; i < hash_size; i++) {
       printf("%02x", gop_info->gop_hash[i]);
     }
     printf("\n");
@@ -891,14 +892,15 @@ check_and_copy_hash_to_hash_list(signed_video_t *self, const uint8_t *nalu_hash)
 {
   if (!self || !nalu_hash) return;
 
+  const size_t hash_size = self->signature_info->hash_size;
   uint8_t *hash_list = &self->gop_info->hash_list[0];
   int *list_idx = &self->gop_info->list_idx;
   // Check if there is room for another hash in the |hash_list|.
-  if (*list_idx + SHA256_HASH_SIZE > (int)self->gop_info->hash_list_size) *list_idx = -1;
+  if (*list_idx + hash_size > self->gop_info->hash_list_size) *list_idx = -1;
   if (*list_idx >= 0) {
     // We have a valid |hash_list| and can copy the |nalu_hash| to it.
-    memcpy(&hash_list[*list_idx], nalu_hash, SHA256_HASH_SIZE);
-    *list_idx += SHA256_HASH_SIZE;
+    memcpy(&hash_list[*list_idx], nalu_hash, hash_size);
+    *list_idx += hash_size;
   }
 }
 
@@ -950,6 +952,7 @@ simply_hash(signed_video_t *self, const h26x_nalu_t *nalu, uint8_t *nalu_hash)
   assert(nalu && nalu->is_last_nalu_part && nalu_hash);
   const uint8_t *hashable_data = nalu->hashable_data;
   size_t hashable_data_size = nalu->hashable_data_size;
+  const size_t hash_size = self->signature_info->hash_size;
 
   if (nalu->is_first_nalu_part) {
     // Entire NALU can be hashed in one part.
@@ -963,7 +966,7 @@ simply_hash(signed_video_t *self, const h26x_nalu_t *nalu, uint8_t *nalu_hash)
       // for the future. Store the |nalu_hash| in |tmp_hash| to be copied for its second use, since
       // it is not possible to recompute the hash from partial NALU data.
       if (status == SVI_OK && nalu->is_first_nalu_in_gop && !nalu->is_first_nalu_part) {
-        memcpy(self->gop_info->tmp_hash, nalu_hash, SHA256_HASH_SIZE);
+        memcpy(self->gop_info->tmp_hash, nalu_hash, hash_size);
         self->gop_info->tmp_hash_ptr = self->gop_info->tmp_hash;
       }
     }
@@ -986,19 +989,20 @@ hash_and_copy_to_ref(signed_video_t *self, const h26x_nalu_t *nalu, uint8_t *nal
   gop_info_t *gop_info = self->gop_info;
   // First hash in |hash_buddies| is the |reference_hash|.
   uint8_t *reference_hash = &gop_info->hash_buddies[0];
+  const size_t hash_size = self->signature_info->hash_size;
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
     if (nalu->is_first_nalu_in_gop && !nalu->is_first_nalu_part && gop_info->tmp_hash_ptr) {
       // If the NALU is split in parts and a hash has already been computed and stored in
       // |tmp_hash|, copy from |tmp_hash| since it is not possible to recompute the hash.
-      memcpy(nalu_hash, gop_info->tmp_hash_ptr, SHA256_HASH_SIZE);
+      memcpy(nalu_hash, gop_info->tmp_hash_ptr, hash_size);
     } else {
       // Hash NALU data and store as |nalu_hash|.
       SVI_THROW(simply_hash(self, nalu, nalu_hash));
     }
     // Copy the |nalu_hash| to |reference_hash| to be used in hash_with_reference().
-    memcpy(reference_hash, nalu_hash, SHA256_HASH_SIZE);
+    memcpy(reference_hash, nalu_hash, hash_size);
     // Tell the user there is a new reference hash.
     gop_info->has_reference_hash = true;
   SVI_CATCH()
@@ -1022,17 +1026,18 @@ hash_with_reference(signed_video_t *self, const h26x_nalu_t *nalu, uint8_t *budd
 {
   assert(self && nalu && buddy_hash);
 
+  const size_t hash_size = self->signature_info->hash_size;
   gop_info_t *gop_info = self->gop_info;
   // Second hash in |hash_buddies| is the |nalu_hash|.
-  uint8_t *nalu_hash = &gop_info->hash_buddies[SHA256_HASH_SIZE];
+  uint8_t *nalu_hash = &gop_info->hash_buddies[hash_size];
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
     // Hash NALU data and store as |nalu_hash|.
     SVI_THROW(simply_hash(self, nalu, nalu_hash));
     // Hash reference hash together with the |nalu_hash| and store in |buddy_hash|.
-    SVI_THROW(openssl_hash_data(
-        self->crypto_handle, gop_info->hash_buddies, SHA256_HASH_SIZE * 2, buddy_hash));
+    SVI_THROW(
+        openssl_hash_data(self->crypto_handle, gop_info->hash_buddies, hash_size * 2, buddy_hash));
   SVI_CATCH()
   SVI_DONE(status)
 
@@ -1182,8 +1187,8 @@ signed_video_create(SignedVideoCodec codec)
     self->crypto_handle = openssl_create_handle();
     SVI_THROW_IF(!self->crypto_handle, SVI_EXTERNAL_FAILURE);
     self->signature_info->hash_size = openssl_get_hash_size(self->crypto_handle);
-    // The default hash algorithm is SHA256, hence the hash size should match that.
-    SVI_THROW_IF(self->signature_info->hash_size != SHA256_HASH_SIZE, SVI_EXTERNAL_FAILURE);
+    // Make sure the hash size matches the default hash size.
+    SVI_THROW_IF(self->signature_info->hash_size != DEFAULT_HASH_SIZE, SVI_EXTERNAL_FAILURE);
     SVI_THROW_WITH_MSG(reset_gop_hash(self), "Couldn't reset gop_hash");
 
     // Signing plugin is setup when the private key is set.

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -93,7 +93,7 @@ struct _h26x_nalu_list_item_t {
   // first NALU in a GOP is used in two neighboring GOPs, but with different hashes. The NALU might
   // also require a second verification due to lost NALUs. Memory for this hash is allocated when
   // needed.
-
+  size_t hash_size;
   // Flags
   bool taken_ownership_of_nalu;  // Flag to indicate if the item has taken ownership of the |nalu|
   // memory, hence need to free the memory if the item is released.

--- a/lib/src/signed_video_h26x_nalu_list.c
+++ b/lib/src/signed_video_h26x_nalu_list.c
@@ -174,12 +174,12 @@ h26x_nalu_list_item_print(const h26x_nalu_list_item_t *item)
       (item->has_been_decoded ? ", has_been_decoded" : ""),
       (item->used_in_gop_hash ? ", used_in_gop_hash" : ""));
   printf("item->hash     ");
-  for (int i = 0; i < SHA256_HASH_SIZE; i++) {
+  for (size_t i = 0; i < item->hash_size; i++) {
     printf("%02x", item->hash[i]);
   }
   if (item->second_hash) {
     printf("\nitem->second_hash ");
-    for (int i = 0; i < SHA256_HASH_SIZE; i++) {
+    for (size_t i = 0; i < item->hash_size; i++) {
       printf("%02x", item->second_hash[i]);
     }
   }

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -48,7 +48,7 @@ typedef struct _h26x_nalu_t h26x_nalu_t;
 // Currently the largest supported hash is SHA-512.
 #define MAX_HASH_SIZE (512 / 8)
 // Currently only support SHA-256 (default hash) which produces hashes of size 256 bits.
-#define SHA256_HASH_SIZE (256 / 8)
+#define DEFAULT_HASH_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
 #define SIGNED_VIDEO_VERSION "v1.1.29"

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -513,7 +513,7 @@ openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *
 
   unsigned int hash_size = 0;
   int ret = EVP_Digest(data, data_size, hash, &hash_size, self->hash_algo.type, NULL);
-  svi_rc status = hash_size == SHA256_HASH_SIZE ? SVI_OK : SVI_EXTERNAL_FAILURE;
+  svi_rc status = hash_size == self->hash_algo.size ? SVI_OK : SVI_EXTERNAL_FAILURE;
   return ret == 1 ? status : SVI_EXTERNAL_FAILURE;
 }
 

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -30,7 +30,7 @@
 #include <stdbool.h>
 #include <stdlib.h>  // malloc, memcpy, calloc, free
 
-#include "signed_video_internal.h"
+#include "signed_video_internal.h"  // signed_video_t
 #include "signed_video_tlv.h"
 #include "sv_vendor_axis_communications_internal.h"
 
@@ -78,8 +78,10 @@ static const uint8_t kFreshness[FRESHNESS_LENGTH] = {
 
 #define TIMESTAMP_SIZE 12
 #define STATIC_BYTES_SIZE 22  // Bytes in signed data with unknown meaning
+// SHA-256 produces hashes of size 256 bits.
+#define SIZE_OF_SHA256_MD (256 / 8)
 #define SIGNED_DATA_SIZE \
-  (SHA256_HASH_SIZE + PUBLIC_KEY_UNCOMPRESSED_SIZE + CHIP_ID_SIZE + ATTRIBUTES_LENGTH + \
+  (SIZE_OF_SHA256_MD + PUBLIC_KEY_UNCOMPRESSED_SIZE + CHIP_ID_SIZE + ATTRIBUTES_LENGTH + \
       TIMESTAMP_SIZE + STATIC_BYTES_SIZE)
 
 #define OBJECT_ID_SIZE 4
@@ -409,7 +411,7 @@ verify_axis_communications_public_key(sv_vendor_axis_communications_t *self)
     // Add Freshness at positions 24-39.
     memcpy(&binary_raw_data[24], kFreshness, FRESHNESS_LENGTH);
     // Hash |binary_raw_data|.
-    uint8_t binary_raw_data_hash[SHA256_HASH_SIZE] = {0};
+    uint8_t binary_raw_data_hash[SIZE_OF_SHA256_MD] = {0};
     SHA256(binary_raw_data, BINARY_RAW_DATA_SIZE, binary_raw_data_hash);
 
     // Create and fill in |signed_data|.
@@ -417,8 +419,8 @@ verify_axis_communications_public_key(sv_vendor_axis_communications_t *self)
     uint8_t *sd_ptr = signed_data;
 
     // Add hash of |binary_raw_data|.
-    memcpy(sd_ptr, binary_raw_data_hash, SHA256_HASH_SIZE);
-    sd_ptr += SHA256_HASH_SIZE;
+    memcpy(sd_ptr, binary_raw_data_hash, SIZE_OF_SHA256_MD);
+    sd_ptr += SIZE_OF_SHA256_MD;
     *sd_ptr++ = 0x41;
     *sd_ptr++ = 0x82;
 

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1685,7 +1685,8 @@ START_TEST(fallback_to_gop_level)
   signed_video_t *sv = get_initialized_signed_video(settings[_i].codec, settings[_i].algo, false);
   ck_assert(sv);
   ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
-  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * SHA256_HASH_SIZE), SVI_OK);
+  // If the true hash size is different from the default one, the test should still pass.
+  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * DEFAULT_HASH_SIZE), SVI_OK);
 
   // Create a list of NALUs given the input string.
   nalu_list_t *list = create_signed_nalus_with_sv(sv, "IPPIPPPPPPPPPPPPPPPPPPPPPPPPIPPI", false);

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -563,7 +563,8 @@ START_TEST(fallback_to_gop_level)
   signed_video_t *sv = get_initialized_signed_video(settings[_i].codec, settings[_i].algo, false);
   ck_assert(sv);
   ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
-  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * SHA256_HASH_SIZE), SVI_OK);
+  // If the true hash size is different from the default one, the test should still pass.
+  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * DEFAULT_HASH_SIZE), SVI_OK);
 
   // Create a list of NALUs given the input string.
   nalu_list_t *list = create_signed_nalus_with_sv(sv, "IPPIPPPPPPPPPPPPPPPPPPPPPPPPI", false);


### PR DESCRIPTION
The signing side of the library is now set up to handle any type
of hash. Only necessary changes to compile has been made to the
validation side. Complete functionality is still only guaranteed
for default hash algorithm (SHA256).
