### PR TITLE
Adds a new struct to replace signature_info_t

### DIFF
--- a/lib/plugins/README.md
+++ b/lib/plugins/README.md
@@ -20,8 +20,8 @@ signing plugin, hence should preferably be built with the unthreaded one.
 
 ## Threaded plugin
 The threaded plugin calls the OpenSSL signing APIs from a separate thread. If the plugin is
-initialized using `sv_signing_plugin_init(user_data)` a central thread is spawned. The `user_data`
-is a `signature_info_t` struct (See
+initialized using `sv_signing_plugin_init_new(user_data)` a central thread is spawned. The
+`user_data` is a `pem_pkey_t` struct (See
 [signed_video_openssl.h](../src/includes/signed_video_openssl.h)) and should include the signing key
 to use. If the user runs multiple sessions they share the same input and output buffers.
 If the plugin is not initialized signing is done from a local thread in each session. This can cause

--- a/lib/plugins/threaded-signing/plugin.c
+++ b/lib/plugins/threaded-signing/plugin.c
@@ -77,9 +77,9 @@ typedef struct _threaded_data {
   signature_data_t out[MAX_BUFFER_LENGTH];
   int out_idx;
   // Variables that can operate without mutex lock.
-  // A local copy of the signing_info is used for signing. The hash to be signed is copied to it
+  // A local copy of the sign_info is used for signing. The hash to be signed is copied to it
   // when it is time to sign.
-  signing_info_t *signing_info;
+  sign_info_t *sign_info;
 } threaded_data_t;
 
 /* A structure for keeping Signed Video session dependent data when signing is central. */
@@ -110,16 +110,16 @@ static id_node_t *id_list = NULL;
  * Helper functions common to both a local and a central thread.
  */
 
-/* Frees the memory of |signing_info|. */
+/* Frees the memory of |sign_info|. */
 static void
-signing_info_free(signing_info_t *signing_info)
+sign_info_free(sign_info_t *sign_info)
 {
-  if (!signing_info) return;
+  if (!sign_info) return;
 
-  openssl_free_key(signing_info->private_key);
-  free(signing_info->signature);
-  free(signing_info->hash);
-  free(signing_info);
+  openssl_free_key(sign_info->key);
+  free(sign_info->signature);
+  free(sign_info->hash);
+  free(sign_info);
 }
 
 /* Resets a hash_data_t element. */
@@ -133,7 +133,7 @@ reset_hash_buffer(hash_data_t *buf)
 static void
 reset_signature_buffer(signature_data_t *buf)
 {
-  buf->size = 0;  // Note that the size of the allocated signature is handled by |signing_info|
+  buf->size = 0;  // Note that the size of the allocated signature is handled by |sign_info|
   buf->id = 0;
   buf->signing_error = false;
 }
@@ -157,26 +157,26 @@ free_signature_buffer(signature_data_t *buf)
   buf->signature = NULL;
 }
 
-/* Allocate memory and copy data from |signing_info|.
+/* Allocate memory and copy data from |sign_info|.
  *
  * This is only done once and the necessary |private_key| is copied. Memory
  * for the |signature| is allocated and if known, also the |hash|. */
-static signing_info_t *
-signature_info_create(const signature_info_t *signature_info)
+static sign_info_t *
+sign_info_create(const signature_info_t *signature_info)
 {
-  signing_info_t *signing_info = calloc(1, sizeof(signing_info_t));
-  if (!signing_info) goto catch_error;
+  sign_info_t *sign_info = calloc(1, sizeof(sign_info_t));
+  if (!sign_info) goto catch_error;
 
   // Turn the PEM key into an EVP_PKEY and allocate memory for signatures.
   if (openssl_private_key_malloc(
-          signing_info, signature_info->private_key, signature_info->private_key_size) != SV_OK) {
+          sign_info, signature_info->private_key, signature_info->private_key_size) != SV_OK) {
     goto catch_error;
   }
 
-  return signing_info;
+  return sign_info;
 
 catch_error:
-  signing_info_free(signing_info);
+  sign_info_free(sign_info);
   return NULL;
 }
 
@@ -197,15 +197,15 @@ free_buffers(threaded_data_t *self)
 static void
 free_plugin(threaded_data_t *self)
 {
-  signing_info_free(self->signing_info);
-  self->signing_info = NULL;
+  sign_info_free(self->sign_info);
+  self->sign_info = NULL;
 
   free_buffers(self);
 }
 
 /* This function is, via sv_signing_plugin_sign(), called from the library upon signing.
  *
- * If this is the first time of signing, memory for |self->signing_info->hash| is allocated.
+ * If this is the first time of signing, memory for |self->sign_info->hash| is allocated.
  * The |hash| is copied to |in|. If memory for the |in| hash has not been allocated it will be
  * allocated. */
 static SignedVideoReturnCode
@@ -228,19 +228,19 @@ sign_hash(threaded_data_t *self, unsigned id, const uint8_t *hash, size_t hash_s
     goto done;
   }
 
-  // Signing from a central thread. The |signing_info| should have been allocated when
+  // Signing from a central thread. The |sign_info| should have been allocated when
   // the plugin was initialized.
-  assert(self->signing_info);
-  // Allocate memory for the hash slot in |signing_info| if this is the first time,
+  assert(self->sign_info);
+  // Allocate memory for the hash slot in |sign_info| if this is the first time,
   // since it is now known to the signing plugin and cannot be changed.
-  if (!self->signing_info->hash) {
-    self->signing_info->hash = calloc(1, hash_size);
-    if (!self->signing_info->hash) {
+  if (!self->sign_info->hash) {
+    self->sign_info->hash = calloc(1, hash_size);
+    if (!self->sign_info->hash) {
       // Failed in memory allocation.
       status = SV_MEMORY;
       goto done;
     }
-    self->signing_info->hash_size = hash_size;
+    self->sign_info->hash_size = hash_size;
   }
 
   if (!self->in[idx].hash) {
@@ -444,10 +444,10 @@ central_worker_thread(void *user_data)
     if (central.in_idx > 0) {
       SignedVideoReturnCode status = SV_UNKNOWN_FAILURE;
       // Get the oldest hash from the input buffer
-      // Copy the hash to |signing_info| and start signing.
-      assert(central.in[0].size == central.signing_info->hash_size);
-      assert(central.signing_info->hash);
-      memcpy(central.signing_info->hash, central.in[0].hash, central.in[0].size);
+      // Copy the hash to |sign_info| and start signing.
+      assert(central.in[0].size == central.sign_info->hash_size);
+      assert(central.sign_info->hash);
+      memcpy(central.sign_info->hash, central.in[0].hash, central.in[0].size);
       id_in_signing = central.in[0].id;
 
       // Move the oldest input buffer to end of queue for reuse at a later stage.
@@ -465,7 +465,7 @@ central_worker_thread(void *user_data)
       // blocked, since variables need to be read under a lock.
       central.is_in_signing = true;
       g_mutex_unlock(&(central.mutex));
-      status = openssl_sign_hash(central.signing_info);
+      status = openssl_sign_hash(central.sign_info);
       g_mutex_lock(&(central.mutex));
       central.is_in_signing = false;
 
@@ -486,7 +486,7 @@ central_worker_thread(void *user_data)
 
       // Allocate memory for the |signature| if necessary.
       if (!central.out[idx].signature) {
-        central.out[idx].signature = calloc(1, central.signing_info->max_signature_size);
+        central.out[idx].signature = calloc(1, central.sign_info->max_signature_size);
         if (!central.out[idx].signature) {
           // Failed in memory allocation. Stop the thread and free all memory.
           status = SV_MEMORY;
@@ -498,9 +498,9 @@ central_worker_thread(void *user_data)
 
       if (status == SV_OK) {
         // Copy the |signature| to the output buffer
-        memcpy(central.out[idx].signature, central.signing_info->signature,
-            central.signing_info->signature_size);
-        central.out[idx].size = central.signing_info->signature_size;
+        memcpy(central.out[idx].signature, central.sign_info->signature,
+            central.sign_info->signature_size);
+        central.out[idx].size = central.sign_info->signature_size;
       }
       central.out_idx++;
     } else {
@@ -585,10 +585,10 @@ local_worker_thread(void *user_data)
   while (self->is_running) {
     if (self->in_idx > 0) {
       // Get the oldest hash from the input buffer
-      // Copy the hash to |signing_info| and start signing.
-      assert(self->in[0].size == self->signing_info->hash_size);
-      assert(self->signing_info->hash);
-      memcpy(self->signing_info->hash, self->in[0].hash, self->in[0].size);
+      // Copy the hash to |sign_info| and start signing.
+      assert(self->in[0].size == self->sign_info->hash_size);
+      assert(self->sign_info->hash);
+      memcpy(self->sign_info->hash, self->in[0].hash, self->in[0].size);
 
       // Move the oldest input buffer to end of queue for reuse at a later stage.
       hash_data_t tmp = self->in[0];
@@ -604,7 +604,7 @@ local_worker_thread(void *user_data)
       // blocked, since variables need to be read under a lock.
       self->is_in_signing = true;
       g_mutex_unlock(&self->mutex);
-      SignedVideoReturnCode status = openssl_sign_hash(self->signing_info);
+      SignedVideoReturnCode status = openssl_sign_hash(self->sign_info);
       g_mutex_lock(&self->mutex);
       self->is_in_signing = false;
 
@@ -622,7 +622,7 @@ local_worker_thread(void *user_data)
 
       // Allocate memory for the |signature| if necessary.
       if (!self->out[idx].signature) {
-        self->out[idx].signature = calloc(1, self->signing_info->max_signature_size);
+        self->out[idx].signature = calloc(1, self->sign_info->max_signature_size);
         if (!self->out[idx].signature) {
           // Failed in memory allocation. Stop the thread and free all memory.
           self->is_running = false;
@@ -633,9 +633,9 @@ local_worker_thread(void *user_data)
 
       if (status == SV_OK) {
         // Copy the |signature| to the output buffer
-        memcpy(self->out[idx].signature, self->signing_info->signature,
-            self->signing_info->signature_size);
-        self->out[idx].size = self->signing_info->signature_size;
+        memcpy(
+            self->out[idx].signature, self->sign_info->signature, self->sign_info->signature_size);
+        self->out[idx].size = self->sign_info->signature_size;
       }
       self->out_idx++;
     } else {
@@ -662,12 +662,12 @@ local_setup(const void *private_key, size_t private_key_size)
 
   if (!self) return NULL;
 
-  // Setup |signing_info| with |private_key| if there is one
-  if (private_key && private_key_size > 0 && !self->signing_info) {
-    self->signing_info = calloc(1, sizeof(signing_info_t));
-    if (!self->signing_info) goto catch_error;
+  // Setup |sign_info| with |private_key| if there is one
+  if (private_key && private_key_size > 0 && !self->sign_info) {
+    self->sign_info = calloc(1, sizeof(sign_info_t));
+    if (!self->sign_info) goto catch_error;
     // Turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
-    if (openssl_private_key_malloc(self->signing_info, private_key, private_key_size) != SV_OK) {
+    if (openssl_private_key_malloc(self->sign_info, private_key, private_key_size) != SV_OK) {
       goto catch_error;
     }
   }
@@ -813,7 +813,7 @@ sv_signing_plugin_session_teardown(void *handle)
 }
 
 /* This plugin initializer expects the |user_data| to be a signature_info_t struct. Only the
- * |private_key| in it is copied to the static |signing_info|. The |private_key| will be
+ * |private_key| in it is copied to the static |sign_info|. The |private_key| will be
  * used throught all added sessions.
  *
  * A central thread is set up and a list, containing the IDs of the active sessions, is initialized
@@ -824,16 +824,16 @@ sv_signing_plugin_init(void *user_data)
 {
   signature_info_t *signature_info = (signature_info_t *)user_data;
 
-  if (central.thread || id_list || central.signing_info) {
-    // Central thread, id list or signing_info already exists
+  if (central.thread || id_list || central.sign_info) {
+    // Central thread, id list or sign_info already exists
     return -1;
   }
 
   id_list = (id_node_t *)calloc(1, sizeof(id_node_t));
   if (!id_list) goto catch_error;
 
-  central.signing_info = signature_info_create(signature_info);
-  if (!central.signing_info) goto catch_error;
+  central.sign_info = sign_info_create(signature_info);
+  if (!central.sign_info) goto catch_error;
 
   g_mutex_init(&(central.mutex));
   g_cond_init(&(central.cond));
@@ -850,8 +850,8 @@ sv_signing_plugin_init(void *user_data)
   return 0;
 
 catch_error:
-  signing_info_free(central.signing_info);
-  central.signing_info = NULL;
+  sign_info_free(central.sign_info);
+  central.sign_info = NULL;
   free(id_list);
   id_list = NULL;
   return -1;
@@ -862,19 +862,19 @@ sv_signing_plugin_init_new(void *user_data)
 {
   pem_pkey_t *pem_private_key = (pem_pkey_t *)user_data;
 
-  if (central.thread || id_list || central.signing_info || !user_data) {
-    // Central thread, id list or signing_info already exists. Or no |user_data| is set.
+  if (central.thread || id_list || central.sign_info || !user_data) {
+    // Central thread, id list or sign_info already exists. Or no |user_data| is set.
     return -1;
   }
 
   id_list = (id_node_t *)calloc(1, sizeof(id_node_t));
   if (!id_list) goto catch_error;
 
-  central.signing_info = calloc(1, sizeof(signing_info_t));
-  if (!central.signing_info) goto catch_error;
+  central.sign_info = calloc(1, sizeof(sign_info_t));
+  if (!central.sign_info) goto catch_error;
 
   // Turn the PEM key into an EVP_PKEY and allocate memory for signatures.
-  if (openssl_private_key_malloc(central.signing_info, (const char *)pem_private_key->key,
+  if (openssl_private_key_malloc(central.sign_info, (const char *)pem_private_key->key,
           pem_private_key->key_size) != SV_OK) {
     goto catch_error;
   }
@@ -894,8 +894,8 @@ sv_signing_plugin_init_new(void *user_data)
   return 0;
 
 catch_error:
-  signing_info_free(central.signing_info);
-  central.signing_info = NULL;
+  sign_info_free(central.sign_info);
+  central.sign_info = NULL;
   free(id_list);
   id_list = NULL;
   return -1;

--- a/lib/plugins/threaded-signing/plugin.c
+++ b/lib/plugins/threaded-signing/plugin.c
@@ -77,9 +77,9 @@ typedef struct _threaded_data {
   signature_data_t out[MAX_BUFFER_LENGTH];
   int out_idx;
   // Variables that can operate without mutex lock.
-  // A local copy of the sign_info is used for signing. The hash to be signed is copied to it
+  // A local copy of the sign_data is used for signing. The hash to be signed is copied to it
   // when it is time to sign.
-  sign_info_t *sign_info;
+  sign_or_verify_data_t *sign_data;
 } threaded_data_t;
 
 /* A structure for keeping Signed Video session dependent data when signing is central. */
@@ -110,16 +110,16 @@ static id_node_t *id_list = NULL;
  * Helper functions common to both a local and a central thread.
  */
 
-/* Frees the memory of |sign_info|. */
+/* Frees the memory of |sign_data|. */
 static void
-sign_info_free(sign_info_t *sign_info)
+sign_data_free(sign_or_verify_data_t *sign_data)
 {
-  if (!sign_info) return;
+  if (!sign_data) return;
 
-  openssl_free_key(sign_info->key);
-  free(sign_info->signature);
-  free(sign_info->hash);
-  free(sign_info);
+  openssl_free_key(sign_data->key);
+  free(sign_data->signature);
+  free(sign_data->hash);
+  free(sign_data);
 }
 
 /* Resets a hash_data_t element. */
@@ -133,7 +133,7 @@ reset_hash_buffer(hash_data_t *buf)
 static void
 reset_signature_buffer(signature_data_t *buf)
 {
-  buf->size = 0;  // Note that the size of the allocated signature is handled by |sign_info|
+  buf->size = 0;  // Note that the size of the allocated signature is handled by |sign_data|
   buf->id = 0;
   buf->signing_error = false;
 }
@@ -157,26 +157,26 @@ free_signature_buffer(signature_data_t *buf)
   buf->signature = NULL;
 }
 
-/* Allocate memory and copy data from |sign_info|.
+/* Allocate memory and copy data from |sign_data|.
  *
  * This is only done once and the necessary |private_key| is copied. Memory
  * for the |signature| is allocated and if known, also the |hash|. */
-static sign_info_t *
-sign_info_create(const signature_info_t *signature_info)
+static sign_or_verify_data_t *
+sign_data_create(const signature_info_t *signature_info)
 {
-  sign_info_t *sign_info = calloc(1, sizeof(sign_info_t));
-  if (!sign_info) goto catch_error;
+  sign_or_verify_data_t *sign_data = calloc(1, sizeof(sign_or_verify_data_t));
+  if (!sign_data) goto catch_error;
 
   // Turn the PEM key into an EVP_PKEY and allocate memory for signatures.
   if (openssl_private_key_malloc(
-          sign_info, signature_info->private_key, signature_info->private_key_size) != SV_OK) {
+          sign_data, signature_info->private_key, signature_info->private_key_size) != SV_OK) {
     goto catch_error;
   }
 
-  return sign_info;
+  return sign_data;
 
 catch_error:
-  sign_info_free(sign_info);
+  sign_data_free(sign_data);
   return NULL;
 }
 
@@ -197,15 +197,15 @@ free_buffers(threaded_data_t *self)
 static void
 free_plugin(threaded_data_t *self)
 {
-  sign_info_free(self->sign_info);
-  self->sign_info = NULL;
+  sign_data_free(self->sign_data);
+  self->sign_data = NULL;
 
   free_buffers(self);
 }
 
 /* This function is, via sv_signing_plugin_sign(), called from the library upon signing.
  *
- * If this is the first time of signing, memory for |self->sign_info->hash| is allocated.
+ * If this is the first time of signing, memory for |self->sign_data->hash| is allocated.
  * The |hash| is copied to |in|. If memory for the |in| hash has not been allocated it will be
  * allocated. */
 static SignedVideoReturnCode
@@ -228,19 +228,19 @@ sign_hash(threaded_data_t *self, unsigned id, const uint8_t *hash, size_t hash_s
     goto done;
   }
 
-  // Signing from a central thread. The |sign_info| should have been allocated when
+  // Signing from a central thread. The |sign_data| should have been allocated when
   // the plugin was initialized.
-  assert(self->sign_info);
-  // Allocate memory for the hash slot in |sign_info| if this is the first time,
+  assert(self->sign_data);
+  // Allocate memory for the hash slot in |sign_data| if this is the first time,
   // since it is now known to the signing plugin and cannot be changed.
-  if (!self->sign_info->hash) {
-    self->sign_info->hash = calloc(1, hash_size);
-    if (!self->sign_info->hash) {
+  if (!self->sign_data->hash) {
+    self->sign_data->hash = calloc(1, hash_size);
+    if (!self->sign_data->hash) {
       // Failed in memory allocation.
       status = SV_MEMORY;
       goto done;
     }
-    self->sign_info->hash_size = hash_size;
+    self->sign_data->hash_size = hash_size;
   }
 
   if (!self->in[idx].hash) {
@@ -444,10 +444,10 @@ central_worker_thread(void *user_data)
     if (central.in_idx > 0) {
       SignedVideoReturnCode status = SV_UNKNOWN_FAILURE;
       // Get the oldest hash from the input buffer
-      // Copy the hash to |sign_info| and start signing.
-      assert(central.in[0].size == central.sign_info->hash_size);
-      assert(central.sign_info->hash);
-      memcpy(central.sign_info->hash, central.in[0].hash, central.in[0].size);
+      // Copy the hash to |sign_data| and start signing.
+      assert(central.in[0].size == central.sign_data->hash_size);
+      assert(central.sign_data->hash);
+      memcpy(central.sign_data->hash, central.in[0].hash, central.in[0].size);
       id_in_signing = central.in[0].id;
 
       // Move the oldest input buffer to end of queue for reuse at a later stage.
@@ -465,7 +465,7 @@ central_worker_thread(void *user_data)
       // blocked, since variables need to be read under a lock.
       central.is_in_signing = true;
       g_mutex_unlock(&(central.mutex));
-      status = openssl_sign_hash(central.sign_info);
+      status = openssl_sign_hash(central.sign_data);
       g_mutex_lock(&(central.mutex));
       central.is_in_signing = false;
 
@@ -486,7 +486,7 @@ central_worker_thread(void *user_data)
 
       // Allocate memory for the |signature| if necessary.
       if (!central.out[idx].signature) {
-        central.out[idx].signature = calloc(1, central.sign_info->max_signature_size);
+        central.out[idx].signature = calloc(1, central.sign_data->max_signature_size);
         if (!central.out[idx].signature) {
           // Failed in memory allocation. Stop the thread and free all memory.
           status = SV_MEMORY;
@@ -498,9 +498,9 @@ central_worker_thread(void *user_data)
 
       if (status == SV_OK) {
         // Copy the |signature| to the output buffer
-        memcpy(central.out[idx].signature, central.sign_info->signature,
-            central.sign_info->signature_size);
-        central.out[idx].size = central.sign_info->signature_size;
+        memcpy(central.out[idx].signature, central.sign_data->signature,
+            central.sign_data->signature_size);
+        central.out[idx].size = central.sign_data->signature_size;
       }
       central.out_idx++;
     } else {
@@ -585,10 +585,10 @@ local_worker_thread(void *user_data)
   while (self->is_running) {
     if (self->in_idx > 0) {
       // Get the oldest hash from the input buffer
-      // Copy the hash to |sign_info| and start signing.
-      assert(self->in[0].size == self->sign_info->hash_size);
-      assert(self->sign_info->hash);
-      memcpy(self->sign_info->hash, self->in[0].hash, self->in[0].size);
+      // Copy the hash to |sign_data| and start signing.
+      assert(self->in[0].size == self->sign_data->hash_size);
+      assert(self->sign_data->hash);
+      memcpy(self->sign_data->hash, self->in[0].hash, self->in[0].size);
 
       // Move the oldest input buffer to end of queue for reuse at a later stage.
       hash_data_t tmp = self->in[0];
@@ -604,7 +604,7 @@ local_worker_thread(void *user_data)
       // blocked, since variables need to be read under a lock.
       self->is_in_signing = true;
       g_mutex_unlock(&self->mutex);
-      SignedVideoReturnCode status = openssl_sign_hash(self->sign_info);
+      SignedVideoReturnCode status = openssl_sign_hash(self->sign_data);
       g_mutex_lock(&self->mutex);
       self->is_in_signing = false;
 
@@ -622,7 +622,7 @@ local_worker_thread(void *user_data)
 
       // Allocate memory for the |signature| if necessary.
       if (!self->out[idx].signature) {
-        self->out[idx].signature = calloc(1, self->sign_info->max_signature_size);
+        self->out[idx].signature = calloc(1, self->sign_data->max_signature_size);
         if (!self->out[idx].signature) {
           // Failed in memory allocation. Stop the thread and free all memory.
           self->is_running = false;
@@ -634,8 +634,8 @@ local_worker_thread(void *user_data)
       if (status == SV_OK) {
         // Copy the |signature| to the output buffer
         memcpy(
-            self->out[idx].signature, self->sign_info->signature, self->sign_info->signature_size);
-        self->out[idx].size = self->sign_info->signature_size;
+            self->out[idx].signature, self->sign_data->signature, self->sign_data->signature_size);
+        self->out[idx].size = self->sign_data->signature_size;
       }
       self->out_idx++;
     } else {
@@ -662,12 +662,12 @@ local_setup(const void *private_key, size_t private_key_size)
 
   if (!self) return NULL;
 
-  // Setup |sign_info| with |private_key| if there is one
-  if (private_key && private_key_size > 0 && !self->sign_info) {
-    self->sign_info = calloc(1, sizeof(sign_info_t));
-    if (!self->sign_info) goto catch_error;
+  // Setup |sign_data| with |private_key| if there is one
+  if (private_key && private_key_size > 0 && !self->sign_data) {
+    self->sign_data = calloc(1, sizeof(sign_or_verify_data_t));
+    if (!self->sign_data) goto catch_error;
     // Turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
-    if (openssl_private_key_malloc(self->sign_info, private_key, private_key_size) != SV_OK) {
+    if (openssl_private_key_malloc(self->sign_data, private_key, private_key_size) != SV_OK) {
       goto catch_error;
     }
   }
@@ -813,7 +813,7 @@ sv_signing_plugin_session_teardown(void *handle)
 }
 
 /* This plugin initializer expects the |user_data| to be a signature_info_t struct. Only the
- * |private_key| in it is copied to the static |sign_info|. The |private_key| will be
+ * |private_key| in it is copied to the static |sign_data|. The |private_key| will be
  * used throught all added sessions.
  *
  * A central thread is set up and a list, containing the IDs of the active sessions, is initialized
@@ -824,16 +824,16 @@ sv_signing_plugin_init(void *user_data)
 {
   signature_info_t *signature_info = (signature_info_t *)user_data;
 
-  if (central.thread || id_list || central.sign_info) {
-    // Central thread, id list or sign_info already exists
+  if (central.thread || id_list || central.sign_data) {
+    // Central thread, id list or sign_data already exists
     return -1;
   }
 
   id_list = (id_node_t *)calloc(1, sizeof(id_node_t));
   if (!id_list) goto catch_error;
 
-  central.sign_info = sign_info_create(signature_info);
-  if (!central.sign_info) goto catch_error;
+  central.sign_data = sign_data_create(signature_info);
+  if (!central.sign_data) goto catch_error;
 
   g_mutex_init(&(central.mutex));
   g_cond_init(&(central.cond));
@@ -850,8 +850,8 @@ sv_signing_plugin_init(void *user_data)
   return 0;
 
 catch_error:
-  sign_info_free(central.sign_info);
-  central.sign_info = NULL;
+  sign_data_free(central.sign_data);
+  central.sign_data = NULL;
   free(id_list);
   id_list = NULL;
   return -1;
@@ -862,19 +862,19 @@ sv_signing_plugin_init_new(void *user_data)
 {
   pem_pkey_t *pem_private_key = (pem_pkey_t *)user_data;
 
-  if (central.thread || id_list || central.sign_info || !user_data) {
-    // Central thread, id list or sign_info already exists. Or no |user_data| is set.
+  if (central.thread || id_list || central.sign_data || !user_data) {
+    // Central thread, id list or sign_data already exists. Or no |user_data| is set.
     return -1;
   }
 
   id_list = (id_node_t *)calloc(1, sizeof(id_node_t));
   if (!id_list) goto catch_error;
 
-  central.sign_info = calloc(1, sizeof(sign_info_t));
-  if (!central.sign_info) goto catch_error;
+  central.sign_data = calloc(1, sizeof(sign_or_verify_data_t));
+  if (!central.sign_data) goto catch_error;
 
   // Turn the PEM key into an EVP_PKEY and allocate memory for signatures.
-  if (openssl_private_key_malloc(central.sign_info, (const char *)pem_private_key->key,
+  if (openssl_private_key_malloc(central.sign_data, (const char *)pem_private_key->key,
           pem_private_key->key_size) != SV_OK) {
     goto catch_error;
   }
@@ -894,8 +894,8 @@ sv_signing_plugin_init_new(void *user_data)
   return 0;
 
 catch_error:
-  sign_info_free(central.sign_info);
-  central.sign_info = NULL;
+  sign_data_free(central.sign_data);
+  central.sign_data = NULL;
   free(id_list);
   id_list = NULL;
   return -1;

--- a/lib/plugins/unthreaded-signing/plugin.c
+++ b/lib/plugins/unthreaded-signing/plugin.c
@@ -39,7 +39,7 @@
 // Plugin handle to store the signature, etc.
 typedef struct _sv_unthreaded_plugin_t {
   bool signature_generated;
-  signature_info_t signature_info;
+  signing_info_t signing_info;
 } sv_unthreaded_plugin_t;
 
 static SignedVideoReturnCode
@@ -50,12 +50,12 @@ unthreaded_openssl_sign_hash(sv_unthreaded_plugin_t *self, const uint8_t *hash, 
   if (self->signature_generated) return SV_NOT_SUPPORTED;
 
   SignedVideoReturnCode status = SV_UNKNOWN_FAILURE;
-  // Borrow the |hash| by passing the pointer to |signature_info| for signing.
-  self->signature_info.hash = (uint8_t *)hash;
-  self->signature_info.hash_size = hash_size;
+  // Borrow the |hash| by passing the pointer to |signing_info| for signing.
+  self->signing_info.hash = (uint8_t *)hash;
+  self->signing_info.hash_size = hash_size;
 
-  status = openssl_sign_hash(&self->signature_info);
-  self->signature_generated = (status == SV_OK) && (self->signature_info.signature_size > 0);
+  status = openssl_sign_hash(&self->signing_info);
+  self->signature_generated = (status == SV_OK) && (self->signing_info.signature_size > 0);
 
   return status;
 }
@@ -83,7 +83,7 @@ sv_signing_plugin_sign(void *handle, const uint8_t *hash, size_t hash_size)
   return unthreaded_openssl_sign_hash(self, hash, hash_size);
 }
 
-/* The |signature| is copied from the local |signature_info| if the |signature_generated|
+/* The |signature| is copied from the local |signing_info| if the |signature_generated|
  * flag is set. */
 bool
 sv_signing_plugin_get_signature(void *handle,
@@ -99,11 +99,11 @@ sv_signing_plugin_get_signature(void *handle,
   bool has_signature = unthreaded_openssl_has_signature(self);
   if (has_signature) {
     // Copy signature if there is room for it.
-    if (max_signature_size < self->signature_info.signature_size) {
+    if (max_signature_size < self->signing_info.signature_size) {
       *written_signature_size = 0;
     } else {
-      memcpy(signature, self->signature_info.signature, self->signature_info.signature_size);
-      *written_signature_size = self->signature_info.signature_size;
+      memcpy(signature, self->signing_info.signature, self->signing_info.signature_size);
+      *written_signature_size = self->signing_info.signature_size;
     }
   }
   if (error) *error = SV_OK;
@@ -120,7 +120,7 @@ sv_signing_plugin_session_setup(const void *private_key, size_t private_key_size
   if (!self) return NULL;
 
   // Turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
-  if (openssl_private_key_malloc(&self->signature_info, private_key, private_key_size) != SV_OK) {
+  if (openssl_private_key_malloc(&self->signing_info, private_key, private_key_size) != SV_OK) {
     sv_signing_plugin_session_teardown((void *)self);
     self = NULL;
   }
@@ -134,8 +134,8 @@ sv_signing_plugin_session_teardown(void *handle)
   sv_unthreaded_plugin_t *self = (sv_unthreaded_plugin_t *)handle;
   if (!self) return;
 
-  openssl_free_key(self->signature_info.private_key);
-  free(self->signature_info.signature);
+  openssl_free_key(self->signing_info.private_key);
+  free(self->signing_info.signature);
   free(self);
 }
 

--- a/lib/plugins/unthreaded-signing/plugin.c
+++ b/lib/plugins/unthreaded-signing/plugin.c
@@ -39,7 +39,7 @@
 // Plugin handle to store the signature, etc.
 typedef struct _sv_unthreaded_plugin_t {
   bool signature_generated;
-  signing_info_t signing_info;
+  sign_info_t sign_info;
 } sv_unthreaded_plugin_t;
 
 static SignedVideoReturnCode
@@ -50,12 +50,12 @@ unthreaded_openssl_sign_hash(sv_unthreaded_plugin_t *self, const uint8_t *hash, 
   if (self->signature_generated) return SV_NOT_SUPPORTED;
 
   SignedVideoReturnCode status = SV_UNKNOWN_FAILURE;
-  // Borrow the |hash| by passing the pointer to |signing_info| for signing.
-  self->signing_info.hash = (uint8_t *)hash;
-  self->signing_info.hash_size = hash_size;
+  // Borrow the |hash| by passing the pointer to |sign_info| for signing.
+  self->sign_info.hash = (uint8_t *)hash;
+  self->sign_info.hash_size = hash_size;
 
-  status = openssl_sign_hash(&self->signing_info);
-  self->signature_generated = (status == SV_OK) && (self->signing_info.signature_size > 0);
+  status = openssl_sign_hash(&self->sign_info);
+  self->signature_generated = (status == SV_OK) && (self->sign_info.signature_size > 0);
 
   return status;
 }
@@ -83,7 +83,7 @@ sv_signing_plugin_sign(void *handle, const uint8_t *hash, size_t hash_size)
   return unthreaded_openssl_sign_hash(self, hash, hash_size);
 }
 
-/* The |signature| is copied from the local |signing_info| if the |signature_generated|
+/* The |signature| is copied from the local |sign_info| if the |signature_generated|
  * flag is set. */
 bool
 sv_signing_plugin_get_signature(void *handle,
@@ -99,11 +99,11 @@ sv_signing_plugin_get_signature(void *handle,
   bool has_signature = unthreaded_openssl_has_signature(self);
   if (has_signature) {
     // Copy signature if there is room for it.
-    if (max_signature_size < self->signing_info.signature_size) {
+    if (max_signature_size < self->sign_info.signature_size) {
       *written_signature_size = 0;
     } else {
-      memcpy(signature, self->signing_info.signature, self->signing_info.signature_size);
-      *written_signature_size = self->signing_info.signature_size;
+      memcpy(signature, self->sign_info.signature, self->sign_info.signature_size);
+      *written_signature_size = self->sign_info.signature_size;
     }
   }
   if (error) *error = SV_OK;
@@ -120,7 +120,7 @@ sv_signing_plugin_session_setup(const void *private_key, size_t private_key_size
   if (!self) return NULL;
 
   // Turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
-  if (openssl_private_key_malloc(&self->signing_info, private_key, private_key_size) != SV_OK) {
+  if (openssl_private_key_malloc(&self->sign_info, private_key, private_key_size) != SV_OK) {
     sv_signing_plugin_session_teardown((void *)self);
     self = NULL;
   }
@@ -134,8 +134,8 @@ sv_signing_plugin_session_teardown(void *handle)
   sv_unthreaded_plugin_t *self = (sv_unthreaded_plugin_t *)handle;
   if (!self) return;
 
-  openssl_free_key(self->signing_info.private_key);
-  free(self->signing_info.signature);
+  openssl_free_key(self->sign_info.key);
+  free(self->sign_info.signature);
   free(self);
 }
 

--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -31,6 +31,7 @@
 extern "C" {
 #endif
 
+/* TO BE DEPRECATED */
 /**
  * @brief Signing algorithm
  *
@@ -42,7 +43,7 @@ extern "C" {
  */
 typedef enum { SIGN_ALGO_RSA = 0, SIGN_ALGO_ECDSA = 1, SIGN_ALGO_NUM } sign_algo_t;
 
-/* NOTE: This struct is in a refactoring state, hence subject to changes. */
+/* TO BE DEPRECATED */
 /**
  * Struct for storing necessary information to generate and verify a signature
  *
@@ -64,6 +65,19 @@ typedef struct _signature_info_t {
 } signature_info_t;
 
 /**
+ * Struct for storing necessary information to sign a hash and generate a signature.
+ * It is used primarily by the signing plugins.
+ */
+typedef struct _signing_info_t {
+  uint8_t *hash;  // The hash to be signed.
+  size_t hash_size;  // The size of the |hash|.
+  void *private_key;  // The private key used for signing.
+  uint8_t *signature;  // The signature of the |hash|.
+  size_t signature_size;  // The size of the |signature|.
+  size_t max_signature_size;  // The allocated size of the |signature|.
+} signing_info_t;
+
+/**
  * Struct to store a private key in PEM format. Useful to bundle the data in a single object.
  */
 typedef struct _pem_pkey_t {
@@ -74,19 +88,19 @@ typedef struct _pem_pkey_t {
 /**
  * @brief Signs a hash
  *
- * The function generates a signature of the |hash| in |singature_info| and stores the result in
- * |signature| of |signature_info|.
+ * The function generates a signature of the |hash| in |signing_info| and stores the result in
+ * |signature| of |signing_info|.
  *
- * @param signature_info A pointer to the struct that holds all necessary information for signing.
+ * @param signing_info A pointer to the struct that holds all necessary information for signing.
  *
  * @returns SV_OK Successfully generated |signature|,
- *          SV_INVALID_PARAMETER Errors in |signature_info|,
+ *          SV_INVALID_PARAMETER Errors in |signing_info|,
  *          SV_NOT_SUPPORTED No private key present,
  *          SV_MEMORY Not enough memory allocated for the |signature|,
  *          SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
 SignedVideoReturnCode
-openssl_sign_hash(signature_info_t *signature_info);
+openssl_sign_hash(signing_info_t *signing_info);
 
 /**
  * @brief Turns a private key on PEM form to EVP_PKEY form
@@ -106,7 +120,7 @@ openssl_sign_hash(signature_info_t *signature_info);
  *          SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
 SignedVideoReturnCode
-openssl_private_key_malloc(signature_info_t *signature_info,
+openssl_private_key_malloc(signing_info_t *signing_info,
     const char *private_key,
     size_t private_key_size);
 

--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -68,14 +68,14 @@ typedef struct _signature_info_t {
  * Struct for storing necessary information to sign a hash and generate a signature.
  * It is used primarily by the signing plugins.
  */
-typedef struct _signing_info_t {
+typedef struct _sign_info_t {
   uint8_t *hash;  // The hash to be signed.
   size_t hash_size;  // The size of the |hash|.
-  void *private_key;  // The private key used for signing.
+  void *key;  // The private key used for signing.
   uint8_t *signature;  // The signature of the |hash|.
   size_t signature_size;  // The size of the |signature|.
   size_t max_signature_size;  // The allocated size of the |signature|.
-} signing_info_t;
+} sign_info_t;
 
 /**
  * Struct to store a private key in PEM format. Useful to bundle the data in a single object.
@@ -88,19 +88,19 @@ typedef struct _pem_pkey_t {
 /**
  * @brief Signs a hash
  *
- * The function generates a signature of the |hash| in |signing_info| and stores the result in
- * |signature| of |signing_info|.
+ * The function generates a signature of the |hash| in |sign_info| and stores the result in
+ * |signature| of |sign_info|.
  *
- * @param signing_info A pointer to the struct that holds all necessary information for signing.
+ * @param sign_info A pointer to the struct that holds all necessary information for signing.
  *
  * @returns SV_OK Successfully generated |signature|,
- *          SV_INVALID_PARAMETER Errors in |signing_info|,
+ *          SV_INVALID_PARAMETER Errors in |sign_info|,
  *          SV_NOT_SUPPORTED No private key present,
  *          SV_MEMORY Not enough memory allocated for the |signature|,
  *          SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
 SignedVideoReturnCode
-openssl_sign_hash(signing_info_t *signing_info);
+openssl_sign_hash(sign_info_t *sign_info);
 
 /**
  * @brief Turns a private key on PEM form to EVP_PKEY form
@@ -120,7 +120,7 @@ openssl_sign_hash(signing_info_t *signing_info);
  *          SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
 SignedVideoReturnCode
-openssl_private_key_malloc(signing_info_t *signing_info,
+openssl_private_key_malloc(sign_info_t *sign_info,
     const char *private_key,
     size_t private_key_size);
 

--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -68,14 +68,14 @@ typedef struct _signature_info_t {
  * Struct for storing necessary information to sign a hash and generate a signature.
  * It is used primarily by the signing plugins.
  */
-typedef struct _sign_info_t {
-  uint8_t *hash;  // The hash to be signed.
+typedef struct _sign_or_verify_data {
+  uint8_t *hash;  // The hash to be signed or to use when verifying the signature.
   size_t hash_size;  // The size of the |hash|.
-  void *key;  // The private key used for signing.
+  void *key;  // The private key used for signing or public key used for verifying.
   uint8_t *signature;  // The signature of the |hash|.
   size_t signature_size;  // The size of the |signature|.
   size_t max_signature_size;  // The allocated size of the |signature|.
-} sign_info_t;
+} sign_or_verify_data_t;
 
 /**
  * Struct to store a private key in PEM format. Useful to bundle the data in a single object.
@@ -88,19 +88,19 @@ typedef struct _pem_pkey_t {
 /**
  * @brief Signs a hash
  *
- * The function generates a signature of the |hash| in |sign_info| and stores the result in
- * |signature| of |sign_info|.
+ * The function generates a signature of the |hash| in |sign_data| and stores the result in
+ * |signature| of |sign_data|.
  *
- * @param sign_info A pointer to the struct that holds all necessary information for signing.
+ * @param sign_data A pointer to the struct that holds all necessary information for signing.
  *
  * @returns SV_OK Successfully generated |signature|,
- *          SV_INVALID_PARAMETER Errors in |sign_info|,
+ *          SV_INVALID_PARAMETER Errors in |sign_data|,
  *          SV_NOT_SUPPORTED No private key present,
  *          SV_MEMORY Not enough memory allocated for the |signature|,
  *          SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
 SignedVideoReturnCode
-openssl_sign_hash(sign_info_t *sign_info);
+openssl_sign_hash(sign_or_verify_data_t *sign_data);
 
 /**
  * @brief Turns a private key on PEM form to EVP_PKEY form
@@ -120,7 +120,7 @@ openssl_sign_hash(sign_info_t *sign_info);
  *          SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
 SignedVideoReturnCode
-openssl_private_key_malloc(sign_info_t *sign_info,
+openssl_private_key_malloc(sign_or_verify_data_t *sign_data,
     const char *private_key,
     size_t private_key_size);
 

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -207,15 +207,15 @@ signature_free(signature_info_t *self)
   free(self);
 }
 
-static signing_info_t *
+static sign_info_t *
 signing_info_create()
 {
-  signing_info_t *self = (signing_info_t *)calloc(1, sizeof(signing_info_t));
+  sign_info_t *self = (sign_info_t *)calloc(1, sizeof(sign_info_t));
   return self;
 }
 
 static void
-signing_info_free(signing_info_t *self)
+signing_info_free(sign_info_t *self)
 {
   if (!self) return;
 
@@ -1177,7 +1177,7 @@ signed_video_create(SignedVideoCodec codec)
 
     // Allocate memory for the signature_info struct.
     self->signature_info = signature_create();
-    self->signing_info = signing_info_create();
+    self->sign_info = signing_info_create();
 
     self->product_info = product_info_create();
     SVI_THROW_IF_WITH_MSG(!self->product_info, SVI_MEMORY, "Could not allocate product_info");
@@ -1294,7 +1294,7 @@ signed_video_free(signed_video_t *self)
   product_info_free(self->product_info);
   gop_info_free(self->gop_info);
   signature_free(self->signature_info);
-  signing_info_free(self->signing_info);
+  signing_info_free(self->sign_info);
   free(self->pem_public_key.key);
 
   free(self);

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -207,6 +207,22 @@ signature_free(signature_info_t *self)
   free(self);
 }
 
+static signing_info_t *
+signing_info_create()
+{
+  signing_info_t *self = (signing_info_t *)calloc(1, sizeof(signing_info_t));
+  return self;
+}
+
+static void
+signing_info_free(signing_info_t *self)
+{
+  if (!self) return;
+
+  free(self->signature);
+  free(self);
+}
+
 static signed_video_product_info_t *
 product_info_create()
 {
@@ -1161,6 +1177,7 @@ signed_video_create(SignedVideoCodec codec)
 
     // Allocate memory for the signature_info struct.
     self->signature_info = signature_create();
+    self->signing_info = signing_info_create();
 
     self->product_info = product_info_create();
     SVI_THROW_IF_WITH_MSG(!self->product_info, SVI_MEMORY, "Could not allocate product_info");
@@ -1277,6 +1294,7 @@ signed_video_free(signed_video_t *self)
   product_info_free(self->product_info);
   gop_info_free(self->gop_info);
   signature_free(self->signature_info);
+  signing_info_free(self->signing_info);
   free(self->pem_public_key.key);
 
   free(self);

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -208,14 +208,14 @@ signature_free(signature_info_t *self)
 }
 
 static sign_or_verify_data_t *
-signing_info_create()
+sign_data_create()
 {
   sign_or_verify_data_t *self = (sign_or_verify_data_t *)calloc(1, sizeof(sign_or_verify_data_t));
   return self;
 }
 
 static void
-signing_info_free(sign_or_verify_data_t *self)
+sign_data_free(sign_or_verify_data_t *self)
 {
   if (!self) return;
 
@@ -1177,7 +1177,7 @@ signed_video_create(SignedVideoCodec codec)
 
     // Allocate memory for the signature_info struct.
     self->signature_info = signature_create();
-    self->sign_data = signing_info_create();
+    self->sign_data = sign_data_create();
 
     self->product_info = product_info_create();
     SVI_THROW_IF_WITH_MSG(!self->product_info, SVI_MEMORY, "Could not allocate product_info");
@@ -1294,7 +1294,7 @@ signed_video_free(signed_video_t *self)
   product_info_free(self->product_info);
   gop_info_free(self->gop_info);
   signature_free(self->signature_info);
-  signing_info_free(self->sign_data);
+  sign_data_free(self->sign_data);
   free(self->pem_public_key.key);
 
   free(self);

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -207,15 +207,15 @@ signature_free(signature_info_t *self)
   free(self);
 }
 
-static sign_info_t *
+static sign_or_verify_data_t *
 signing_info_create()
 {
-  sign_info_t *self = (sign_info_t *)calloc(1, sizeof(sign_info_t));
+  sign_or_verify_data_t *self = (sign_or_verify_data_t *)calloc(1, sizeof(sign_or_verify_data_t));
   return self;
 }
 
 static void
-signing_info_free(sign_info_t *self)
+signing_info_free(sign_or_verify_data_t *self)
 {
   if (!self) return;
 
@@ -1177,7 +1177,7 @@ signed_video_create(SignedVideoCodec codec)
 
     // Allocate memory for the signature_info struct.
     self->signature_info = signature_create();
-    self->sign_info = signing_info_create();
+    self->sign_data = signing_info_create();
 
     self->product_info = product_info_create();
     SVI_THROW_IF_WITH_MSG(!self->product_info, SVI_MEMORY, "Could not allocate product_info");
@@ -1294,7 +1294,7 @@ signed_video_free(signed_video_t *self)
   product_info_free(self->product_info);
   gop_info_free(self->gop_info);
   signature_free(self->signature_info);
-  signing_info_free(self->sign_info);
+  signing_info_free(self->sign_data);
   free(self->pem_public_key.key);
 
   free(self);

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -702,20 +702,20 @@ signed_video_set_private_key_new(signed_video_t *self,
   SVI_TRY()
     // Temporally turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
     SVI_THROW(sv_rc_to_svi_rc(
-        openssl_private_key_malloc(self->sign_info, private_key, private_key_size)));
-    SVI_THROW(openssl_read_pubkey_from_private_key(self->sign_info, &self->pem_public_key));
+        openssl_private_key_malloc(self->sign_data, private_key, private_key_size)));
+    SVI_THROW(openssl_read_pubkey_from_private_key(self->sign_data, &self->pem_public_key));
 
     self->plugin_handle = sv_signing_plugin_session_setup(private_key, private_key_size);
     SVI_THROW_IF(!self->plugin_handle, SVI_EXTERNAL_FAILURE);
     // TODO: Temporarily allocating memory for the seignature in signature_info. It will be removed.
-    self->signature_info->signature = calloc(1, self->sign_info->max_signature_size);
-    self->signature_info->max_signature_size = self->sign_info->max_signature_size;
+    self->signature_info->signature = calloc(1, self->sign_data->max_signature_size);
+    self->signature_info->max_signature_size = self->sign_data->max_signature_size;
   SVI_CATCH()
   SVI_DONE(status)
 
   // Free the EVP_PKEY since it is no longer needed. It is handled by the signing plugin.
-  openssl_free_key(self->sign_info->key);
-  self->sign_info->key = NULL;
+  openssl_free_key(self->sign_data->key);
+  self->sign_data->key = NULL;
 
   return svi_rc_to_signed_video_rc(status);
 }

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -702,20 +702,20 @@ signed_video_set_private_key_new(signed_video_t *self,
   SVI_TRY()
     // Temporally turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
     SVI_THROW(sv_rc_to_svi_rc(
-        openssl_private_key_malloc(self->signing_info, private_key, private_key_size)));
-    SVI_THROW(openssl_read_pubkey_from_private_key(self->signing_info, &self->pem_public_key));
+        openssl_private_key_malloc(self->sign_info, private_key, private_key_size)));
+    SVI_THROW(openssl_read_pubkey_from_private_key(self->sign_info, &self->pem_public_key));
 
     self->plugin_handle = sv_signing_plugin_session_setup(private_key, private_key_size);
     SVI_THROW_IF(!self->plugin_handle, SVI_EXTERNAL_FAILURE);
     // TODO: Temporarily allocating memory for the seignature in signature_info. It will be removed.
-    self->signature_info->signature = calloc(1, self->signing_info->max_signature_size);
-    self->signature_info->max_signature_size = self->signing_info->max_signature_size;
+    self->signature_info->signature = calloc(1, self->sign_info->max_signature_size);
+    self->signature_info->max_signature_size = self->sign_info->max_signature_size;
   SVI_CATCH()
   SVI_DONE(status)
 
   // Free the EVP_PKEY since it is no longer needed. It is handled by the signing plugin.
-  openssl_free_key(self->signing_info->private_key);
-  self->signing_info->private_key = NULL;
+  openssl_free_key(self->sign_info->key);
+  self->sign_info->key = NULL;
 
   return svi_rc_to_signed_video_rc(status);
 }

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -702,17 +702,20 @@ signed_video_set_private_key_new(signed_video_t *self,
   SVI_TRY()
     // Temporally turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
     SVI_THROW(sv_rc_to_svi_rc(
-        openssl_private_key_malloc(self->signature_info, private_key, private_key_size)));
-    SVI_THROW(openssl_read_pubkey_from_private_key(self->signature_info, &self->pem_public_key));
+        openssl_private_key_malloc(self->signing_info, private_key, private_key_size)));
+    SVI_THROW(openssl_read_pubkey_from_private_key(self->signing_info, &self->pem_public_key));
 
     self->plugin_handle = sv_signing_plugin_session_setup(private_key, private_key_size);
     SVI_THROW_IF(!self->plugin_handle, SVI_EXTERNAL_FAILURE);
+    // TODO: Temporarily allocating memory for the seignature in signature_info. It will be removed.
+    self->signature_info->signature = calloc(1, self->signing_info->max_signature_size);
+    self->signature_info->max_signature_size = self->signing_info->max_signature_size;
   SVI_CATCH()
   SVI_DONE(status)
 
   // Free the EVP_PKEY since it is no longer needed. It is handled by the signing plugin.
-  openssl_free_key(self->signature_info->private_key);
-  self->signature_info->private_key = NULL;
+  openssl_free_key(self->signing_info->private_key);
+  self->signing_info->private_key = NULL;
 
   return svi_rc_to_signed_video_rc(status);
 }

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -170,7 +170,7 @@ struct _signed_video_t {
 
   // For signing plugin
   void *plugin_handle;
-  signing_info_t *signing_info;  // Pointer to all necessary information to sign in a plugin.
+  sign_info_t *sign_info;  // Pointer to all necessary information to sign in a plugin.
   signature_info_t
       *signature_info;  // Pointer to all necessary information to sign in a plugin. DEPRECATED
   pem_pkey_t pem_public_key;  // Public key in PEM form for writing/reading to/from SEIs

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -170,7 +170,9 @@ struct _signed_video_t {
 
   // For signing plugin
   void *plugin_handle;
-  signature_info_t *signature_info;  // Pointer to all necessary information to sign in a plugin.
+  signing_info_t *signing_info;  // Pointer to all necessary information to sign in a plugin.
+  signature_info_t
+      *signature_info;  // Pointer to all necessary information to sign in a plugin. DEPRECATED
   pem_pkey_t pem_public_key;  // Public key in PEM form for writing/reading to/from SEIs
 
   // Arbitrary data

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -170,7 +170,7 @@ struct _signed_video_t {
 
   // For signing plugin
   void *plugin_handle;
-  sign_info_t *sign_info;  // Pointer to all necessary information to sign in a plugin.
+  sign_or_verify_data_t *sign_data;  // Pointer to all necessary information to sign in a plugin.
   signature_info_t
       *signature_info;  // Pointer to all necessary information to sign in a plugin. DEPRECATED
   pem_pkey_t pem_public_key;  // Public key in PEM form for writing/reading to/from SEIs

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -90,13 +90,15 @@ openssl_free_key(void *key)
 }
 
 /* Reads the |private_key| which is expected to be on PEM form and creates an EVP_PKEY
- * object out of it and sets it in |sign_info|. Further, enough memory for the signature
+ * object out of it and sets it in |sign_data|. Further, enough memory for the signature
  * is allocated. */
 SignedVideoReturnCode
-openssl_private_key_malloc(sign_info_t *sign_info, const char *private_key, size_t private_key_size)
+openssl_private_key_malloc(sign_or_verify_data_t *sign_data,
+    const char *private_key,
+    size_t private_key_size)
 {
   // Sanity check input
-  if (!sign_info || !private_key || private_key_size == 0) return SV_INVALID_PARAMETER;
+  if (!sign_data || !private_key || private_key_size == 0) return SV_INVALID_PARAMETER;
 
   EVP_PKEY_CTX *ctx = NULL;
   EVP_PKEY *signing_key = NULL;
@@ -112,8 +114,8 @@ openssl_private_key_malloc(sign_info_t *sign_info, const char *private_key, size
     // Read the maximum size of the signature that the |private_key| can generate
     size_t max_signature_size = EVP_PKEY_size(signing_key);
     SVI_THROW_IF(max_signature_size == 0, SVI_EXTERNAL_FAILURE);
-    sign_info->signature = malloc(max_signature_size);
-    SVI_THROW_IF(!sign_info->signature, SVI_MEMORY);
+    sign_data->signature = malloc(max_signature_size);
+    SVI_THROW_IF(!sign_data->signature, SVI_MEMORY);
     // Create a context from the |signing_key|
     ctx = EVP_PKEY_CTX_new(signing_key, NULL /* no engine */);
     SVI_THROW_IF(!ctx, SVI_EXTERNAL_FAILURE);
@@ -126,13 +128,13 @@ openssl_private_key_malloc(sign_info_t *sign_info, const char *private_key, size
       SVI_THROW_IF(EVP_PKEY_CTX_set_signature_md(ctx, EVP_sha256()) <= 0, SVI_EXTERNAL_FAILURE);
     }
 
-    // Set the content in |sign_info|
-    sign_info->max_signature_size = max_signature_size;
-    sign_info->key = ctx;
+    // Set the content in |sign_data|
+    sign_data->max_signature_size = max_signature_size;
+    sign_data->key = ctx;
   SVI_CATCH()
   {
-    free(sign_info->signature);
-    sign_info->signature = NULL;
+    free(sign_data->signature);
+    sign_data->signature = NULL;
     EVP_PKEY_CTX_free(ctx);
     ctx = NULL;
   }
@@ -194,20 +196,20 @@ openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_publ
 
 /* Signs a hash. */
 SignedVideoReturnCode
-openssl_sign_hash(sign_info_t *sign_info)
+openssl_sign_hash(sign_or_verify_data_t *sign_data)
 {
   // Sanity check input
-  if (!sign_info) return SV_INVALID_PARAMETER;
+  if (!sign_data) return SV_INVALID_PARAMETER;
 
-  unsigned char *signature = sign_info->signature;
-  const size_t max_signature_size = sign_info->max_signature_size;
+  unsigned char *signature = sign_data->signature;
+  const size_t max_signature_size = sign_data->max_signature_size;
   // Return if no memory has been allocated for the signature.
   if (!signature || max_signature_size == 0) return SV_INVALID_PARAMETER;
 
-  EVP_PKEY_CTX *ctx = (EVP_PKEY_CTX *)sign_info->key;
+  EVP_PKEY_CTX *ctx = (EVP_PKEY_CTX *)sign_data->key;
   size_t siglen = 0;
-  const uint8_t *hash_to_sign = sign_info->hash;
-  size_t hash_size = sign_info->hash_size;
+  const uint8_t *hash_to_sign = sign_data->hash;
+  size_t hash_size = sign_data->hash_size;
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
@@ -222,7 +224,7 @@ openssl_sign_hash(sign_info_t *sign_info)
         EVP_PKEY_sign(ctx, signature, &siglen, hash_to_sign, hash_size) <= 0, SVI_EXTERNAL_FAILURE);
     // Set the actually written size of the signature. Depending on signing algorithm a shorter
     // signature may have been written.
-    sign_info->signature_size = siglen;
+    sign_data->signature_size = siglen;
   SVI_CATCH()
   SVI_DONE(status)
 
@@ -659,7 +661,7 @@ openssl_get_hash_size(void *handle)
 
 /* Reads the public key from the private key. */
 svi_rc
-openssl_read_pubkey_from_private_key(sign_info_t *sign_info, pem_pkey_t *pem_pkey)
+openssl_read_pubkey_from_private_key(sign_or_verify_data_t *sign_data, pem_pkey_t *pem_pkey)
 {
   EVP_PKEY_CTX *ctx = NULL;
   EVP_PKEY *pkey = NULL;
@@ -667,11 +669,11 @@ openssl_read_pubkey_from_private_key(sign_info_t *sign_info, pem_pkey_t *pem_pke
   char *public_key = NULL;
   long public_key_size = 0;
 
-  if (!sign_info) return SVI_INVALID_PARAMETER;
+  if (!sign_data) return SVI_INVALID_PARAMETER;
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
-    ctx = (EVP_PKEY_CTX *)sign_info->key;
+    ctx = (EVP_PKEY_CTX *)sign_data->key;
     SVI_THROW_IF(!ctx, SVI_INVALID_PARAMETER);
     // Borrow the EVP_PKEY |pkey| from |ctx|.
     pkey = EVP_PKEY_CTX_get0_pkey(ctx);

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -90,15 +90,13 @@ openssl_free_key(void *key)
 }
 
 /* Reads the |private_key| which is expected to be on PEM form and creates an EVP_PKEY
- * object out of it and sets it in |signing_info|. Further, enough memory for the signature
+ * object out of it and sets it in |sign_info|. Further, enough memory for the signature
  * is allocated. */
 SignedVideoReturnCode
-openssl_private_key_malloc(signing_info_t *signing_info,
-    const char *private_key,
-    size_t private_key_size)
+openssl_private_key_malloc(sign_info_t *sign_info, const char *private_key, size_t private_key_size)
 {
   // Sanity check input
-  if (!signing_info || !private_key || private_key_size == 0) return SV_INVALID_PARAMETER;
+  if (!sign_info || !private_key || private_key_size == 0) return SV_INVALID_PARAMETER;
 
   EVP_PKEY_CTX *ctx = NULL;
   EVP_PKEY *signing_key = NULL;
@@ -114,8 +112,8 @@ openssl_private_key_malloc(signing_info_t *signing_info,
     // Read the maximum size of the signature that the |private_key| can generate
     size_t max_signature_size = EVP_PKEY_size(signing_key);
     SVI_THROW_IF(max_signature_size == 0, SVI_EXTERNAL_FAILURE);
-    signing_info->signature = malloc(max_signature_size);
-    SVI_THROW_IF(!signing_info->signature, SVI_MEMORY);
+    sign_info->signature = malloc(max_signature_size);
+    SVI_THROW_IF(!sign_info->signature, SVI_MEMORY);
     // Create a context from the |signing_key|
     ctx = EVP_PKEY_CTX_new(signing_key, NULL /* no engine */);
     SVI_THROW_IF(!ctx, SVI_EXTERNAL_FAILURE);
@@ -128,13 +126,13 @@ openssl_private_key_malloc(signing_info_t *signing_info,
       SVI_THROW_IF(EVP_PKEY_CTX_set_signature_md(ctx, EVP_sha256()) <= 0, SVI_EXTERNAL_FAILURE);
     }
 
-    // Set the content in |signing_info|
-    signing_info->max_signature_size = max_signature_size;
-    signing_info->private_key = ctx;
+    // Set the content in |sign_info|
+    sign_info->max_signature_size = max_signature_size;
+    sign_info->key = ctx;
   SVI_CATCH()
   {
-    free(signing_info->signature);
-    signing_info->signature = NULL;
+    free(sign_info->signature);
+    sign_info->signature = NULL;
     EVP_PKEY_CTX_free(ctx);
     ctx = NULL;
   }
@@ -196,20 +194,20 @@ openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_publ
 
 /* Signs a hash. */
 SignedVideoReturnCode
-openssl_sign_hash(signing_info_t *signing_info)
+openssl_sign_hash(sign_info_t *sign_info)
 {
   // Sanity check input
-  if (!signing_info) return SV_INVALID_PARAMETER;
+  if (!sign_info) return SV_INVALID_PARAMETER;
 
-  unsigned char *signature = signing_info->signature;
-  const size_t max_signature_size = signing_info->max_signature_size;
+  unsigned char *signature = sign_info->signature;
+  const size_t max_signature_size = sign_info->max_signature_size;
   // Return if no memory has been allocated for the signature.
   if (!signature || max_signature_size == 0) return SV_INVALID_PARAMETER;
 
-  EVP_PKEY_CTX *ctx = (EVP_PKEY_CTX *)signing_info->private_key;
+  EVP_PKEY_CTX *ctx = (EVP_PKEY_CTX *)sign_info->key;
   size_t siglen = 0;
-  const uint8_t *hash_to_sign = signing_info->hash;
-  size_t hash_size = signing_info->hash_size;
+  const uint8_t *hash_to_sign = sign_info->hash;
+  size_t hash_size = sign_info->hash_size;
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
@@ -224,7 +222,7 @@ openssl_sign_hash(signing_info_t *signing_info)
         EVP_PKEY_sign(ctx, signature, &siglen, hash_to_sign, hash_size) <= 0, SVI_EXTERNAL_FAILURE);
     // Set the actually written size of the signature. Depending on signing algorithm a shorter
     // signature may have been written.
-    signing_info->signature_size = siglen;
+    sign_info->signature_size = siglen;
   SVI_CATCH()
   SVI_DONE(status)
 
@@ -661,7 +659,7 @@ openssl_get_hash_size(void *handle)
 
 /* Reads the public key from the private key. */
 svi_rc
-openssl_read_pubkey_from_private_key(signing_info_t *signing_info, pem_pkey_t *pem_pkey)
+openssl_read_pubkey_from_private_key(sign_info_t *sign_info, pem_pkey_t *pem_pkey)
 {
   EVP_PKEY_CTX *ctx = NULL;
   EVP_PKEY *pkey = NULL;
@@ -669,11 +667,11 @@ openssl_read_pubkey_from_private_key(signing_info_t *signing_info, pem_pkey_t *p
   char *public_key = NULL;
   long public_key_size = 0;
 
-  if (!signing_info) return SVI_INVALID_PARAMETER;
+  if (!sign_info) return SVI_INVALID_PARAMETER;
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
-    ctx = (EVP_PKEY_CTX *)signing_info->private_key;
+    ctx = (EVP_PKEY_CTX *)sign_info->key;
     SVI_THROW_IF(!ctx, SVI_INVALID_PARAMETER);
     // Borrow the EVP_PKEY |pkey| from |ctx|.
     pkey = EVP_PKEY_CTX_get0_pkey(ctx);

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -198,16 +198,16 @@ openssl_verify_hash(const signature_info_t *signature_info, int *verified_result
  * This function extracts the public key from the |private_key| and writes it to |pem_pkey|. The
  * |private_key| is assumed to be on EVP_PKEY form.
  *
- * @param sign_info A pointer to the object holding the |private_key|.
+ * @param sign_data A pointer to the object holding the |private_key|.
  * @param pem_pkey A pointer to the object where the public key, on PEM format, will be written.
  *
  * @returns SVI_OK Successfully written |key| to |pem_pkey|,
- *          SVI_INVALID_PARAMETER Errors in |sign_info|, or no private key present,
+ *          SVI_INVALID_PARAMETER Errors in |sign_data|, or no private key present,
  *          SVI_MEMORY Could not allocate memory for |key|,
  *          SVI_EXTERNAL_FAILURE Failure in OpenSSL.
  */
 svi_rc
-openssl_read_pubkey_from_private_key(sign_info_t *sign_info, pem_pkey_t *pem_pkey);
+openssl_read_pubkey_from_private_key(sign_or_verify_data_t *sign_data, pem_pkey_t *pem_pkey);
 
 /**
  * @brief Turns a public key on PEM form to EVP_PKEY form

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -198,16 +198,16 @@ openssl_verify_hash(const signature_info_t *signature_info, int *verified_result
  * This function extracts the public key from the |private_key| and writes it to |pem_pkey|. The
  * |private_key| is assumed to be on EVP_PKEY form.
  *
- * @param signature_info A pointer to the object holding the |private_key|.
+ * @param signing_info A pointer to the object holding the |private_key|.
  * @param pem_pkey A pointer to the object where the public key, on PEM format, will be written.
  *
  * @returns SVI_OK Successfully written |key| to |pem_pkey|,
- *          SVI_INVALID_PARAMETER Errors in |signature_info|, or no private key present,
+ *          SVI_INVALID_PARAMETER Errors in |signing_info|, or no private key present,
  *          SVI_MEMORY Could not allocate memory for |key|,
  *          SVI_EXTERNAL_FAILURE Failure in OpenSSL.
  */
 svi_rc
-openssl_read_pubkey_from_private_key(signature_info_t *signature_info, pem_pkey_t *pem_pkey);
+openssl_read_pubkey_from_private_key(signing_info_t *signing_info, pem_pkey_t *pem_pkey);
 
 /**
  * @brief Turns a public key on PEM form to EVP_PKEY form

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -198,16 +198,16 @@ openssl_verify_hash(const signature_info_t *signature_info, int *verified_result
  * This function extracts the public key from the |private_key| and writes it to |pem_pkey|. The
  * |private_key| is assumed to be on EVP_PKEY form.
  *
- * @param signing_info A pointer to the object holding the |private_key|.
+ * @param sign_info A pointer to the object holding the |private_key|.
  * @param pem_pkey A pointer to the object where the public key, on PEM format, will be written.
  *
  * @returns SVI_OK Successfully written |key| to |pem_pkey|,
- *          SVI_INVALID_PARAMETER Errors in |signing_info|, or no private key present,
+ *          SVI_INVALID_PARAMETER Errors in |sign_info|, or no private key present,
  *          SVI_MEMORY Could not allocate memory for |key|,
  *          SVI_EXTERNAL_FAILURE Failure in OpenSSL.
  */
 svi_rc
-openssl_read_pubkey_from_private_key(signing_info_t *signing_info, pem_pkey_t *pem_pkey);
+openssl_read_pubkey_from_private_key(sign_info_t *sign_info, pem_pkey_t *pem_pkey);
 
 /**
  * @brief Turns a public key on PEM form to EVP_PKEY form

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1967,7 +1967,7 @@ START_TEST(test_public_key_scenarios)
     // On validation side
     signed_video_t *sv_vms = signed_video_create(codec);
 
-    signing_info_t sign_info_wrong_key = {0};
+    sign_info_t sign_info_wrong_key = {0};
     // Generate a new private key in order to extract a bad private key (a key not compatible with
     // the one generated on the camera side)
     settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
@@ -1991,7 +1991,7 @@ START_TEST(test_public_key_scenarios)
     signed_video_free(sv_camera);
     signed_video_free(sv_vms);
     free(tmp_private_key);
-    openssl_free_key(sign_info_wrong_key.private_key);
+    openssl_free_key(sign_info_wrong_key.key);
     free(sign_info_wrong_key.signature);
     free(wrong_public_key.key);
     nalu_list_free_item(sei);
@@ -2022,7 +2022,7 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
 
   // Generate a new private key in order to extract a bad private key (a key not compatible with the
   // one generated on the camera side)
-  signing_info_t sign_info = {0};
+  sign_info_t sign_info = {0};
   settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
   sv_rc = openssl_private_key_malloc(&sign_info, tmp_private_key, tmp_private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -2053,7 +2053,7 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   signed_video_free(sv_vms);
   signed_video_free(sv_camera);
   free(tmp_private_key);
-  openssl_free_key(sign_info.private_key);
+  openssl_free_key(sign_info.key);
   free(sign_info.signature);
   free(wrong_public_key.key);
 }

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1967,13 +1967,13 @@ START_TEST(test_public_key_scenarios)
     // On validation side
     signed_video_t *sv_vms = signed_video_create(codec);
 
-    sign_info_t sign_info_wrong_key = {0};
+    sign_or_verify_data_t sign_data_wrong_key = {0};
     // Generate a new private key in order to extract a bad private key (a key not compatible with
     // the one generated on the camera side)
     settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
-    sv_rc = openssl_private_key_malloc(&sign_info_wrong_key, tmp_private_key, tmp_private_key_size);
+    sv_rc = openssl_private_key_malloc(&sign_data_wrong_key, tmp_private_key, tmp_private_key_size);
     ck_assert_int_eq(sv_rc, SV_OK);
-    openssl_read_pubkey_from_private_key(&sign_info_wrong_key, &wrong_public_key);
+    openssl_read_pubkey_from_private_key(&sign_data_wrong_key, &wrong_public_key);
 
     pem_pkey_t *public_key = &sv_camera->pem_public_key;
     if (pk_tests[j].use_wrong_pk) {
@@ -1991,8 +1991,8 @@ START_TEST(test_public_key_scenarios)
     signed_video_free(sv_camera);
     signed_video_free(sv_vms);
     free(tmp_private_key);
-    openssl_free_key(sign_info_wrong_key.key);
-    free(sign_info_wrong_key.signature);
+    openssl_free_key(sign_data_wrong_key.key);
+    free(sign_data_wrong_key.signature);
     free(wrong_public_key.key);
     nalu_list_free_item(sei);
   }
@@ -2022,11 +2022,11 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
 
   // Generate a new private key in order to extract a bad private key (a key not compatible with the
   // one generated on the camera side)
-  sign_info_t sign_info = {0};
+  sign_or_verify_data_t sign_data = {0};
   settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
-  sv_rc = openssl_private_key_malloc(&sign_info, tmp_private_key, tmp_private_key_size);
+  sv_rc = openssl_private_key_malloc(&sign_data, tmp_private_key, tmp_private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  openssl_read_pubkey_from_private_key(&sign_info, &wrong_public_key);
+  openssl_read_pubkey_from_private_key(&sign_data, &wrong_public_key);
   // Set public key
   sv_rc = signed_video_set_public_key(sv_vms, wrong_public_key.key, wrong_public_key.key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -2053,8 +2053,8 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   signed_video_free(sv_vms);
   signed_video_free(sv_camera);
   free(tmp_private_key);
-  openssl_free_key(sign_info.key);
-  free(sign_info.signature);
+  openssl_free_key(sign_data.key);
+  free(sign_data.signature);
   free(wrong_public_key.key);
 }
 END_TEST

--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -1967,7 +1967,7 @@ START_TEST(test_public_key_scenarios)
     // On validation side
     signed_video_t *sv_vms = signed_video_create(codec);
 
-    signature_info_t sign_info_wrong_key = {0};
+    signing_info_t sign_info_wrong_key = {0};
     // Generate a new private key in order to extract a bad private key (a key not compatible with
     // the one generated on the camera side)
     settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
@@ -1993,7 +1993,6 @@ START_TEST(test_public_key_scenarios)
     free(tmp_private_key);
     openssl_free_key(sign_info_wrong_key.private_key);
     free(sign_info_wrong_key.signature);
-    openssl_free_key(sign_info_wrong_key.public_key);
     free(wrong_public_key.key);
     nalu_list_free_item(sei);
   }
@@ -2023,7 +2022,7 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
 
   // Generate a new private key in order to extract a bad private key (a key not compatible with the
   // one generated on the camera side)
-  signature_info_t sign_info = {0};
+  signing_info_t sign_info = {0};
   settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
   sv_rc = openssl_private_key_malloc(&sign_info, tmp_private_key, tmp_private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -2056,7 +2055,6 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   free(tmp_private_key);
   openssl_free_key(sign_info.private_key);
   free(sign_info.signature);
-  openssl_free_key(sign_info.public_key);
   free(wrong_public_key.key);
 }
 END_TEST


### PR DESCRIPTION
To add a clearer separation between the signing side and the
validation side in the code the signature_info_t is split
into one siging_info_t part and one for validation.
This commit address the signing part only and a new struct
signing_info_t is added, which holds the hash to sign, the
private key and the generated signature.

Three functions now use this new struct openssl_sign_hash(),
openssl_private_key_malloc() and
openssl_read_pubkey_from_private_key().

The change affects the signing plugins in particular. The src
code still has a member signature_info, which is used and the
necessary parts have been copied from signing_info for now.
