### PR TITLE
Changes openssl_verify_hash

### DIFF
--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -27,7 +27,7 @@
 
 #include "includes/signed_video_auth.h"  // signed_video_product_info_t
 #include "includes/signed_video_common.h"  // signed_video_t
-#include "includes/signed_video_openssl.h"  // pem_pkey_t, signature_info_t
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t, signature_info_t
 #include "includes/signed_video_sign.h"  // SignedVideoAuthenticityLevel
 #include "signed_video_defines.h"  // svi_rc, sv_tlv_tag_t
 

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -40,7 +40,7 @@
 #include <unistd.h>  // unlink
 #endif
 
-#include "includes/signed_video_openssl.h"  // pem_pkey_t, signature_info_t
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t, signature_info_t
 #include "signed_video_defines.h"
 #include "signed_video_internal.h"  // svi_rc_to_signed_video_rc(), sv_rc_to_svi_rc()
 #include "signed_video_openssl_internal.h"
@@ -233,21 +233,21 @@ openssl_sign_hash(sign_or_verify_data_t *sign_data)
 
 /* Verifies the |signature|. */
 svi_rc
-openssl_verify_hash(const signature_info_t *signature_info, int *verified_result)
+openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_result)
 {
-  if (!signature_info || !verified_result) return SVI_INVALID_PARAMETER;
+  if (!verify_data || !verified_result) return SVI_INVALID_PARAMETER;
 
   int verified_hash = -1;  // Initialize to 'error'.
 
-  const unsigned char *signature = signature_info->signature;
-  const size_t signature_size = signature_info->signature_size;
-  const uint8_t *hash_to_verify = signature_info->hash;
-  size_t hash_size = signature_info->hash_size;
+  const unsigned char *signature = verify_data->signature;
+  const size_t signature_size = verify_data->signature_size;
+  const uint8_t *hash_to_verify = verify_data->hash;
+  size_t hash_size = verify_data->hash_size;
 
   svi_rc status = SVI_UNKNOWN;
   SVI_TRY()
     SVI_THROW_IF(!signature || signature_size == 0 || !hash_to_verify, SVI_INVALID_PARAMETER);
-    EVP_PKEY_CTX *ctx = (EVP_PKEY_CTX *)signature_info->public_key;
+    EVP_PKEY_CTX *ctx = (EVP_PKEY_CTX *)verify_data->key;
     SVI_THROW_IF(!ctx, SVI_INVALID_PARAMETER);
     // EVP_PKEY_verify returns 1 upon success, 0 upon failure and < 0 upon error.
     verified_hash = EVP_PKEY_verify(ctx, signature, signature_size, hash_to_verify, hash_size);

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -25,7 +25,7 @@
 #include <stdint.h>  // uint8_t
 #include <string.h>  // size_t
 
-#include "includes/signed_video_openssl.h"  // pem_pkey_t, signature_info_t
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t signature_info_t
 #include "signed_video_defines.h"  // svi_rc
 
 /**
@@ -179,18 +179,18 @@ openssl_finalize_hash(void *handle, uint8_t *hash);
 /**
  * @brief Verifies a signature against a hash
  *
- * The |hash| is verified against the |signature| using the |public_key|, all being
- * members of the input parameter |signature_info|.
+ * The |hash| is verified against the |signature| using the public |key|, all being
+ * members of the input parameter |verify_data|.
  *
- * @param signature_info Pointer to the signature_info_t object in use.
+ * @param verify_data Pointer to the sign_or_verify_data_t object in use.
  * @param verified_result Poiniter to the place where the verification result is written. The
  *   |verified_result| can either be 1 (success), 0 (failure), or < 0 (error).
  *
  * @returns SVI_OK Successfully generated |signature|,
- *          SVI_INVALID_PARAMETER Errors in |signature_info|, or null pointer inputs,
+ *          SVI_INVALID_PARAMETER Errors in |verify_data|, or null pointer inputs,
  */
 svi_rc
-openssl_verify_hash(const signature_info_t *signature_info, int *verified_result);
+openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_result);
 
 /**
  * @brief Reads the public key from the private key


### PR DESCRIPTION
The verify hash function now takes a sign_or_verify_data_t
struct as input.
