### PR TITLE
Removes svi_rc sv_rc helpers

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -1111,7 +1111,7 @@ signed_video_add_nalu_and_authenticate(signed_video_t *self,
   SV_CATCH()
   SV_DONE(status)
 
-  return svi_rc_to_signed_video_rc(status);
+  return status;
 }
 
 SignedVideoReturnCode
@@ -1135,5 +1135,5 @@ signed_video_set_public_key(signed_video_t *self, const char *public_key, size_t
   SV_CATCH()
   SV_DONE(status)
 
-  return svi_rc_to_signed_video_rc(status);
+  return status;
 }

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -128,57 +128,6 @@ nalu_type_to_char(const h26x_nalu_t *nalu)
 }
 
 /* Declared in signed_video_internal.h */
-SignedVideoReturnCode
-svi_rc_to_signed_video_rc(svi_rc status)
-{
-  switch (status) {
-    case SV_OK:
-      return SV_OK;
-    case SV_MEMORY:
-      return SV_MEMORY;
-    case SV_NOT_SUPPORTED:
-      return SV_NOT_SUPPORTED;
-    case SV_INVALID_PARAMETER:
-      return SV_INVALID_PARAMETER;
-    case SV_INCOMPATIBLE_VERSION:
-      return SV_INCOMPATIBLE_VERSION;
-    case SV_AUTHENTICATION_ERROR:
-      return SV_AUTHENTICATION_ERROR;
-    case SV_EXTERNAL_ERROR:
-      return SV_EXTERNAL_ERROR;
-    case SV_VENDOR_ERROR:
-      return SV_VENDOR_ERROR;
-    default:
-      return SV_UNKNOWN_FAILURE;
-  }
-}
-
-svi_rc
-sv_rc_to_svi_rc(SignedVideoReturnCode status)
-{
-  switch (status) {
-    case SV_OK:
-      return SV_OK;
-    case SV_MEMORY:
-      return SV_MEMORY;
-    case SV_NOT_SUPPORTED:
-      return SV_NOT_SUPPORTED;
-    case SV_INVALID_PARAMETER:
-      return SV_INVALID_PARAMETER;
-    case SV_INCOMPATIBLE_VERSION:
-      return SV_INCOMPATIBLE_VERSION;
-    case SV_AUTHENTICATION_ERROR:
-      return SV_AUTHENTICATION_ERROR;
-    case SV_EXTERNAL_ERROR:
-      return SV_EXTERNAL_ERROR;
-    case SV_VENDOR_ERROR:
-      return SV_VENDOR_ERROR;
-    case SV_UNKNOWN_FAILURE:
-    default:
-      return SV_UNKNOWN_FAILURE;
-  }
-}
-
 // SEI UUID types
 const uint8_t kUuidSignedVideo[UUID_LEN] = {
     0x53, 0x69, 0x67, 0x6e, 0x65, 0x64, 0x20, 0x56, 0x69, 0x64, 0x65, 0x6f, 0x2e, 0x2e, 0x2e, 0x30};
@@ -1259,7 +1208,7 @@ signed_video_reset(signed_video_t *self)
   SV_CATCH()
   SV_DONE(status)
 
-  return svi_rc_to_signed_video_rc(status);
+  return status;
 }
 
 void

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -242,12 +242,6 @@ struct _gop_info_t {
 void
 bytes_to_version_str(const int *arr, char *str);
 
-SignedVideoReturnCode
-svi_rc_to_signed_video_rc(svi_rc status);
-
-svi_rc
-sv_rc_to_svi_rc(SignedVideoReturnCode status);
-
 svi_rc
 struct_member_memory_allocated_and_copy(void **member_ptr,
     uint8_t *member_size_ptr,

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -41,7 +41,7 @@
 
 #include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t
 #include "signed_video_defines.h"
-#include "signed_video_internal.h"  // svi_rc_to_signed_video_rc(), sv_rc_to_svi_rc()
+#include "signed_video_internal.h"  // MAX_HASH_SIZE
 #include "signed_video_openssl_internal.h"
 
 /**
@@ -141,7 +141,7 @@ openssl_private_key_malloc(sign_or_verify_data_t *sign_data,
 
   EVP_PKEY_free(signing_key);
 
-  return svi_rc_to_signed_video_rc(status);
+  return status;
 }
 
 /* Reads the |pem_public_key| which is expected to be on PEM form and creates an EVP_PKEY
@@ -271,7 +271,7 @@ openssl_sign_hash(sign_or_verify_data_t *sign_data)
   SV_CATCH()
   SV_DONE(status)
 
-  return svi_rc_to_signed_video_rc(status);
+  return status;
 }
 
 /* Verifies the |signature|. */
@@ -671,7 +671,7 @@ signed_video_generate_ecdsa_private_key(const char *dir_to_key,
     free(pem_key.key);
   }
 
-  return svi_rc_to_signed_video_rc(status);
+  return status;
 }
 
 SignedVideoReturnCode
@@ -697,7 +697,7 @@ signed_video_generate_rsa_private_key(const char *dir_to_key,
     free(pem_key.key);
   }
 
-  return svi_rc_to_signed_video_rc(status);
+  return status;
 }
 
 /* TO BE DEPRECATED */


### PR DESCRIPTION
Since the library no longer use internal return codes
mapping functions between them has been removed.
