### PR TITLE
Adds a meson option to print decoded SEIs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,9 @@ endif
 if get_option('debugprints')
   add_global_arguments('-DSIGNED_VIDEO_DEBUG', language : 'c')
 endif
+if get_option('parsesei')
+  add_global_arguments('-DPRINT_DECODED_SEI', language : 'c')
+endif
 
 build_with_axis = ('axis-communications' in get_option('vendors')) or ('all' in get_option('vendors'))
 if build_with_axis

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,3 +11,7 @@ option('vendors',
   choices : [ 'all', 'axis-communications' ],
   value : [ 'all' ],
   description : 'Select vendor(s) to support. By default all vendors are added. Set an empty list \'-Dvendors=\' if the library should be built without vendors.')
+option('parsesei',
+  type : 'boolean',
+  value : false,
+  description : 'Parse SEI frames')


### PR DESCRIPTION
This option enables printing by setting a compile time define;
PRINT_DECODED_SEI. No prints have yet been implemented.
