### PR TITLE
Change computation of GOP hash

### DIFF
--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -190,6 +190,9 @@ hash_and_add_for_auth(signed_video_t *signed_video, h26x_nalu_list_item_t *item)
 svrc_t
 compute_partial_gop_hash(signed_video_t *self);
 
+svrc_t
+compute_partial_gop_hash_for_auth(signed_video_t *self);
+
 h26x_nalu_t
 parse_nalu_info(const uint8_t *nalu_data,
     size_t nalu_data_size,

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -214,7 +214,7 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
   // Reset |signature_hash_type| to |GOP_HASH|. If the |hash_list| is successfully added,
   // |signature_hash_type| is changed to |DOCUMENT_HASH|.
   // If it is golden SEI hash type should be |DOCUMENT_HASH|.
-  self->gop_info->signature_hash_type = !self->is_golden_sei ? GOP_HASH : DOCUMENT_HASH;
+  self->gop_info->signature_hash_type =  DOCUMENT_HASH;
 
   svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
@@ -298,6 +298,7 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
     reserved_byte |= self->is_golden_sei << 6;
     reserved_byte |= self->linked_hash_on << 5;
     reserved_byte |= !self->gop_hash_off << 4;
+    reserved_byte |= self->linked_hash_on << 5;
     *payload_ptr++ = reserved_byte;
 
     size_t written_size = 0;

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -201,6 +201,7 @@ struct _signed_video_t {
 
   // Legacy validation
   legacy_sv_t *legacy_sv;
+  bool sv_test_on;
 };
 
 typedef enum { GOP_HASH = 0, DOCUMENT_HASH = 1, NUM_HASH_TYPES } hash_type_t;
@@ -246,6 +247,7 @@ struct _gop_info_t {
   // detected.
   int verified_signature_hash;  // Status of last hash-signature-pair verification. Has 1 for
   // success, 0 for fail, and -1 for error.
+  bool verified_gop_hash;
   bool has_timestamp;  // True if timestamp exists and has not yet been written to SEI.
   int64_t timestamp;  // Unix epoch UTC timestamp of the first nalu in GOP
 


### PR DESCRIPTION
Instead of computing GOP hash with recursive hash, it is extracted from
the signature. To validate, recompute with the stream and compare against
the received hash from the signature.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
