### PR TITLE
Renames signed_video_helpers

### DIFF
--- a/tests/check/check_h26xsigned_auth.c
+++ b/tests/check/check_h26xsigned_auth.c
@@ -33,7 +33,7 @@
 #include "lib/src/signed_video_internal.h"  // set_hash_list_size()
 #include "lib/src/signed_video_openssl_internal.h"  // openssl_read_pubkey_from_private_key()
 #include "lib/src/signed_video_tlv.h"  // write_byte_many()
-#include "signed_video_helpers.h"  // sv_setting, create_signed_nalus()
+#include "test_helpers.h"  // sv_setting, create_signed_nalus()
 #include "test_stream.h"  // test_stream_create()
 
 #define TMP_FIX_TO_ALLOW_TWO_INVALID_SEIS_AT_STARTUP true

--- a/tests/check/check_h26xsigned_sign.c
+++ b/tests/check/check_h26xsigned_sign.c
@@ -31,7 +31,7 @@
 #include "lib/src/signed_video_defines.h"  // svi_rc, sv_tlv_tag_t
 #include "lib/src/signed_video_h26x_internal.h"  // h26x_nalu_t
 #include "lib/src/signed_video_internal.h"  // set_hash_list_size()
-#include "signed_video_helpers.h"
+#include "test_helpers.h"
 #include "test_stream.h"
 
 static void

--- a/tests/check/meson.build
+++ b/tests/check/meson.build
@@ -9,8 +9,8 @@ tests = [
       [
         'test_stream.h',
         'test_stream.c',
-        'signed_video_helpers.h',
-        'signed_video_helpers.c',
+        'test_helpers.h',
+        'test_helpers.c',
         'check_h26xsigned_sign.c'
       ]
     ],
@@ -23,8 +23,8 @@ if (get_option('signingplugin') != 'threaded_unless_check_dep')
         [ 
           'test_stream.h',
           'test_stream.c',
-          'signed_video_helpers.h',
-          'signed_video_helpers.c',
+          'test_helpers.h',
+          'test_helpers.c',
           'check_h26xsigned_auth.c' 
         ] 
       ] 

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -18,7 +18,7 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#include "signed_video_helpers.h"
+#include "test_helpers.h"
 
 #include <assert.h>  // assert
 #include <check.h>

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -18,8 +18,8 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifndef __SIGNED_VIDEO_HELPERS_H__
-#define __SIGNED_VIDEO_HELPERS_H__
+#ifndef __TEST_HELPERS_H__
+#define __TEST_HELPERS_H__
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -123,4 +123,4 @@ modify_list_item(test_stream_t *list, int item_number, char type);
 bool
 tag_is_present(test_stream_item_t *item, SignedVideoCodec codec, sv_tlv_tag_t tag);
 
-#endif  // __SIGNED_VIDEO_HELPERS_H__
+#endif  // __TEST_HELPERS_H__


### PR DESCRIPTION
To separate from the src code, renames the helper files to
test_helpers.{c, h}
