### PR TITLE
Adds peek NAL Unit to signed_video_get_sei(...)

### DIFF
--- a/lib/src/includes/signed_video_sign.h
+++ b/lib/src/includes/signed_video_sign.h
@@ -259,17 +259,17 @@ signed_video_get_nalu_to_prepend(signed_video_t *self,
  *     // Handle error
  *   } else {
  *     size_t sei_size = 0;
- *     status = signed_video_get_sei(sv, NULL, &sei_size);
+ *     status = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
  *     // The first call of the function is for getting the |sei_size|.
  *     // The second call is to get the sei.
  *     while (status == SV_OK && sei_size > 0) {
  *         uint8_t *sei = malloc(sei_size);
- *         status = signed_video_get_sei(sv, sei, &sei_size);
+ *         status = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
  *         if (status != SV_OK) {
  *          // True error. Handle it properly.
  *         }
  *         // The user is responsible for freeing |sei|.
- *         status = signed_video_get_sei(sv, NULL, &sei_size);
+ *         status = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
  *     }
  *     // Handle return code
  *     if (status != SV_OK) {
@@ -281,13 +281,22 @@ signed_video_get_nalu_to_prepend(signed_video_t *self,
  * @param sei Pointer to the memory to which a complete SEI will be copied.
  *   If a NULL pointer is used, only the |sei_size| is updated.
  * @param sei_size Pointer to where the size of the SEI is written.
+ * @param peek_nalu Pointer to the NAL Unit of which the SEI will be prepended as a
+ *   header. When peeking at the next NAL Unit, SEIs can only be fetched if the NAL is a
+ *   primary slice. A NULL pointer means that the user is responsible to add the SEI
+ *   according to standard.
+ * @param peek_nalu_size The size of the peek NAL Unit.
  *
  * @returns SV_OK            - NALU was copied successfully,
  *          SV_NOT_SUPPORTED - no available data, the action is not supported,
  *          otherwise        - an error code.
  */
 SignedVideoReturnCode
-signed_video_get_sei(signed_video_t *self, uint8_t *sei, size_t *sei_size);
+signed_video_get_sei(signed_video_t *self,
+    uint8_t *sei,
+    size_t *sei_size,
+    const uint8_t *peek_nalu,
+    size_t peek_nalu_size);
 
 /**
  * @brief Frees the |nalu_data| of signed_video_nalu_to_prepend_t

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1662,15 +1662,15 @@ START_TEST(vendor_axis_communications_operation)
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_add_nalu_for_signing(sv, i_nalu_2->data, i_nalu_2->data_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
   ck_assert(sei_size > 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   sei_item = test_stream_item_create(sei, sei_size, codec);
   ck_assert(tag_is_present(sei_item, codec, VENDOR_AXIS_COMMUNICATIONS_TAG));
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
 
@@ -1751,14 +1751,14 @@ generate_and_set_private_key_on_camera_side(struct sv_setting setting,
   ck_assert_int_eq(sv_rc, SV_OK);
 
   size_t sei_size = 0;
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
   ck_assert(sei_size > 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   *sei_item = test_stream_item_create(sei, sei_size, setting.codec);
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
 
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
@@ -2018,10 +2018,10 @@ START_TEST(no_emulation_prevention_bytes)
       sv, i_nalu_2->data, i_nalu_2->data_size, &g_testTimestamp);
   ck_assert_int_eq(sv_rc, SV_OK);
 
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
 
   ck_assert(sei_size != 0);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -2041,7 +2041,7 @@ START_TEST(no_emulation_prevention_bytes)
   // Create a SEI.
   sei_item = test_stream_item_create(sei_with_epb, sei_with_epb_size, codec);
 
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
 

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -140,17 +140,18 @@ get_seis(signed_video_t *sv, int num_seis_to_get, int *num_seis_gotten)
   int num_pulled_nalus = 0;
 
   size_t sei_size = 0;
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  // Pull SEIs without peek.
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
   while (num_seis_to_get != 0 && sv_rc == SV_OK && sei_size > 0) {
     uint8_t *sei = malloc(sei_size);
     ck_assert(sei);
-    sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+    sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
     ck_assert_int_eq(sv_rc, SV_OK);
     // Sizes can vary between SEIs, so it is better to free and allocate new memory for each SEI
     free(sei);
     num_pulled_nalus++;
     num_seis_to_get--;
-    sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+    sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
   }
 
   if (num_seis_gotten) *num_seis_gotten = num_pulled_nalus;
@@ -300,15 +301,15 @@ START_TEST(api_inputs)
 
   // TODO: Add check on |sv| to make sure nothing has changed.
   // Checking signed_video_get_sei() for NULL pointers.
-  sv_rc = signed_video_get_sei(sv, NULL, NULL);
+  sv_rc = signed_video_get_sei(sv, NULL, NULL, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(NULL, sei, &sei_size);
+  sv_rc = signed_video_get_sei(NULL, sei, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   // Checking signed_video_set_end_of_stream() for NULL pointers.
   sv_rc = signed_video_set_end_of_stream(NULL);
@@ -685,23 +686,23 @@ START_TEST(two_completed_seis_pending)
   ck_assert_int_eq(sv_rc, SV_OK);
 
   // Now 2 SEIs should be available. Get the first one.
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size_1);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size_1, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size_1 != 0);
   uint8_t *sei_1 = malloc(sei_size_1);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_get_sei(sv, sei_1, &sei_size_1);
+  sv_rc = signed_video_get_sei(sv, sei_1, &sei_size_1, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   // Now get the second one.
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size_2);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size_2, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size_2 != 0);
   uint8_t *sei_2 = malloc(sei_size_2);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_get_sei(sv, sei_2, &sei_size_2);
+  sv_rc = signed_video_get_sei(sv, sei_2, &sei_size_2, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   // There should not be a third one.
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size_3);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size_3, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert_int_eq(sei_size_3, 0);
 
@@ -735,11 +736,11 @@ START_TEST(golden_sei_created)
   ck_assert_int_eq(sv_rc, SV_OK);
 
   size_t sei_size = 0;
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
   ck_assert(sei_size != 0);
   uint8_t *sei = malloc(sei_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   // Verify the golden SEI
@@ -851,10 +852,10 @@ START_TEST(correct_timestamp)
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_add_nalu_for_signing(sv, i_nalu_2->data, i_nalu_2->data_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size > 0);
 
@@ -864,10 +865,10 @@ START_TEST(correct_timestamp)
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_add_nalu_for_signing(sv_ts, i_nalu_2->data, i_nalu_2->data_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_get_sei(sv_ts, NULL, &sei_size_ts);
+  sv_rc = signed_video_get_sei(sv_ts, NULL, &sei_size_ts, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei_ts = malloc(sei_size_ts);
-  sv_rc = signed_video_get_sei(sv_ts, sei_ts, &sei_size_ts);
+  sv_rc = signed_video_get_sei(sv_ts, sei_ts, &sei_size_ts, NULL, 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size_ts > 0);
 
@@ -962,11 +963,11 @@ START_TEST(w_wo_emulation_prevention_bytes)
     sv_rc = signed_video_add_nalu_for_signing_with_timestamp(
         sv, i_nalu_2->data, i_nalu_2->data_size, &g_testTimestamp);
     ck_assert_int_eq(sv_rc, SV_OK);
-    sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+    sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
     ck_assert_int_eq(sv_rc, SV_OK);
     ck_assert(sei_size > 0);
     seis[ii] = malloc(sei_size);
-    sv_rc = signed_video_get_sei(sv, seis[ii], &sei_size);
+    sv_rc = signed_video_get_sei(sv, seis[ii], &sei_size, NULL, 0);
     ck_assert_int_eq(sv_rc, SV_OK);
     ck_assert(seis[ii]);
     sei_sizes[ii] = sei_size;

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -98,12 +98,14 @@ pull_seis(signed_video_t *sv, test_stream_item_t *item)
 {
   bool is_first_sei = true;
   size_t sei_size = 0;
-  SignedVideoReturnCode sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  // Only prepend the SEI if it follows the standard, by peeking the current NAL Unit.
+  SignedVideoReturnCode sv_rc =
+      signed_video_get_sei(sv, NULL, &sei_size, item->data, item->data_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   while (sv_rc == SV_OK && (sei_size != 0)) {
     uint8_t *sei = malloc(sei_size);
-    sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+    sv_rc = signed_video_get_sei(sv, sei, &sei_size, item->data, item->data_size);
     ck_assert_int_eq(sv_rc, SV_OK);
     if (!is_first_sei) {
       // The first SEI could be a golden SEI, hence do not check.
@@ -114,7 +116,7 @@ pull_seis(signed_video_t *sv, test_stream_item_t *item)
     // Prepend the |item| with this |new_item|.
     test_stream_item_prepend(item, new_item);
     // Ask for next completed SEI.
-    sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+    sv_rc = signed_video_get_sei(sv, NULL, &sei_size, item->data, item->data_size);
     ck_assert_int_eq(sv_rc, SV_OK);
     is_first_sei = false;
   }


### PR DESCRIPTION
This helps the user to get SEIs only when they can safely prepend
the peeked NAL Unit and at the same time follow the H.26x
standard.
