### PR TITLE
Implements signed_video_parse_sei(...)

### DIFF
--- a/lib/src/includes/signed_video_helpers.h
+++ b/lib/src/includes/signed_video_helpers.h
@@ -1,0 +1,33 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2021 Axis Communications AB
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next paragraph) shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __SIGNED_VIDEO_HELPERS_H__
+#define __SIGNED_VIDEO_HELPERS_H__
+
+#include <stdint.h>  // uint8_t
+#include <stdlib.h>  // size_t
+
+#include "signed_video_common.h"
+
+void
+signed_video_parse_sei(uint8_t *nalu, size_t nalu_size, SignedVideoCodec codec);
+
+#endif  // __SIGNED_VIDEO_HELPERS_H__

--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -1,6 +1,7 @@
 signedvideoframework_public_headers = files(
   'includes/signed_video_auth.h',
   'includes/signed_video_common.h',
+  'includes/signed_video_helpers.h',
   'includes/signed_video_interfaces.h',
   'includes/signed_video_openssl.h',
   'includes/signed_video_sign.h',

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -1348,7 +1348,7 @@ signed_video_is_golden_sei(signed_video_t *self, const uint8_t *nalu, size_t nal
 void
 signed_video_parse_sei(uint8_t *nalu, size_t nalu_size, SignedVideoCodec codec)
 {
-  if (!nalu || nalu_size == 0) {
+  if (!nalu || nalu_size == 0 || codec < SV_CODEC_H264 || codec >= SV_CODEC_NUM) {
     return;
   }
 

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -32,6 +32,7 @@
 #include "axis-communications/sv_vendor_axis_communications_internal.h"
 #endif
 #include "includes/signed_video_common.h"
+#include "includes/signed_video_helpers.h"  // onvif_media_signing_parse_sei()
 #include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t
 #include "includes/signed_video_signing_plugin.h"
 #include "signed_video_authenticity.h"  // latest_validation_init()
@@ -1343,3 +1344,32 @@ signed_video_is_golden_sei(signed_video_t *self, const uint8_t *nalu, size_t nal
   free(parsed_nalu.nalu_data_wo_epb);
   return parsed_nalu.is_golden_sei;
 };
+
+void
+signed_video_parse_sei(uint8_t *nalu, size_t nalu_size, SignedVideoCodec codec)
+{
+  if (!nalu || nalu_size == 0) {
+    return;
+  }
+
+#ifdef PRINT_DECODED_SEI
+  h26x_nalu_t nalu_info = parse_nalu_info(nalu, nalu_size, codec, true, true);
+  if (nalu_info.is_gop_sei) {
+    printf("\nSEI (%zu bytes):\n", nalu_size);
+    for (size_t i = 0; i < nalu_size; ++i) {
+      printf(" %02x", nalu[i]);
+    }
+    printf("\n");
+    printf("Reserved byte: ");
+    for (int i = 7; i >= 0; i--) {
+      printf("%u", (nalu_info.reserved_byte & (1 << i)) ? 1 : 0);
+    }
+    printf("\n");
+    signed_video_t *self = signed_video_create(codec);
+    tlv_decode(self, nalu_info.tlv_data, nalu_info.tlv_size);
+    signed_video_free(self);
+  }
+
+  free(nalu_info.nalu_data_wo_epb);
+#endif
+}

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>  // EXIT_SUCCESS, EXIT_FAILURE, size_t, abs()
 
 #include "lib/src/includes/signed_video_common.h"
+#include "lib/src/includes/signed_video_helpers.h"
 #include "lib/src/includes/signed_video_openssl.h"  // sign_algo_t
 #include "lib/src/includes/signed_video_sign.h"
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
@@ -120,8 +121,7 @@ verify_seis(test_stream_t *list, struct sv_setting setting)
       ck_assert(!(setting.is_vendor_axis ^ has_axis_tag));
 #ifdef PRINT_DECODED_SEI
       printf("\n--- SEI # %d ---\n", num_seis);
-      // TODO: To be implemented
-      // signed_video_parse_sei(item->data, item->data_size, list->codec);
+      signed_video_parse_sei(item->data, item->data_size, list->codec);
 #endif
     }
     free(nalu_info.nalu_data_wo_epb);


### PR DESCRIPTION
which can be used to decode and parse the data of a SEI. Currently
only prints the SEI data itself and the reserved byte. Prints for
decoded TLV tags are out of scope for this commit.
