### PR TITLE
Removes signing_present

### DIFF
--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -1157,8 +1157,6 @@ signed_video_create(SignedVideoCodec codec)
 
     self->last_two_bytes = LAST_TWO_BYTES_INIT_VALUE;
 
-    self->signing_present = -1;
-
     // Initialize validation members
     self->nalu_list = h26x_nalu_list_create();
     // No need to check if |nalu_list| is a nullptr, since it is only of importance on the

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -495,7 +495,6 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
   }
 
   sign_or_verify_data_t *sign_data = self->sign_data;
-  int signing_present = self->signing_present;
 
   svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
@@ -528,7 +527,6 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
 
       uint8_t *payload = NULL;
       uint8_t *payload_signature_ptr = NULL;
-      signing_present = 0;  // About to add SEI NALUs.
 
       SV_THROW(generate_sei_nalu(self, &payload, &payload_signature_ptr));
       // Add |payload| to buffer. Will be picked up again when the signature has been generated.
@@ -569,7 +567,6 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
         SV_THROW_IF_WITH_MSG(verified != 1, SV_EXTERNAL_ERROR, "Verification test failed");
 #endif
         SV_THROW(complete_sei_nalu_and_add_to_prepend(self));
-        signing_present = 1;  // At least one SEI NALU present.
       }
     }
 
@@ -577,8 +574,6 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
   SV_DONE(status)
 
   free(nalu.nalu_data_wo_epb);
-
-  if (signing_present > self->signing_present) self->signing_present = signing_present;
 
   return status;
 }

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -163,14 +163,6 @@ struct _signed_video_t {
   int sei_data_buffer_idx;
   int num_of_completed_seis;
 
-  // TODO: Remove this member. It is not used after adding a flag in |validation_flags|
-  int signing_present;
-  // State to indicate if Signed Video is present or not. Used for signing, and can only move
-  // downwards between the states below.
-  // -1 : Initialized value. No NALUs processed yet.
-  // 0 : Signed Video information so far not present.
-  // 1 : Signed Video information is present.
-
   // Members only used for validation
   // TODO: Collect everything needed by the authentication part only in one struct/object, which
   // then is not needed to be created on the signing side, saving some memory.


### PR DESCRIPTION
The member in signed_video_t is not used anywhere, since it
is part of validation_flags.
