### PR TITLE
Prints decoded information of the crypto info tag

### DIFF
--- a/lib/src/legacy/legacy_tlv.c
+++ b/lib/src/legacy/legacy_tlv.c
@@ -503,6 +503,8 @@ legacy_decode_crypto_info(legacy_sv_t *self, const uint8_t *data, size_t data_si
   uint8_t version = *data_ptr++;
   size_t hash_algo_encoded_oid_size = *data_ptr++;
   const unsigned char *hash_algo_encoded_oid = (const unsigned char *)data_ptr;
+  char *hash_algo_name =
+      openssl_encoded_oid_to_str(hash_algo_encoded_oid, hash_algo_encoded_oid_size);
 
   svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
@@ -514,8 +516,19 @@ legacy_decode_crypto_info(legacy_sv_t *self, const uint8_t *data, size_t data_si
     data_ptr += hash_algo_encoded_oid_size;
 
     SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
+#ifdef PRINT_DECODED_SEI
+    printf("\nCrypto Information Tag\n");
+    printf("             tag version: %u\n", version);
+    printf("hashing algo (ASN.1/DER): ");
+    for (size_t i = 0; i < hash_algo_encoded_oid_size; i++) {
+      printf("%02x", hash_algo_encoded_oid[i]);
+    }
+    printf(" -> %s\n", hash_algo_name);
+#endif
   SV_CATCH()
   SV_DONE(status)
+
+  free(hash_algo_name);
 
   return status;
 }

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -505,6 +505,28 @@ openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size)
   return (const unsigned char *)self->hash_algo.encoded_oid;
 }
 
+char *
+openssl_encoded_oid_to_str(const unsigned char *encoded_oid, size_t encoded_oid_size)
+{
+  ASN1_OBJECT *obj = NULL;
+  char *algo_name = calloc(1, 50);
+
+  if (!encoded_oid || encoded_oid_size == 0) {
+    goto done;
+  }
+
+  // Point to the first byte of the OID. The |oid_ptr| will increment while decoding.
+  if (!d2i_ASN1_OBJECT(&obj, &encoded_oid, encoded_oid_size)) {
+    goto done;
+  }
+  OBJ_obj2txt(algo_name, 50, obj, 1);
+
+done:
+  ASN1_OBJECT_free(obj);
+
+  return algo_name;
+}
+
 size_t
 openssl_get_hash_size(void *handle)
 {

--- a/lib/src/signed_video_openssl_internal.h
+++ b/lib/src/signed_video_openssl_internal.h
@@ -97,6 +97,19 @@ const unsigned char *
 openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size);
 
 /**
+ * @brief Converts hashing algorithm from OID form to readable string
+ *
+ * The ownership of the allocated string is transferred.
+ *
+ * @param encoded_oid Pointer to the OID on serialized form.
+ * @param encoded_oid_size The size of the encoded OID.
+ *
+ * @return A string.
+ */
+char *
+openssl_encoded_oid_to_str(const unsigned char *encoded_oid, size_t encoded_oid_size);
+
+/**
  * @brief Gets the hash size of the hashing algorithm
  *
  * Returns the hash size of the hashing algorithm and 0 upon failure.

--- a/lib/src/signed_video_tlv.c
+++ b/lib/src/signed_video_tlv.c
@@ -1001,6 +1001,8 @@ decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size)
   uint8_t version = *data_ptr++;
   size_t hash_algo_encoded_oid_size = *data_ptr++;
   const unsigned char *hash_algo_encoded_oid = (const unsigned char *)data_ptr;
+  char *hash_algo_name =
+      openssl_encoded_oid_to_str(hash_algo_encoded_oid, hash_algo_encoded_oid_size);
 
   svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
@@ -1014,8 +1016,19 @@ decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size)
     data_ptr += hash_algo_encoded_oid_size;
 
     SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
+#ifdef PRINT_DECODED_SEI
+    printf("\nCrypto Information Tag\n");
+    printf("             tag version: %u\n", version);
+    printf("hashing algo (ASN.1/DER): ");
+    for (size_t i = 0; i < hash_algo_encoded_oid_size; i++) {
+      printf("%02x", hash_algo_encoded_oid[i]);
+    }
+    printf(" -> %s\n", hash_algo_name);
+#endif
   SV_CATCH()
   SV_DONE(status)
+
+  free(hash_algo_name);
 
   return status;
 }


### PR DESCRIPTION
Under the PRINT_DECODED_SEI flag prints the content of a Crypto
Information tag present in a SEI. This is applied to both the
current and the legacy code.

In addition, adds a helper function to convert a hash algorithm
on OID serialized form to a readable string.
