### PR TITLE
Cleanups in openssl

### DIFF
--- a/lib/plugins/threaded-signing/plugin.c
+++ b/lib/plugins/threaded-signing/plugin.c
@@ -874,7 +874,7 @@ sv_signing_plugin_init_new(void *user_data)
   if (!central.signature_info) goto catch_error;
 
   // Turn the PEM key into an EVP_PKEY and allocate memory for signatures.
-  if (openssl_private_key_malloc(central.signature_info, (const char *)pem_private_key->pkey,
+  if (openssl_private_key_malloc(central.signature_info, (const char *)pem_private_key->key,
           pem_private_key->pkey_size) != SV_OK) {
     goto catch_error;
   }

--- a/lib/plugins/threaded-signing/plugin.c
+++ b/lib/plugins/threaded-signing/plugin.c
@@ -875,7 +875,7 @@ sv_signing_plugin_init_new(void *user_data)
 
   // Turn the PEM key into an EVP_PKEY and allocate memory for signatures.
   if (openssl_private_key_malloc(central.signature_info, (const char *)pem_private_key->key,
-          pem_private_key->pkey_size) != SV_OK) {
+          pem_private_key->key_size) != SV_OK) {
     goto catch_error;
   }
 

--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -67,8 +67,8 @@ typedef struct _signature_info_t {
  * Struct to store a private key in PEM format. Useful to bundle the data in a single object.
  */
 typedef struct _pem_pkey_t {
-  void *pkey;  // The private/public key used for signing/verification in a pem file format.
-  size_t pkey_size;  // The size of the |pkey|.
+  void *key;  // The private/public key used for signing/verification in a pem file format.
+  size_t pkey_size;  // The size of the |key|.
 } pem_pkey_t;
 
 /**
@@ -94,7 +94,7 @@ openssl_sign_hash(signature_info_t *signature_info);
  * and allocates memory for a signature
  *
  * The function allocates enough memory for a signature given the |private_key|.
- * Use openssl_free_key() to free the key.
+ * Use openssl_free_key() to free the key context.
  *
  * @param signature_info A pointer to the struct that holds all necessary information for signing.
  * @param private_key The content of the private key PEM file.
@@ -111,14 +111,14 @@ openssl_private_key_malloc(signature_info_t *signature_info,
     size_t private_key_size);
 
 /**
- * @brief Frees the memory of a private/public key
+ * @brief Frees the memory of a private/public key context
  *
- * The |pkey| is assumed to be on EVP_PKEY form.
+ * The |key| is assumed to be a key on context form.
  *
- * @param pkey A pointer to the key which memory to free
+ * @param key A pointer to the key context which memory to free
  */
 void
-openssl_free_key(void *pkey);
+openssl_free_key(void *key);
 
 /**
  * @brief Helper function to generate a private key

--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -68,7 +68,7 @@ typedef struct _signature_info_t {
  */
 typedef struct _pem_pkey_t {
   void *key;  // The private/public key used for signing/verification in a pem file format.
-  size_t pkey_size;  // The size of the |key|.
+  size_t key_size;  // The size of the |key|.
 } pem_pkey_t;
 
 /**

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -1118,15 +1118,15 @@ SignedVideoReturnCode
 signed_video_set_public_key(signed_video_t *self, const char *public_key, size_t public_key_size)
 {
   if (!self || !public_key || public_key_size == 0) return SV_INVALID_PARAMETER;
-  if (self->pem_public_key.pkey) return SV_NOT_SUPPORTED;
+  if (self->pem_public_key.key) return SV_NOT_SUPPORTED;
   if (self->authentication_started) return SV_NOT_SUPPORTED;
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
     // Allocate memory and copy |public_key|.
-    self->pem_public_key.pkey = malloc(public_key_size);
-    SVI_THROW_IF(!self->pem_public_key.pkey, SVI_MEMORY);
-    memcpy(self->pem_public_key.pkey, public_key, public_key_size);
+    self->pem_public_key.key = malloc(public_key_size);
+    SVI_THROW_IF(!self->pem_public_key.key, SVI_MEMORY);
+    memcpy(self->pem_public_key.key, public_key, public_key_size);
     self->pem_public_key.pkey_size = public_key_size;
     // Turn the public key from PEM to EVP_PKEY form.
     SVI_THROW(openssl_public_key_malloc(self->signature_info, &self->pem_public_key));

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -1127,7 +1127,7 @@ signed_video_set_public_key(signed_video_t *self, const char *public_key, size_t
     self->pem_public_key.key = malloc(public_key_size);
     SVI_THROW_IF(!self->pem_public_key.key, SVI_MEMORY);
     memcpy(self->pem_public_key.key, public_key, public_key_size);
-    self->pem_public_key.pkey_size = public_key_size;
+    self->pem_public_key.key_size = public_key_size;
     // Turn the public key from PEM to EVP_PKEY form.
     SVI_THROW(openssl_public_key_malloc(self->signature_info, &self->pem_public_key));
     self->has_public_key = true;

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -1277,7 +1277,7 @@ signed_video_free(signed_video_t *self)
   product_info_free(self->product_info);
   gop_info_free(self->gop_info);
   signature_free(self->signature_info);
-  free(self->pem_public_key.pkey);
+  free(self->pem_public_key.key);
 
   free(self);
 }

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -156,7 +156,7 @@ openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_publ
   EVP_PKEY_CTX *ctx = NULL;
   EVP_PKEY *verification_key = NULL;
   const void *buf = pem_public_key->key;
-  int buf_size = (int)(pem_public_key->pkey_size);
+  int buf_size = (int)(pem_public_key->key_size);
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
@@ -309,7 +309,7 @@ write_private_key_to_buffer(EVP_PKEY *pkey, pem_pkey_t *pem_key)
     pem_key->key = malloc(private_key_size);
     SVI_THROW_IF(!pem_key->key, SVI_MEMORY);
     memcpy(pem_key->key, private_key, private_key_size);
-    pem_key->pkey_size = private_key_size;
+    pem_key->key_size = private_key_size;
 
   SVI_CATCH()
   SVI_DONE(status)
@@ -699,7 +699,7 @@ openssl_read_pubkey_from_private_key(signature_info_t *signature_info, pem_pkey_
   // Transfer ownership to |pem_pkey|.
   free(pem_pkey->key);
   pem_pkey->key = public_key;
-  pem_pkey->pkey_size = public_key_size;
+  pem_pkey->key_size = public_key_size;
 
   return status;
 }
@@ -722,10 +722,10 @@ signed_video_generate_ecdsa_private_key(const char *dir_to_key,
   free(full_path_to_private_key);
   if (private_key && private_key_size) {
     *private_key = pem_key.key;
-    *private_key_size = pem_key.pkey_size;
+    *private_key_size = pem_key.key_size;
   } else {
     // Free the key if it is not transferred to the user.
-    free(pem_key.pkey);
+    free(pem_key.key);
   }
 
   return svi_rc_to_signed_video_rc(status);
@@ -748,10 +748,10 @@ signed_video_generate_rsa_private_key(const char *dir_to_key,
   free(full_path_to_private_key);
   if (private_key && private_key_size) {
     *private_key = pem_key.key;
-    *private_key_size = pem_key.pkey_size;
+    *private_key_size = pem_key.key_size;
   } else {
     // Free the key if it is not transferred to the user.
-    free(pem_key.pkey);
+    free(pem_key.key);
   }
 
   return svi_rc_to_signed_video_rc(status);

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -580,7 +580,7 @@ encode_public_key(signed_video_t *self, uint8_t *data)
   data_size += sizeof(version);
 
   // Size of pubkey
-  data_size += pem_public_key->pkey_size;
+  data_size += pem_public_key->key_size;
 
   if (!data) return data_size;
 
@@ -593,7 +593,7 @@ encode_public_key(signed_video_t *self, uint8_t *data)
   write_byte(last_two_bytes, &data_ptr, version, epb);
 
   // public_key; public_key_size bytes
-  for (size_t ii = 0; ii < pem_public_key->pkey_size; ++ii) {
+  for (size_t ii = 0; ii < pem_public_key->key_size; ++ii) {
     write_byte(last_two_bytes, &data_ptr, public_key[ii], epb);
   }
 
@@ -624,11 +624,11 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
     SVI_THROW_IF(version == 0, SVI_INCOMPATIBLE_VERSION);
     SVI_THROW_IF(pubkey_size == 0, SVI_DECODING_ERROR);
 
-    if (pem_public_key->pkey_size != pubkey_size) {
+    if (pem_public_key->key_size != pubkey_size) {
       free(pem_public_key->key);
       pem_public_key->key = calloc(1, pubkey_size);
       SVI_THROW_IF(!pem_public_key->key, SVI_MEMORY);
-      pem_public_key->pkey_size = pubkey_size;
+      pem_public_key->key_size = pubkey_size;
     }
 
     int key_diff = memcmp(data_ptr, pem_public_key->key, pubkey_size);

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -566,9 +566,9 @@ encode_public_key(signed_video_t *self, uint8_t *data)
   size_t data_size = 0;
   const uint8_t version = 2;
 
-  // If there is no |pkey| present, or if it should not be added to the SEI, skip encoding,
+  // If there is no |key| present, or if it should not be added to the SEI, skip encoding,
   // that is, return 0.
-  if (!pem_public_key->pkey || !self->add_public_key_to_sei) return 0;
+  if (!pem_public_key->key || !self->add_public_key_to_sei) return 0;
 
   // Version 1:
   //  - version (1 byte)
@@ -587,7 +587,7 @@ encode_public_key(signed_video_t *self, uint8_t *data)
   uint8_t *data_ptr = data;
   uint16_t *last_two_bytes = &self->last_two_bytes;
   bool epb = self->sei_epb;
-  uint8_t *public_key = (uint8_t *)pem_public_key->pkey;
+  uint8_t *public_key = (uint8_t *)pem_public_key->key;
 
   // Version
   write_byte(last_two_bytes, &data_ptr, version, epb);
@@ -625,17 +625,17 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
     SVI_THROW_IF(pubkey_size == 0, SVI_DECODING_ERROR);
 
     if (pem_public_key->pkey_size != pubkey_size) {
-      free(pem_public_key->pkey);
-      pem_public_key->pkey = calloc(1, pubkey_size);
-      SVI_THROW_IF(!pem_public_key->pkey, SVI_MEMORY);
+      free(pem_public_key->key);
+      pem_public_key->key = calloc(1, pubkey_size);
+      SVI_THROW_IF(!pem_public_key->key, SVI_MEMORY);
       pem_public_key->pkey_size = pubkey_size;
     }
 
-    int key_diff = memcmp(data_ptr, pem_public_key->pkey, pubkey_size);
+    int key_diff = memcmp(data_ptr, pem_public_key->key, pubkey_size);
     if (self->has_public_key && key_diff) {
       self->latest_validation->public_key_has_changed = true;
     }
-    memcpy(pem_public_key->pkey, data_ptr, pubkey_size);
+    memcpy(pem_public_key->key, data_ptr, pubkey_size);
     self->has_public_key = true;
     data_ptr += pubkey_size;
 

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1873,7 +1873,7 @@ validate_public_key_scenario(signed_video_t *sv,
 
   // Late public key
   if (public_key) {
-    sv_rc = signed_video_set_public_key(sv, public_key->key, public_key->pkey_size);
+    sv_rc = signed_video_set_public_key(sv, public_key->key, public_key->key_size);
     ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
     // Since setting a public key after the session start is not supported, there is no point in
     // adding the i_nalu and authenticate.
@@ -1980,7 +1980,7 @@ START_TEST(test_public_key_scenarios)
       public_key = &wrong_public_key;
     }
     if (pk_tests[j].set_pk_before_session_start) {
-      sv_rc = signed_video_set_public_key(sv_vms, public_key->key, public_key->pkey_size);
+      sv_rc = signed_video_set_public_key(sv_vms, public_key->key, public_key->key_size);
       ck_assert_int_eq(sv_rc, SV_OK);
     }
     if (!pk_tests[j].set_pk_after_session_start) {
@@ -2029,7 +2029,7 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   ck_assert_int_eq(sv_rc, SV_OK);
   openssl_read_pubkey_from_private_key(&sign_info, &wrong_public_key);
   // Set public key
-  sv_rc = signed_video_set_public_key(sv_vms, wrong_public_key.key, wrong_public_key.pkey_size);
+  sv_rc = signed_video_set_public_key(sv_vms, wrong_public_key.key, wrong_public_key.key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   // Validate this first GOP.

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1873,7 +1873,7 @@ validate_public_key_scenario(signed_video_t *sv,
 
   // Late public key
   if (public_key) {
-    sv_rc = signed_video_set_public_key(sv, public_key->pkey, public_key->pkey_size);
+    sv_rc = signed_video_set_public_key(sv, public_key->key, public_key->pkey_size);
     ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
     // Since setting a public key after the session start is not supported, there is no point in
     // adding the i_nalu and authenticate.
@@ -1980,7 +1980,7 @@ START_TEST(test_public_key_scenarios)
       public_key = &wrong_public_key;
     }
     if (pk_tests[j].set_pk_before_session_start) {
-      sv_rc = signed_video_set_public_key(sv_vms, public_key->pkey, public_key->pkey_size);
+      sv_rc = signed_video_set_public_key(sv_vms, public_key->key, public_key->pkey_size);
       ck_assert_int_eq(sv_rc, SV_OK);
     }
     if (!pk_tests[j].set_pk_after_session_start) {
@@ -1994,7 +1994,7 @@ START_TEST(test_public_key_scenarios)
     openssl_free_key(sign_info_wrong_key.private_key);
     free(sign_info_wrong_key.signature);
     openssl_free_key(sign_info_wrong_key.public_key);
-    free(wrong_public_key.pkey);
+    free(wrong_public_key.key);
     nalu_list_free_item(sei);
   }
 }
@@ -2029,7 +2029,7 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   ck_assert_int_eq(sv_rc, SV_OK);
   openssl_read_pubkey_from_private_key(&sign_info, &wrong_public_key);
   // Set public key
-  sv_rc = signed_video_set_public_key(sv_vms, wrong_public_key.pkey, wrong_public_key.pkey_size);
+  sv_rc = signed_video_set_public_key(sv_vms, wrong_public_key.key, wrong_public_key.pkey_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   // Validate this first GOP.
@@ -2057,7 +2057,7 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   openssl_free_key(sign_info.private_key);
   free(sign_info.signature);
   openssl_free_key(sign_info.public_key);
-  free(wrong_public_key.pkey);
+  free(wrong_public_key.key);
 }
 END_TEST
 


### PR DESCRIPTION
Renames members of pem_key_t from pkey to key to avoid
misunderstanding with EVP_PKEY objects.
Updated some descriptions and comments and removed unnecessary
includes.
