### PR TITLE
Solves validation side with arbitrary hash algo

### DIFF
--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -123,6 +123,7 @@ struct _h26x_nalu_t {
   size_t nalu_data_size;  // The total size of the NALU data
   const uint8_t *hashable_data;  // The NALU data for potential hashing
   size_t hashable_data_size;  // Size of the data to hash, excluding stop bit
+  uint8_t *pending_hashable_data;  // The NALU data for potential hashing
   SignedVideoFrameType nalu_type;  // Frame type: I, P, SPS, PPS, VPS or SEI
   SignedVideoUUIDType uuid_type;  // UUID type if a SEI nalu
   int is_valid;  // Is a valid H26x NALU (1), invalid (0) or has errors (-1)
@@ -181,7 +182,7 @@ svi_rc
 hash_and_add(signed_video_t *signed_video, const h26x_nalu_t *nalu);
 
 svi_rc
-hash_and_add_for_auth(signed_video_t *signed_video, const h26x_nalu_t *nalu);
+hash_and_add_for_auth(signed_video_t *signed_video, h26x_nalu_list_item_t *item);
 
 h26x_nalu_t
 parse_nalu_info(const uint8_t *nalu_data,

--- a/lib/src/signed_video_h26x_nalu_list.h
+++ b/lib/src/signed_video_h26x_nalu_list.h
@@ -85,7 +85,7 @@ h26x_nalu_list_append(h26x_nalu_list_t* list, const h26x_nalu_t* nalu);
  * @returns Signed Video Internal Return Code
  */
 svi_rc
-h26x_nalu_list_copy_last_item(h26x_nalu_list_t* list);
+h26x_nalu_list_copy_last_item(h26x_nalu_list_t* list, bool hash_algo_known);
 
 /**
  * @brief Appends or prepends a certain item of a list with a new item marked as missing

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -85,6 +85,7 @@ struct _validation_flags_t {
   bool signing_present;  // Indicates if Signed Video is present or not. It is only possible to move
   // from false to true unless a reset is performed.
   bool is_first_sei;  // Indicates that this is the first received SEI.
+  bool hash_algo_known;  // Information on what hash algorithm to use has been received.
 };
 
 struct _gop_state_t {

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -906,6 +906,8 @@ decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size)
     SVI_THROW_IF(hash_algo_encoded_oid_size == 0, SVI_DECODING_ERROR);
     SVI_THROW(openssl_set_hash_algo_by_encoded_oid(
         self->crypto_handle, hash_algo_encoded_oid, hash_algo_encoded_oid_size));
+    self->validation_flags.hash_algo_known = true;
+    self->signature_info->hash_size = openssl_get_hash_size(self->crypto_handle);
     data_ptr += hash_algo_encoded_oid_size;
 
     SVI_THROW_IF(data_ptr != data + data_size, SVI_DECODING_ERROR);

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -75,7 +75,7 @@ struct sv_setting settings[NUM_SETTINGS] = {
     {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, NULL},
     {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, NULL},
     // Special cases
-    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, "sha512"},
+    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, "sha384"},
 };
 
 /* Pull NALUs to prepend from the signed_video_t session (sv) and prepend, or append, them to the

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -75,7 +75,7 @@ struct sv_setting settings[NUM_SETTINGS] = {
     {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, NULL},
     {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, NULL},
     // Special cases
-    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, "sha384"},
+    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, "sha256"},
 };
 
 /* Pull NALUs to prepend from the signed_video_t session (sv) and prepend, or append, them to the

--- a/tests/check/signed_video_helpers.c
+++ b/tests/check/signed_video_helpers.c
@@ -75,7 +75,7 @@ struct sv_setting settings[NUM_SETTINGS] = {
     {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, NULL},
     {SV_CODEC_H265, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, NULL},
     // Special cases
-    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, "sha256"},
+    {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, SIGN_ALGO_ECDSA, 0, "sha512"},
 };
 
 /* Pull NALUs to prepend from the signed_video_t session (sv) and prepend, or append, them to the


### PR DESCRIPTION
The hash algorithm is not known until the first SEI arrives.
Therefore, the hashable data is copied and kept until the
hash algo is known. When the first SEI arrives, all stored
NALUs are re-run and hashed.

The side effect is that when the video is not signed the
memory impact becomes larger.

Further, the hash_and_add_for_auth() function now takes
a list item rather than the h26x_nalu_t struct as input.
