### PR TITLE
Prints decoded information of the public key tag

### DIFF
--- a/lib/src/legacy/legacy_tlv.c
+++ b/lib/src/legacy/legacy_tlv.c
@@ -384,6 +384,16 @@ legacy_decode_public_key(legacy_sv_t *self, const uint8_t *data, size_t data_siz
 #endif
 
     SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
+#ifdef PRINT_DECODED_SEI
+    char *public_key_str = calloc(1, pubkey_size + 1);
+    SV_THROW_IF(!public_key_str, SV_MEMORY);
+    memcpy(public_key_str, pem_public_key->key, pubkey_size);
+    printf("\nPublic Key Tag\n");
+    printf("             tag version: %u\n", version);
+    printf("         public key size: %u\n", pubkey_size);
+    printf("              public key:\n%s\n", public_key_str);
+    free(public_key_str);
+#endif
   SV_CATCH()
   SV_DONE(status)
 

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -741,6 +741,16 @@ decode_public_key(signed_video_t *self, const uint8_t *data, size_t data_size)
 #endif
 
     SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
+#ifdef PRINT_DECODED_SEI
+    char *public_key_str = calloc(1, pubkey_size + 1);
+    SV_THROW_IF(!public_key_str, SV_MEMORY);
+    memcpy(public_key_str, pem_public_key->key, pubkey_size);
+    printf("\nPublic Key Tag\n");
+    printf("             tag version: %u\n", version);
+    printf("         public key size: %u\n", pubkey_size);
+    printf("              public key:\n%s\n", public_key_str);
+    free(public_key_str);
+#endif
   SV_CATCH()
   SV_DONE(status)
 


### PR DESCRIPTION
Under the PRINT_DECODED_SEI flag prints the content of a Public
Key tag present in a SEI. This is applied to both the current and
the legacy code.
