### PR TITLE
Adds hash size as input to hash functions

### DIFF
--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -176,7 +176,9 @@ svi_rc
 update_gop_hash(void *crypto_handle, gop_info_t *gop_info);
 
 void
-check_and_copy_hash_to_hash_list(signed_video_t *signed_video, const uint8_t *nalu_hash);
+check_and_copy_hash_to_hash_list(signed_video_t *signed_video,
+    const uint8_t *hash,
+    size_t hash_size);
 
 svi_rc
 hash_and_add(signed_video_t *signed_video, const h26x_nalu_t *nalu);


### PR DESCRIPTION
The hash size has more or less been implicitly used when
hash function wrappers are used. They now take a size as
input.
