### PR TITLE
Support only OpenSSL 3

### DIFF
--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -27,7 +27,7 @@ signedvideoframework_sources = files(
 signedvideoframework_sources += plugin_sources
 signedvideoframework_sources += vendor_sources
 
-openssl_dep = dependency('openssl', required : true)
+openssl_dep = dependency('openssl', required : true, version : '>=3.0.0')
 
 # Add vendor specific public headers
 if build_with_axis


### PR DESCRIPTION
OpenSSL version older than 3.0.0 has been deprecated. Therefore,
all code for 1.1.1 is removed. The validation side has not been
limited by the older version, so old recordings are still
backwards compatible.
