### PR TITLE
Test function for getting initialized session has changed

### DIFF
--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -940,6 +940,7 @@ decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size)
         self->crypto_handle, hash_algo_encoded_oid, hash_algo_encoded_oid_size));
     self->validation_flags.hash_algo_known = true;
     self->verify_data->hash_size = openssl_get_hash_size(self->crypto_handle);
+    self->gop_info->nalu_hash = self->gop_info->hashes + self->verify_data->hash_size;
     data_ptr += hash_algo_encoded_oid_size;
 
     SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1632,12 +1632,10 @@ START_TEST(fallback_to_gop_level)
   // |settings|; See signed_video_helpers.h.
 
   const size_t kFallbackSize = 10;
-  signed_video_t *sv =
-      get_initialized_signed_video(settings[_i].codec, settings[_i].generate_key, false);
+  signed_video_t *sv = get_initialized_signed_video(settings[_i], false);
   ck_assert(sv);
-  ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
   // If the true hash size is different from the default one, the test should still pass.
-  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * DEFAULT_HASH_SIZE), SV_OK);
+  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * MAX_HASH_SIZE), SV_OK);
 
   // Create a list of NAL Units given the input string.
   test_stream_t *list = create_signed_nalus_with_sv(sv, "IPPIPPPPPPPPPPPPPPPPPPPPPPPPIPPI", false);

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -580,12 +580,10 @@ START_TEST(fallback_to_gop_level)
   if (settings[_i].auth_level != SV_AUTHENTICITY_LEVEL_FRAME) return;
 
   const size_t kFallbackSize = 10;
-  signed_video_t *sv =
-      get_initialized_signed_video(settings[_i].codec, settings[_i].generate_key, false);
+  signed_video_t *sv = get_initialized_signed_video(settings[_i], false);
   ck_assert(sv);
-  ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
   // If the true hash size is different from the default one, the test should still pass.
-  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * DEFAULT_HASH_SIZE), SV_OK);
+  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * MAX_HASH_SIZE), SV_OK);
 
   // Create a test stream given the input string.
   test_stream_t *list = create_signed_nalus_with_sv(sv, "IPPIPPPPPPPPPPPPPPPPPPPPPPPPI", false);

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -60,16 +60,12 @@ extern const char *axisDummyCertificateChain;
 
 extern const int64_t g_testTimestamp;
 
-/* Creates a signed_video_t session and initialize it by setting
- * 1. a private key
- * 2. product info strings
+/* Creates a signed_video_t session and initialize it from settings
  *
  * new_private_key = Generate a new private key, otherwise read from an existing file.
  * This is useful for testing the signing part and generating a signed stream of nalus. */
 signed_video_t *
-get_initialized_signed_video(SignedVideoCodec codec,
-    generate_key_fcn_t generate_key,
-    bool new_private_key);
+get_initialized_signed_video(struct sv_setting settings, bool new_private_key);
 
 /* See function create_signed_nalus_int */
 test_stream_t *


### PR DESCRIPTION
Now it fully relies on the setting and makes all necessary
changes to it.

Also, fixes a bug when using other hashes than the default one.
The NALU hash position is now correctly updated upon decoding the
crypto tag.
