### PR TITLE
Keeps the GOP hash flag until stats collected

### DIFF
--- a/lib/src/signed_video_h26x_nalu_list.c
+++ b/lib/src/signed_video_h26x_nalu_list.c
@@ -461,12 +461,11 @@ h26x_nalu_list_get_next_sei_item(const h26x_nalu_list_t *list)
   return item;
 }
 
-/* Loops through the |list| and collects statistics.
+/* Loops through the |list| and collects statistics from items used in GOP hash.
  * The stats collected are
  *   - number of invalid NALUs
  *   - number of missing NALUs
- * and return true if any valid NALUs, including those pending a second verification, are present.
- */
+ * and return true if any valid NALUs are present. */
 bool
 h26x_nalu_list_get_stats(const h26x_nalu_list_t *list,
     int *num_invalid_nalus,
@@ -481,6 +480,11 @@ h26x_nalu_list_get_stats(const h26x_nalu_list_t *list,
   // From the list, get number of invalid NALUs and number of missing NALUs.
   h26x_nalu_list_item_t *item = list->first_item;
   while (item) {
+    // Only collect statistics from the NAL Units |used_in_gop_hash|.
+    if (!item->used_in_gop_hash) {
+      item = item->next;
+      continue;
+    }
     if (item->validation_status == 'M') local_num_missing_nalus++;
     if (item->validation_status == 'N' || item->validation_status == 'E') local_num_invalid_nalus++;
     if (item->validation_status == '.') {

--- a/lib/src/signed_video_h26x_nalu_list.h
+++ b/lib/src/signed_video_h26x_nalu_list.h
@@ -134,7 +134,7 @@ h26x_nalu_list_get_next_sei_item(const h26x_nalu_list_t* list);
 /**
  * @brief Collects statistics from a list
  *
- * Loops through the |list| and collects statistics.
+ * Loops through the |list| and collects statistics from items used in GOP hash.
  * The stats collected are
  *   - number of invalid NALUs
  *   - number of missing NALUs
@@ -145,8 +145,7 @@ h26x_nalu_list_get_next_sei_item(const h26x_nalu_list_t* list);
  * @param num_missing_nalus A pointer to which the number of missing NALUs, detected by the
  *   validation, is written.
  *
- * @returns True if at least one item is validated as authentic including those that are pending a
- *   second verification.
+ * @return True if at least one item is validated as authentic.
  */
 bool
 h26x_nalu_list_get_stats(const h26x_nalu_list_t* list,


### PR DESCRIPTION
This makes sure to collect statistics correctly if several GOPs
are being validated in the same go.
