### PR TITLE
Renames svi_rc to svrc_t

### DIFF
--- a/lib/src/signed_video_authenticity.c
+++ b/lib/src/signed_video_authenticity.c
@@ -29,13 +29,13 @@
 #include "signed_video_h26x_nalu_list.h"  // h26x_nalu_list_get_validation_str()
 
 /* Transfer functions. */
-static svi_rc
+static svrc_t
 transfer_latest_validation(signed_video_latest_validation_t *dst,
     const signed_video_latest_validation_t *src);
 static void
 transfer_accumulated_validation(signed_video_accumulated_validation_t *dst,
     const signed_video_accumulated_validation_t *src);
-static svi_rc
+static svrc_t
 transfer_authenticity(signed_video_authenticity_t *dst, const signed_video_authenticity_t *src);
 /* Init and update functions. */
 static void
@@ -54,7 +54,7 @@ signed_video_authenticity_report_create();
  * Helper functions.
  */
 
-svi_rc
+svrc_t
 allocate_memory_and_copy_string(char **dst_str, const char *src_str)
 {
   if (!dst_str) return SV_INVALID_PARAMETER;
@@ -85,14 +85,14 @@ catch_error:
  * Group of functions that performs transfer operations between structs.
  */
 
-svi_rc
+svrc_t
 transfer_product_info(signed_video_product_info_t *dst, const signed_video_product_info_t *src)
 {
   // For simplicity we allow nullptrs for both |dst| and |src|. If so, we take no action and return
   // SV_OK.
   if (!src || !dst) return SV_OK;
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW(allocate_memory_and_copy_string(&dst->hardware_id, src->hardware_id));
     SV_THROW(allocate_memory_and_copy_string(&dst->firmware_version, src->firmware_version));
@@ -105,13 +105,13 @@ transfer_product_info(signed_video_product_info_t *dst, const signed_video_produ
   return status;
 }
 
-static svi_rc
+static svrc_t
 transfer_latest_validation(signed_video_latest_validation_t *dst,
     const signed_video_latest_validation_t *src)
 {
   assert(dst && src);
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW(allocate_memory_and_copy_string(&dst->nalu_str, src->nalu_str));
     SV_THROW(allocate_memory_and_copy_string(&dst->validation_str, src->validation_str));
@@ -146,12 +146,12 @@ transfer_accumulated_validation(signed_video_accumulated_validation_t *dst,
   dst->last_timestamp = src->last_timestamp;
 }
 
-static svi_rc
+static svrc_t
 transfer_authenticity(signed_video_authenticity_t *dst, const signed_video_authenticity_t *src)
 {
   assert(dst && src);
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     strcpy(dst->version_on_signing_side, src->version_on_signing_side);
     strcpy(dst->this_version, SIGNED_VIDEO_VERSION);
@@ -310,7 +310,7 @@ signed_video_get_authenticity_report(signed_video_t *self)
 
   signed_video_authenticity_t *authenticity_report = signed_video_authenticity_report_create();
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW_IF(!authenticity_report, SV_MEMORY);
     // Update |number_of_pending_nalus| since that may have changed since |latest_validation|.
@@ -343,7 +343,7 @@ signed_video_get_authenticity_report(signed_video_t *self)
  * Functions to create and free authenticity reports and members.
  */
 
-svi_rc
+svrc_t
 create_local_authenticity_report_if_needed(signed_video_t *self)
 {
   if (!self) return SV_INVALID_PARAMETER;
@@ -351,7 +351,7 @@ create_local_authenticity_report_if_needed(signed_video_t *self)
   // Already exists, return SV_OK.
   if (self->authenticity) return SV_OK;
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     // Create a new one.
     signed_video_authenticity_t *auth_report = signed_video_authenticity_report_create();

--- a/lib/src/signed_video_authenticity.h
+++ b/lib/src/signed_video_authenticity.h
@@ -22,7 +22,7 @@
 #define __SIGNED_VIDEO_AUTHENTICITY_H__
 
 #include "includes/signed_video_auth.h"  // signed_video_product_info_t
-#include "signed_video_defines.h"  // svi_rc
+#include "signed_video_defines.h"  // svrc_t
 #include "signed_video_internal.h"
 
 /**
@@ -31,9 +31,9 @@
  * @param dst The signed_video_product_info_t struct of which to write to
  * @param src The signed_video_product_info_t struct of which to read from
  *
- * @returns A Signed Video Internal Return Code (svi_rc)
+ * @returns A Signed Video Return Code
  */
-svi_rc
+svrc_t
 transfer_product_info(signed_video_product_info_t *dst, const signed_video_product_info_t *src);
 
 /**
@@ -64,9 +64,9 @@ accumulated_validation_init(signed_video_accumulated_validation_t *self);
  *
  * @param self The current Signed Video session
  *
- * @returns A Signed Video Internal Return Code (svi_rc)
+ * @returns A Signed Video Return Code
  */
-svi_rc
+svrc_t
 create_local_authenticity_report_if_needed(signed_video_t *self);
 
 /**
@@ -78,9 +78,9 @@ create_local_authenticity_report_if_needed(signed_video_t *self);
  * @param dst_str A pointer holding a pointer to the copied string. Memory is allocated if needed.
  * @param src_str The null-terminated string to copy. A NULL pointer copies "".
  *
- * @returns A Signed Video Internal Return Code (svi_rc)
+ * @returns A Signed Video Return Code
  */
-svi_rc
+svrc_t
 allocate_memory_and_copy_string(char **dst_str, const char *src_str);
 
 void

--- a/lib/src/signed_video_defines.h
+++ b/lib/src/signed_video_defines.h
@@ -25,7 +25,7 @@
 
 #include "includes/signed_video_common.h"  // SignedVideoReturnCode
 
-typedef SignedVideoReturnCode svi_rc;
+typedef SignedVideoReturnCode svrc_t;
 
 // Semicolon needed after, ex. DEBUG_LOG("my debug: %d", 42);
 #ifdef SIGNED_VIDEO_DEBUG
@@ -58,7 +58,7 @@ typedef SignedVideoReturnCode svi_rc;
  * SV_THROW_IF(fail_condition, fail_status)
  *     checks |fail_condition| and throws a |fail_status| error.
  * SV_THROW(my_status)
- *     same as SV_THROW_IF(), but with the difference that a svi_rc check is assumed, that is,
+ *     same as SV_THROW_IF(), but with the difference that a svrc_t check is assumed, that is,
  *     simplification of SV_THROW_IF(my_status != SV_OK, my_status)
  *
  * The THROW macros has a version to print a specific error message |fail_msg| upon failure.
@@ -77,19 +77,19 @@ typedef SignedVideoReturnCode svi_rc;
  *
  * Example code:
  *
- * svi_rc
+ * svrc_t
  * example_function(my_struct_t **output_parameter)
  * {
  *   if (!output_parameter) return SV_INVALID_PARAMETER;
  *
  *   my_struct_t *a = NULL;
- *   svi_rc status = SV_UNKNOWN_FAILURE;  // Initiate to something that fails
+ *   svrc_t status = SV_UNKNOWN_FAILURE;  // Initiate to something that fails
  *   SV_TRY()
  *     a = malloc(sizeof(my_struct_t));
  *     SV_THROW_IF(!a, SV_MEMORY);  // Throw without message
  *
  *     int b = -1;
- *     // get_b_value() returns svi_rc
+ *     // get_b_value() returns svrc_t
  *     SV_THROW_WITH_MSG(get_b_value(&b), "Could not get b");
  *
  *     a->b = b;
@@ -105,7 +105,7 @@ typedef SignedVideoReturnCode svi_rc;
  * }
  */
 #define SV_TRY() \
-  svi_rc status_; \
+  svrc_t status_; \
   bool status_set_ = false;
 #define SV_CATCH() \
   catch_error: \

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -23,7 +23,7 @@
 
 #include <stdbool.h>  // bool
 
-#include "signed_video_defines.h"  // svi_rc
+#include "signed_video_defines.h"  // svrc_t
 #include "signed_video_internal.h"  // gop_info_t, gop_state_t, MAX_HASH_SIZE
 
 typedef struct _h26x_nalu_list_item_t h26x_nalu_list_item_t;
@@ -173,7 +173,7 @@ gop_state_reset(gop_state_t *gop_state);
 void
 update_num_nalus_in_gop_hash(signed_video_t *signed_video, const h26x_nalu_t *nalu);
 
-svi_rc
+svrc_t
 update_gop_hash(void *crypto_handle, gop_info_t *gop_info);
 
 void
@@ -181,10 +181,10 @@ check_and_copy_hash_to_hash_list(signed_video_t *signed_video,
     const uint8_t *hash,
     size_t hash_size);
 
-svi_rc
+svrc_t
 hash_and_add(signed_video_t *signed_video, const h26x_nalu_t *nalu);
 
-svi_rc
+svrc_t
 hash_and_add_for_auth(signed_video_t *signed_video, h26x_nalu_list_item_t *item);
 
 h26x_nalu_t

--- a/lib/src/signed_video_h26x_nalu_list.c
+++ b/lib/src/signed_video_h26x_nalu_list.c
@@ -293,7 +293,7 @@ h26x_nalu_list_free_items(h26x_nalu_list_t *list)
 
 /* Appends the |last_item| of the |list| with a new item. The new item has a pointer to |nalu|, but
  * does not take ownership of it. */
-svi_rc
+svrc_t
 h26x_nalu_list_append(h26x_nalu_list_t *list, const h26x_nalu_t *nalu)
 {
   if (!list || !nalu) return SV_INVALID_PARAMETER;
@@ -315,7 +315,7 @@ h26x_nalu_list_append(h26x_nalu_list_t *list, const h26x_nalu_t *nalu)
  * not needed are set to NULL, since no ownership is transferred. The ownership of |nalu| is
  * released. If the |nalu| could not be copied it will be a NULL pointer. If hash algo is
  * not known the |hashable_data| is copied so the NALU can be hashed later. */
-svi_rc
+svrc_t
 h26x_nalu_list_copy_last_item(h26x_nalu_list_t *list, bool hash_algo_known)
 {
   if (!list) return SV_INVALID_PARAMETER;
@@ -325,7 +325,7 @@ h26x_nalu_list_copy_last_item(h26x_nalu_list_t *list, bool hash_algo_known)
   uint8_t *nalu_data_wo_epb = NULL;
   h26x_nalu_list_item_t *item = list->last_item;
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW_IF(!item->nalu, SV_UNKNOWN_FAILURE);
     copied_nalu = (h26x_nalu_t *)malloc(sizeof(h26x_nalu_t));
@@ -367,7 +367,7 @@ h26x_nalu_list_copy_last_item(h26x_nalu_list_t *list, bool hash_algo_known)
 }
 
 /* Append or prepend the |item| of the |list| with |num_missing| NALUs. */
-svi_rc
+svrc_t
 h26x_nalu_list_add_missing(h26x_nalu_list_t *list,
     int num_missing,
     bool append,
@@ -378,7 +378,7 @@ h26x_nalu_list_add_missing(h26x_nalu_list_t *list,
 
   int added_items = 0;
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     for (added_items = 0; added_items < num_missing; added_items++) {
       h26x_nalu_list_item_t *missing_nalu = h26x_nalu_list_item_create(NULL);

--- a/lib/src/signed_video_h26x_nalu_list.h
+++ b/lib/src/signed_video_h26x_nalu_list.h
@@ -69,7 +69,7 @@ h26x_nalu_list_free_items(h26x_nalu_list_t* list);
  *
  * @returns Signed Video Internal Return Code
  */
-svi_rc
+svrc_t
 h26x_nalu_list_append(h26x_nalu_list_t* list, const h26x_nalu_t* nalu);
 
 /**
@@ -84,7 +84,7 @@ h26x_nalu_list_append(h26x_nalu_list_t* list, const h26x_nalu_t* nalu);
  *
  * @returns Signed Video Internal Return Code
  */
-svi_rc
+svrc_t
 h26x_nalu_list_copy_last_item(h26x_nalu_list_t* list, bool hash_algo_known);
 
 /**
@@ -101,7 +101,7 @@ h26x_nalu_list_copy_last_item(h26x_nalu_list_t* list, bool hash_algo_known);
  *
  * @returns Signed Video Internal Return Code
  */
-svi_rc
+svrc_t
 h26x_nalu_list_add_missing(h26x_nalu_list_t* list,
     int num_missing,
     bool append,

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -29,7 +29,7 @@
 #include "includes/signed_video_common.h"  // signed_video_t
 #include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t
 #include "includes/signed_video_sign.h"  // SignedVideoAuthenticityLevel
-#include "signed_video_defines.h"  // svi_rc, sv_tlv_tag_t
+#include "signed_video_defines.h"  // svrc_t, sv_tlv_tag_t
 
 typedef struct _gop_info_t gop_info_t;
 typedef struct _validation_flags_t validation_flags_t;
@@ -242,7 +242,7 @@ struct _gop_info_t {
 void
 bytes_to_version_str(const int *arr, char *str);
 
-svi_rc
+svrc_t
 struct_member_memory_allocated_and_copy(void **member_ptr,
     uint8_t *member_size_ptr,
     const void *new_data_ptr,
@@ -253,11 +253,11 @@ gop_info_reset(gop_info_t *gop_info);
 
 /* Sets the allowed size of |hash_list|.
  * Note that this can be different from what is allocated. */
-svi_rc
+svrc_t
 set_hash_list_size(gop_info_t *gop_info, size_t hash_list_size);
 
 /* Resets the gop_hash. */
-svi_rc
+svrc_t
 reset_gop_hash(signed_video_t *signed_video);
 
 void

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -26,7 +26,7 @@
 #include <string.h>  // size_t
 
 #include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t
-#include "signed_video_defines.h"  // svi_rc
+#include "signed_video_defines.h"  // svrc_t
 
 /**
  * @brief Create cryptographic handle
@@ -62,7 +62,7 @@ openssl_free_handle(void *handle);
  * @returns SV_OK Successfully set hash algorithm,
  *          SV_INVALID_PARAMETER Null pointer |handle| or invalid |name_or_oid|.
  */
-svi_rc
+svrc_t
 openssl_set_hash_algo(void *handle, const char *name_or_oid);
 
 /**
@@ -77,7 +77,7 @@ openssl_set_hash_algo(void *handle, const char *name_or_oid);
  * @returns SV_OK Successfully set hash algorithm,
  *          Other appropriate error.
  */
-svi_rc
+svrc_t
 openssl_set_hash_algo_by_encoded_oid(void *handle,
     const unsigned char *encoded_oid,
     size_t encoded_oid_size);
@@ -126,7 +126,7 @@ openssl_get_hash_size(void *handle);
  *          SV_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
  *          SV_EXTERNAL_ERROR Failed to hash.
  */
-svi_rc
+svrc_t
 openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *hash);
 
 /**
@@ -140,7 +140,7 @@ openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *
  *          SV_INVALID_PARAMETER Null pointer input,
  *          SV_EXTERNAL_ERROR Failed to initialize.
  */
-svi_rc
+svrc_t
 openssl_init_hash(void *handle);
 
 /**
@@ -157,7 +157,7 @@ openssl_init_hash(void *handle);
  *          SV_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
  *          SV_EXTERNAL_ERROR Failed to update.
  */
-svi_rc
+svrc_t
 openssl_update_hash(void *handle, const uint8_t *data, size_t data_size);
 
 /**
@@ -173,7 +173,7 @@ openssl_update_hash(void *handle, const uint8_t *data, size_t data_size);
  *          SV_INVALID_PARAMETER Null pointer inputs,
  *          SV_EXTERNAL_ERROR Failed to finalize.
  */
-svi_rc
+svrc_t
 openssl_finalize_hash(void *handle, uint8_t *hash);
 
 /**
@@ -189,7 +189,7 @@ openssl_finalize_hash(void *handle, uint8_t *hash);
  * @returns SV_OK Successfully generated |signature|,
  *          SV_INVALID_PARAMETER Errors in |verify_data|, or null pointer inputs,
  */
-svi_rc
+svrc_t
 openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_result);
 
 /**
@@ -206,7 +206,7 @@ openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_resu
  *          SV_MEMORY Could not allocate memory for |key|,
  *          SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
-svi_rc
+svrc_t
 openssl_read_pubkey_from_private_key(sign_or_verify_data_t *sign_data, pem_pkey_t *pem_pkey);
 
 /**
@@ -223,7 +223,7 @@ openssl_read_pubkey_from_private_key(sign_or_verify_data_t *sign_data, pem_pkey_
  *          SV_INVALID_PARAMETER Missing inputs,
  *          SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
-svi_rc
+svrc_t
 openssl_public_key_malloc(sign_or_verify_data_t *verify_data, pem_pkey_t *pem_public_key);
 
 #endif  // __SIGNED_VIDEO_OPENSSL_INTERNAL__

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -53,51 +53,51 @@ typedef size_t (*sv_tlv_encoder_t)(signed_video_t *, uint8_t *);
  *
  * @returns SV_OK if successful otherwise an error code.
  */
-typedef svi_rc (*sv_tlv_decoder_t)(signed_video_t *, const uint8_t *, size_t);
+typedef svrc_t (*sv_tlv_decoder_t)(signed_video_t *, const uint8_t *, size_t);
 
 /**
  * Declarations of encoder and decoder implementations.
  */
 static size_t
 encode_general(signed_video_t *self, uint8_t *data);
-static svi_rc
+static svrc_t
 decode_general(signed_video_t *self, const uint8_t *data, size_t data_size);
 
 static size_t
 encode_public_key(signed_video_t *self, uint8_t *data);
-static svi_rc
+static svrc_t
 decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size);
 
 static size_t
 encode_arbitrary_data(signed_video_t *self, uint8_t *data);
-static svi_rc
+static svrc_t
 decode_arbitrary_data(signed_video_t *self, const uint8_t *data, size_t data_size);
 
 static size_t
 encode_product_info(signed_video_t *self, uint8_t *data);
-static svi_rc
+static svrc_t
 decode_product_info(signed_video_t *self, const uint8_t *data, size_t data_size);
 
 static size_t
 encode_hash_list(signed_video_t *self, uint8_t *data);
-static svi_rc
+static svrc_t
 decode_hash_list(signed_video_t *self, const uint8_t *data, size_t data_size);
 
 static size_t
 encode_signature(signed_video_t *self, uint8_t *data);
-static svi_rc
+static svrc_t
 decode_signature(signed_video_t *self, const uint8_t *data, size_t data_size);
 
 static size_t
 encode_crypto_info(signed_video_t *self, uint8_t *data);
-static svi_rc
+static svrc_t
 decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size);
 
 // Vendor specific encoders and decoders. Serves as wrappers of vendor specific calls with
 // |vendor_handle| as input.
 static size_t
 encode_axis_communications(signed_video_t *self, uint8_t *data);
-static svi_rc
+static svrc_t
 decode_axis_communications(signed_video_t *self, const uint8_t *data, size_t data_size);
 
 /**
@@ -175,7 +175,7 @@ static sv_tlv_decoder_t
 get_decoder(sv_tlv_tag_t tag);
 static sv_tlv_tuple_t
 get_tlv_tuple(sv_tlv_tag_t tag);
-static svi_rc
+static svrc_t
 decode_tlv_header(const uint8_t *data, size_t *read_data_bytes, sv_tlv_tag_t *tag, size_t *length);
 
 /* Selects and returns the correct decoder from either |tlv_tuples| or |vendor_tlv_tuples|. */
@@ -280,7 +280,7 @@ encode_general(signed_video_t *self, uint8_t *data)
 /**
  * @brief Decodes the GENERAL_TAG from data
  */
-static svi_rc
+static svrc_t
 decode_general(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
   if (!self || !data) return SV_INVALID_PARAMETER;
@@ -288,7 +288,7 @@ decode_general(signed_video_t *self, const uint8_t *data, size_t data_size)
   const uint8_t *data_ptr = data;
   gop_info_t *gop_info = self->gop_info;
   uint8_t version = *data_ptr++;
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
 
   SV_TRY()
     SV_THROW_IF(version == 0, SV_INCOMPATIBLE_VERSION);
@@ -462,12 +462,12 @@ encode_product_info(signed_video_t *self, uint8_t *data)
  * @param data_size Size of this TLV
  * @param self Session struct
  */
-static svi_rc
+static svrc_t
 decode_product_info(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
   const uint8_t *data_ptr = data;
   uint8_t version = *data_ptr++;
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
 
   if (!self || !self->product_info) return SV_INVALID_PARAMETER;
 
@@ -544,13 +544,13 @@ encode_arbitrary_data(signed_video_t *self, uint8_t *data)
  * @brief Decodes the ARBITRARY_DATA_TAG from data
  *
  */
-static svi_rc
+static svrc_t
 decode_arbitrary_data(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
   const uint8_t *data_ptr = data;
   uint8_t version = *data_ptr++;
   uint16_t arbdata_size = (uint16_t)(data_size - 1);
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
 
   SV_TRY()
     SV_THROW_IF(version == 0, SV_INCOMPATIBLE_VERSION);
@@ -622,7 +622,7 @@ encode_public_key(signed_video_t *self, uint8_t *data)
  * @brief Decodes the PUBLIC_KEY_TAG from data
  *
  */
-static svi_rc
+static svrc_t
 decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
   const uint8_t *data_ptr = data;
@@ -637,7 +637,7 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
     pubkey_size -= 1;
   }
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW_IF(version == 0, SV_INCOMPATIBLE_VERSION);
     SV_THROW_IF(pubkey_size == 0, SV_AUTHENTICATION_ERROR);
@@ -722,14 +722,14 @@ encode_hash_list(signed_video_t *self, uint8_t *data)
  * @brief Decodes the HASH_LIST_TAG from data
  *
  */
-static svi_rc
+static svrc_t
 decode_hash_list(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
   const uint8_t *data_ptr = data;
   uint8_t version = *data_ptr++;
   size_t hash_list_size = data_size - (data_ptr - data);
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW_IF(version == 0, SV_INCOMPATIBLE_VERSION);
     SV_THROW_IF_WITH_MSG(
@@ -813,7 +813,7 @@ encode_signature(signed_video_t *self, uint8_t *data)
  * @brief Decodes the SIGNATURE_TAG from data
  *
  */
-static svi_rc
+static svrc_t
 decode_signature(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
   const uint8_t *data_ptr = data;
@@ -831,7 +831,7 @@ decode_signature(signed_video_t *self, const uint8_t *data, size_t data_size)
   // The rest should now be the allocated size for the signature.
   max_signature_size = data_size - (data_ptr - data);
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
 
   SV_TRY()
     SV_THROW_IF(version == 0, SV_INCOMPATIBLE_VERSION);
@@ -910,7 +910,7 @@ encode_crypto_info(signed_video_t *self, uint8_t *data)
  * @brief Decodes the CRYPTO_INFO_TAG from data
  *
  */
-static svi_rc
+static svrc_t
 decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
   const uint8_t *data_ptr = data;
@@ -918,7 +918,7 @@ decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size)
   size_t hash_algo_encoded_oid_size = *data_ptr++;
   const unsigned char *hash_algo_encoded_oid = (const unsigned char *)data_ptr;
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW_IF(version == 0, SV_INCOMPATIBLE_VERSION);
     SV_THROW_IF(hash_algo_encoded_oid_size == 0, SV_AUTHENTICATION_ERROR);
@@ -959,7 +959,7 @@ encode_axis_communications(signed_video_t ATTR_UNUSED *self, uint8_t ATTR_UNUSED
  * @brief Decodes the VENDOR_AXIS_COMMUNICATIONS_TAG from data
  *
  */
-static svi_rc
+static svrc_t
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
 decode_axis_communications(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
@@ -1052,7 +1052,7 @@ tlv_list_encode_or_get_size(signed_video_t *self,
   return tlv_list_size;
 }
 
-static svi_rc
+static svrc_t
 decode_tlv_header(const uint8_t *data, size_t *read_data_bytes, sv_tlv_tag_t *tag, size_t *length)
 {
   // Sanity checks on input parameters.
@@ -1079,10 +1079,10 @@ decode_tlv_header(const uint8_t *data, size_t *read_data_bytes, sv_tlv_tag_t *ta
   return SV_OK;
 }
 
-svi_rc
+svrc_t
 tlv_decode(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
-  svi_rc status = SV_INVALID_PARAMETER;
+  svrc_t status = SV_INVALID_PARAMETER;
   const uint8_t *data_ptr = data;
 
   if (!self || !data || data_size == 0) return SV_INVALID_PARAMETER;
@@ -1151,7 +1151,7 @@ tlv_find_and_decode_recurrent_tags(signed_video_t *self,
 
   if (!self || !tlv_data || tlv_data_size == 0) return false;
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   bool recurrent_tags_decoded = false;
   while (tlv_data_ptr < tlv_data + tlv_data_size) {
     size_t tlv_header_size = 0;

--- a/lib/src/signed_video_tlv.h
+++ b/lib/src/signed_video_tlv.h
@@ -26,7 +26,7 @@
 #include <string.h>  // size_t
 
 #include "includes/signed_video_common.h"  // signed_video_t
-#include "signed_video_defines.h"  // svi_rc, sv_tlv_tag_t
+#include "signed_video_defines.h"  // svrc_t, sv_tlv_tag_t
 
 /**
  * @brief Encodes a SEI-nalu payload defined by a list of tags.
@@ -59,7 +59,7 @@ tlv_list_encode_or_get_size(signed_video_t *signed_video,
  *
  * @returns SV_OK if decoding was successful, otherwise an error code.
  */
-svi_rc
+svrc_t
 tlv_decode(signed_video_t *signed_video, const uint8_t *data, size_t data_size);
 
 /**

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -124,13 +124,13 @@ typedef struct _sv_vendor_axis_communications_t {
 } sv_vendor_axis_communications_t;
 
 // Declarations of static functions.
-static svi_rc
+static svrc_t
 verify_certificate_chain(X509 *trusted_ca, STACK_OF(X509) * untrusted_certificates);
-static svi_rc
+static svrc_t
 verify_and_parse_certificate_chain(sv_vendor_axis_communications_t *self);
-static svi_rc
+static svrc_t
 deserialize_attestation(sv_vendor_axis_communications_t *self);
-static svi_rc
+static svrc_t
 verify_axis_communications_public_key(sv_vendor_axis_communications_t *self);
 static size_t
 get_untrusted_certificates_size(const sv_vendor_axis_communications_t *self);
@@ -141,7 +141,7 @@ get_untrusted_certificates_size(const sv_vendor_axis_communications_t *self);
  *
  * Uses the |trusted_ca| to verify the first certificate in the chain. The last certificate verified
  * is the |attestation_certificate| which will be used to verify the transmitted public key. */
-static svi_rc
+static svrc_t
 verify_certificate_chain(X509 *trusted_ca, STACK_OF(X509) * untrusted_certificates)
 {
   assert(trusted_ca && untrusted_certificates);
@@ -149,7 +149,7 @@ verify_certificate_chain(X509 *trusted_ca, STACK_OF(X509) * untrusted_certificat
   X509_STORE *trust_store = NULL;
   X509_STORE_CTX *ctx = NULL;
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     trust_store = X509_STORE_new();
     SV_THROW_IF(!trust_store, SV_EXTERNAL_ERROR);
@@ -187,7 +187,7 @@ verify_certificate_chain(X509 *trusted_ca, STACK_OF(X509) * untrusted_certificat
  * If all goes well, ownership of |md_ctx| is transfered to |self|. Anything that does not follow
  * the expected format will return SV_VENDOR_ERROR.
  */
-static svi_rc
+static svrc_t
 verify_and_parse_certificate_chain(sv_vendor_axis_communications_t *self)
 {
   if (!self || !self->certificate_chain) return SV_INVALID_PARAMETER;
@@ -204,7 +204,7 @@ verify_and_parse_certificate_chain(sv_vendor_axis_communications_t *self)
   // Remove the old message digest context.
   EVP_MD_CTX_free(self->md_ctx);
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     // Create an empty stack of X509 certificates.
     untrusted_certificates = sk_X509_new_null();
@@ -307,7 +307,7 @@ verify_and_parse_certificate_chain(sv_vendor_axis_communications_t *self)
  *     - timestamp (12 bytes)
  *     - signature_size (2 bytes)
  *     - signature (|signature_size| bytes) */
-static svi_rc
+static svrc_t
 deserialize_attestation(sv_vendor_axis_communications_t *self)
 {
   assert(self);
@@ -368,7 +368,7 @@ deserialize_attestation(sv_vendor_axis_communications_t *self)
  *   - attributes
  *   - timestamp
  */
-static svi_rc
+static svrc_t
 verify_axis_communications_public_key(sv_vendor_axis_communications_t *self)
 {
   assert(self);
@@ -380,7 +380,7 @@ verify_axis_communications_public_key(sv_vendor_axis_communications_t *self)
   // Initiate verification to not feasible/error.
   int verified_signature = -1;
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     // If no message digest context exists, the |public_key| cannot be validated.
     SV_THROW_IF(!self->md_ctx, SV_VENDOR_ERROR);
@@ -599,7 +599,7 @@ encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, bool e
 }
 
 /* Decodes the TLV tag VENDOR_AXIS_COMMUNICATIONS_TAG to the handle data. */
-svi_rc
+svrc_t
 decode_axis_communications_handle(void *handle, const uint8_t *data, size_t data_size)
 {
   if (!handle) return SV_INVALID_PARAMETER;
@@ -610,7 +610,7 @@ decode_axis_communications_handle(void *handle, const uint8_t *data, size_t data
   uint8_t attestation_size = 0;
   size_t cert_size = 0;
 
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW_IF(version != 1, SV_INCOMPATIBLE_VERSION);
     // Read |attestation_size|.
@@ -656,7 +656,7 @@ decode_axis_communications_handle(void *handle, const uint8_t *data, size_t data
   return status;
 }
 
-svi_rc
+svrc_t
 set_axis_communications_public_key(void *handle,
     const void *public_key,
     bool public_key_has_changed)
@@ -679,7 +679,7 @@ set_axis_communications_public_key(void *handle,
   }
 
   int public_key_validation = self->supplemental_authenticity.public_key_validation;
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     // Validate that the public key is of correct type and size.
     SV_THROW_IF(!pkey, SV_EXTERNAL_ERROR);
@@ -708,7 +708,7 @@ set_axis_communications_public_key(void *handle,
   return status;
 }
 
-svi_rc
+svrc_t
 get_axis_communications_supplemental_authenticity(void *handle,
     sv_vendor_axis_supplemental_authenticity_t **supplemental_authenticity)
 {
@@ -717,7 +717,7 @@ get_axis_communications_supplemental_authenticity(void *handle,
   sv_vendor_axis_communications_t *self = (sv_vendor_axis_communications_t *)handle;
 
   // TODO: Fill in the skeleton below step by step.
-  svi_rc status = SV_UNKNOWN_FAILURE;
+  svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW(verify_and_parse_certificate_chain(self));
     SV_THROW(deserialize_attestation(self));

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "signed_video_defines.h"  // svi_rc
+#include "signed_video_defines.h"  // svrc_t
 
 #define SV_VENDOR_AXIS_SER_NO_MAX_LENGTH 20
 /**
@@ -90,7 +90,7 @@ encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, bool e
  *
  * @returns An internal return code to catch potential errors.
  */
-svi_rc
+svrc_t
 decode_axis_communications_handle(void *handle, const uint8_t *data, size_t data_size);
 
 /**
@@ -104,7 +104,7 @@ decode_axis_communications_handle(void *handle, const uint8_t *data, size_t data
  *
  * @returns An internal return code to catch potential errors.
  */
-svi_rc
+svrc_t
 set_axis_communications_public_key(void *handle,
     void const *public_key,
     bool public_key_has_changed);
@@ -121,7 +121,7 @@ set_axis_communications_public_key(void *handle,
  *
  * @returns An internal return code to catch potential errors.
  */
-svi_rc
+svrc_t
 get_axis_communications_supplemental_authenticity(void *handle,
     sv_vendor_axis_supplemental_authenticity_t **supplemental_authenticity);
 


### PR DESCRIPTION
The typedef svrc_t is the same as SignedVideoReturnCode, but
should be used with the distinction between internal and public
interfaces.
