### PR TITLE
Makes some functions static

### DIFF
--- a/tests/check/test_stream.c
+++ b/tests/check/test_stream.c
@@ -75,6 +75,10 @@ const uint8_t pps_nalu_h265[DUMMY_NALU_SIZE] = {0x44, 0x01, 0x00, 0x00, 0x80};
 const uint8_t sei_nalu_h265[DUMMY_SEI_SIZE] = {0x4e, 0x01, 0x05, 0x11, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
     0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x80};
 
+// Function declarations.
+static void
+test_stream_append_last_item(test_stream_t *list, test_stream_item_t *new_item);
+
 /* Helper that parses information from the NAL Unit and returns a character representing
  * the NALU type. */
 static char
@@ -288,7 +292,7 @@ test_stream_pop_last_item(test_stream_t *list)
 }
 
 /* Appends a list item with a new item. Assumes list_item exists. */
-void
+static void
 test_stream_item_append(test_stream_item_t *list_item, test_stream_item_t *new_item)
 {
   if (!list_item || !new_item) return;
@@ -464,7 +468,7 @@ test_stream_append_item(test_stream_t *list, test_stream_item_t *new_item, int i
 }
 
 /* Appends the |last_item| of a |list| with a |new_item|. */
-void
+static void
 test_stream_append_last_item(test_stream_t *list, test_stream_item_t *new_item)
 {
   if (!list || !new_item) return;

--- a/tests/check/test_stream.h
+++ b/tests/check/test_stream.h
@@ -97,26 +97,22 @@ test_stream_append_item(test_stream_t *list,
     test_stream_item_t *new_item,
     int item_number_to_append);
 
-/* Appends the last_item of a list with a |new_item|. */
-void
-test_stream_append_last_item(test_stream_t *list, test_stream_item_t *new_item);
-
 /* Prepends the first_item of a list with a |new_item|. */
 void
 test_stream_prepend_first_item(test_stream_t *list, test_stream_item_t *new_item);
 
-/* Makes a refresh on the list. This means restoring all struct members. Helpful if the
- * list is out of sync. Rewinds the first_item to the beginning and loops through all
- * items to get the size, the last_item and the types. Note that the first_item has to be
- * represented in the list. */
+/* Makes a refresh on the |list|. This means restoring all struct members. Helpful if the
+ * |list| is out of sync. Rewinds the |first_item| to the beginning and loops through all
+ * items to get the size, the |last_item| and the |types|. Note that the |first_item| has
+ * to be represented in the |list|. */
 void
 test_stream_refresh(test_stream_t *list);
 
-/* Checks the sequence of NAL Unis of |list| against the expected |str| of types. */
+/* Checks the sequence of NAL Units of |list| against the expected |types|. */
 void
-test_stream_check_types(const test_stream_t *list, const char *str);
+test_stream_check_types(const test_stream_t *list, const char *types);
 
-/* Prints the members of the list. */
+/* Prints the members of the |list|. */
 void
 test_stream_print(test_stream_t *list);
 
@@ -157,10 +153,6 @@ test_stream_pop_first_item(test_stream_t *list);
  * is responsible to free the memory. */
 test_stream_item_t *
 test_stream_pop_last_item(test_stream_t *list);
-
-/* Appends a |list_item| with a new item. Assumes |list_item| exists. */
-void
-test_stream_item_append(test_stream_item_t *list_item, test_stream_item_t *new_item);
 
 /* Prepends a |list_item| with a |new_item|. Assumes |list_item| exists. */
 void


### PR DESCRIPTION
Some functions are not used outside test_stream.c. These
have been made static instead. The print functions are still
declared in the header file for manual debug purposes.
