### PR TITLE
Adds num_pending_seis parameter to signed_video_get_sei(...)

### DIFF
--- a/lib/src/includes/signed_video_sign.h
+++ b/lib/src/includes/signed_video_sign.h
@@ -259,17 +259,17 @@ signed_video_get_nalu_to_prepend(signed_video_t *self,
  *     // Handle error
  *   } else {
  *     size_t sei_size = 0;
- *     status = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
+ *     status = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
  *     // The first call of the function is for getting the |sei_size|.
  *     // The second call is to get the sei.
  *     while (status == SV_OK && sei_size > 0) {
  *         uint8_t *sei = malloc(sei_size);
- *         status = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
+ *         status = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
  *         if (status != SV_OK) {
  *          // True error. Handle it properly.
  *         }
  *         // The user is responsible for freeing |sei|.
- *         status = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
+ *         status = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
  *     }
  *     // Handle return code
  *     if (status != SV_OK) {
@@ -286,6 +286,7 @@ signed_video_get_nalu_to_prepend(signed_video_t *self,
  *   primary slice. A NULL pointer means that the user is responsible to add the SEI
  *   according to standard.
  * @param peek_nalu_size The size of the peek NAL Unit.
+ * @param num_pending_seis Pointer to where the number of pending SEIs is written.
  *
  * @returns SV_OK            - NALU was copied successfully,
  *          SV_NOT_SUPPORTED - no available data, the action is not supported,
@@ -296,7 +297,8 @@ signed_video_get_sei(signed_video_t *self,
     uint8_t *sei,
     size_t *sei_size,
     const uint8_t *peek_nalu,
-    size_t peek_nalu_size);
+    size_t peek_nalu_size,
+    unsigned *num_pending_seis);
 
 /**
  * @brief Frees the |nalu_data| of signed_video_nalu_to_prepend_t

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -627,11 +627,15 @@ signed_video_get_sei(signed_video_t *self,
     uint8_t *sei,
     size_t *sei_size,
     const uint8_t *peek_nalu,
-    size_t peek_nalu_size)
+    size_t peek_nalu_size,
+    unsigned *num_pending_seis)
 {
 
   if (!self || !sei_size) return SV_INVALID_PARAMETER;
   *sei_size = 0;
+  if (num_pending_seis) {
+    *num_pending_seis = self->sei_data_buffer_idx;
+  }
 
   svrc_t status = get_signature_complete_sei_and_add_to_prepend(self);
   if (status != SV_OK) return status;
@@ -661,6 +665,12 @@ signed_video_get_sei(signed_video_t *self,
   free(self->sei_data_buffer[0].sei);
   --(self->num_of_completed_seis);
   shift_sei_buffer_at_index(self, 0);
+
+  // Update |num_pending_seis| in case SEIs were fetched.
+  if (num_pending_seis) {
+    *num_pending_seis = self->sei_data_buffer_idx;
+  }
+
   return SV_OK;
 }
 

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1662,15 +1662,15 @@ START_TEST(vendor_axis_communications_operation)
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_add_nalu_for_signing(sv, i_nalu_2->data, i_nalu_2->data_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
   ck_assert(sei_size > 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   sei_item = test_stream_item_create(sei, sei_size, codec);
   ck_assert(tag_is_present(sei_item, codec, VENDOR_AXIS_COMMUNICATIONS_TAG));
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
 
@@ -1751,14 +1751,14 @@ generate_and_set_private_key_on_camera_side(struct sv_setting setting,
   ck_assert_int_eq(sv_rc, SV_OK);
 
   size_t sei_size = 0;
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
   ck_assert(sei_size > 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   *sei_item = test_stream_item_create(sei, sei_size, setting.codec);
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
 
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
@@ -2018,10 +2018,10 @@ START_TEST(no_emulation_prevention_bytes)
       sv, i_nalu_2->data, i_nalu_2->data_size, &g_testTimestamp);
   ck_assert_int_eq(sv_rc, SV_OK);
 
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
 
   ck_assert(sei_size != 0);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -2041,7 +2041,7 @@ START_TEST(no_emulation_prevention_bytes)
   // Create a SEI.
   sei_item = test_stream_item_create(sei_with_epb, sei_with_epb_size, codec);
 
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
 

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -100,12 +100,12 @@ pull_seis(signed_video_t *sv, test_stream_item_t *item)
   size_t sei_size = 0;
   // Only prepend the SEI if it follows the standard, by peeking the current NAL Unit.
   SignedVideoReturnCode sv_rc =
-      signed_video_get_sei(sv, NULL, &sei_size, item->data, item->data_size);
+      signed_video_get_sei(sv, NULL, &sei_size, item->data, item->data_size, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   while (sv_rc == SV_OK && (sei_size != 0)) {
     uint8_t *sei = malloc(sei_size);
-    sv_rc = signed_video_get_sei(sv, sei, &sei_size, item->data, item->data_size);
+    sv_rc = signed_video_get_sei(sv, sei, &sei_size, item->data, item->data_size, NULL);
     ck_assert_int_eq(sv_rc, SV_OK);
     if (!is_first_sei) {
       // The first SEI could be a golden SEI, hence do not check.
@@ -116,7 +116,7 @@ pull_seis(signed_video_t *sv, test_stream_item_t *item)
     // Prepend the |item| with this |new_item|.
     test_stream_item_prepend(item, new_item);
     // Ask for next completed SEI.
-    sv_rc = signed_video_get_sei(sv, NULL, &sei_size, item->data, item->data_size);
+    sv_rc = signed_video_get_sei(sv, NULL, &sei_size, item->data, item->data_size, NULL);
     ck_assert_int_eq(sv_rc, SV_OK);
     is_first_sei = false;
   }


### PR DESCRIPTION
This means that the user now can know how many SEIs are still in process
of being signed.

Tests have been updated with checks for correct numbers in queue.
