### PR TITLE
Removes last dependency on signature_info_t in openssl

### DIFF
--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -110,7 +110,7 @@ openssl_sign_hash(sign_or_verify_data_t *sign_data);
  * The function allocates enough memory for a signature given the |private_key|.
  * Use openssl_free_key() to free the key context.
  *
- * @param signature_info A pointer to the struct that holds all necessary information for signing.
+ * @param sign_data A pointer to the struct that holds all necessary information for signing.
  * @param private_key The content of the private key PEM file.
  * @param private_key_size The size of the |private_key|.
  *

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -1138,8 +1138,13 @@ signed_video_set_public_key(signed_video_t *self, const char *public_key, size_t
     SVI_THROW_IF(!self->pem_public_key.key, SVI_MEMORY);
     memcpy(self->pem_public_key.key, public_key, public_key_size);
     self->pem_public_key.key_size = public_key_size;
+    // TODO: Remove this temporary solution when signature_info has been replaced with
+    // a verify_data struct instead. Borrow the public key from signature_info.
+    sign_or_verify_data_t verify_data = {.key = self->signature_info->public_key};
     // Turn the public key from PEM to EVP_PKEY form.
-    SVI_THROW(openssl_public_key_malloc(self->signature_info, &self->pem_public_key));
+    SVI_THROW(openssl_public_key_malloc(&verify_data, &self->pem_public_key));
+    // Hand the key back.
+    self->signature_info->public_key = verify_data.key;
     self->has_public_key = true;
 
   SVI_CATCH()

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -542,8 +542,6 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
 #ifdef SIGNED_VIDEO_DEBUG
         // TODO: This might not work for blocked signatures, that is if the hash in
         // |signature_info| does not correspond to the copied |signature|.
-        // Convert the public key to EVP_PKEY for verification. Normally done upon validation.
-        SVI_THROW(openssl_public_key_malloc(signature_info, &self->pem_public_key));
         // Borrow hash, signature and public key from signature_info to verify it.
         sign_or_verify_data_t verify_data = {
             .hash = signature_info->hash,
@@ -553,10 +551,13 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
             .signature_size = signature_info->signature_size,
             .max_signature_size = signature_info->max_signature_size,
         };
+        // Convert the public key to EVP_PKEY for verification. Normally done upon validation.
+        SVI_THROW(openssl_public_key_malloc(&verify_data, &self->pem_public_key));
         // Verify the just signed hash.
         int verified = -1;
         SVI_THROW_WITH_MSG(
             openssl_verify_hash(&verify_data, &verified), "Verification test had errors");
+        openssl_free_key(verify_data.key);
         SVI_THROW_IF_WITH_MSG(verified != 1, SVI_EXTERNAL_FAILURE, "Verification test failed");
 #endif
         SVI_THROW(complete_sei_nalu_and_add_to_prepend(self));

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -40,7 +40,7 @@
 #include <unistd.h>  // unlink
 #endif
 
-#include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t, signature_info_t
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t
 #include "signed_video_defines.h"
 #include "signed_video_internal.h"  // svi_rc_to_signed_video_rc(), sv_rc_to_svi_rc()
 #include "signed_video_openssl_internal.h"
@@ -146,12 +146,12 @@ openssl_private_key_malloc(sign_or_verify_data_t *sign_data,
 }
 
 /* Reads the |pem_public_key| which is expected to be on PEM form and creates an EVP_PKEY
- * object out of it and sets it in |signature_info|. */
+ * object out of it and sets it in |verify_data|. */
 svi_rc
-openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_public_key)
+openssl_public_key_malloc(sign_or_verify_data_t *verify_data, pem_pkey_t *pem_public_key)
 {
   // Sanity check input
-  if (!signature_info || !pem_public_key) return SVI_INVALID_PARAMETER;
+  if (!verify_data || !pem_public_key) return SVI_INVALID_PARAMETER;
 
   EVP_PKEY_CTX *ctx = NULL;
   EVP_PKEY *verification_key = NULL;
@@ -179,9 +179,9 @@ openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_publ
     }
 
     // Free any existing key
-    EVP_PKEY_CTX_free(signature_info->public_key);
-    // Set the content in |signature_info|
-    signature_info->public_key = ctx;
+    EVP_PKEY_CTX_free(verify_data->key);
+    // Set the content in |verify_data|
+    verify_data->key = ctx;
   SVI_CATCH()
   {
     EVP_PKEY_CTX_free(ctx);

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -25,7 +25,7 @@
 #include <stdint.h>  // uint8_t
 #include <string.h>  // size_t
 
-#include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t signature_info_t
+#include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t
 #include "signed_video_defines.h"  // svi_rc
 
 /**
@@ -213,10 +213,10 @@ openssl_read_pubkey_from_private_key(sign_or_verify_data_t *sign_data, pem_pkey_
  * @brief Turns a public key on PEM form to EVP_PKEY form
  *
  * The function takes the public key as a pem_pkey_t and stores it as |public_key| in
- * |signature_info| on the EVP_PKEY form.
+ * |verify_data| on the EVP_PKEY form.
  * Use openssl_free_key() to free the key context.
  *
- * @param signature_info A pointer to the struct that holds all necessary information for signing.
+ * @param verify_data A pointer to the struct that holds all necessary information for signing.
  * @param pem_public_key A pointer to the PEM format struct.
  *
  * @returns SVI_OK Successfully stored |public_key|,
@@ -224,6 +224,6 @@ openssl_read_pubkey_from_private_key(sign_or_verify_data_t *sign_data, pem_pkey_
  *          SVI_EXTERNAL_FAILURE Failure in OpenSSL.
  */
 svi_rc
-openssl_public_key_malloc(signature_info_t *signature_info, pem_pkey_t *pem_public_key);
+openssl_public_key_malloc(sign_or_verify_data_t *verify_data, pem_pkey_t *pem_public_key);
 
 #endif  // __SIGNED_VIDEO_OPENSSL_INTERNAL__

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -639,8 +639,13 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
     self->has_public_key = true;
     data_ptr += pubkey_size;
 
+    // TODO: Remove this temporary solution when signature_info has been replaced with
+    // a verify_data struct instead. Borrow the public key from signature_info.
+    sign_or_verify_data_t verify_data = {.key = self->signature_info->public_key};
     // Convert to EVP_PKEY
-    SVI_THROW(openssl_public_key_malloc(self->signature_info, &self->pem_public_key));
+    SVI_THROW(openssl_public_key_malloc(&verify_data, &self->pem_public_key));
+    // Hand the key back.
+    self->signature_info->public_key = verify_data.key;
 
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
     // If "Axis Communications AB" can be identified from the |product_info|, set |public_key| to


### PR DESCRIPTION
The last function, openssl_public_key_malloc(), now takes the
new sign_or_verify_data_t as input.
