### PR TITLE
Adds payload_offset to signed_video_get_sei()

### DIFF
--- a/lib/src/includes/signed_video_sign.h
+++ b/lib/src/includes/signed_video_sign.h
@@ -256,18 +256,18 @@ signed_video_get_nalu_to_prepend(signed_video_t *self,
  *   SignedVideoReturnCode status;
  *   size_t sei_size = 0;
  *   // The first call of the function is for getting the |sei_size|.
- *   status = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
+ *   status = signed_video_get_sei(sv, NULL, &sei_size, NULL, NULL, 0, NULL);
  *   // The second call is to get the sei.
  *   while (status == SV_OK && sei_size > 0) {
  *       uint8_t *sei = malloc(sei_size);
- *       status = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
+ *       status = signed_video_get_sei(sv, sei, &sei_size, NULL, NULL, 0, NULL);
  *       if (status != SV_OK) {
  *        // True error. Handle it properly.
  *       }
  *       // Add the SEI to the stream according to the standard.
  *       // The user is responsible for freeing |sei|.
  *       // Check for more SEIs.
- *       status = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
+ *       status = signed_video_get_sei(sv, NULL, &sei_size, NULL, NULL, 0, NULL);
  *   }
  *   status = signed_video_add_nalu_for_signing_with_timestamp(sv, nalu, nalu_size, NULL);
  *   if (status != SV_OK) {
@@ -278,6 +278,9 @@ signed_video_get_nalu_to_prepend(signed_video_t *self,
  * @param sei Pointer to the memory to which a complete SEI will be copied.
  *   If a NULL pointer is used, only the |sei_size| is updated.
  * @param sei_size Pointer to where the size of the SEI is written.
+ * @param payload_offset Pointer to where the offset to the start of the SEI payload is written.
+ *   This is useful if the SEI is added by the encoder, which would take the SEI payload only and
+ *   then fill in the header, payload size and apply emulation prevention onto the data.
  * @param peek_nalu Pointer to the NAL Unit of which the SEI will be prepended as a
  *   header. When peeking at the next NAL Unit, SEIs can only be fetched if the NAL is a
  *   primary slice. A NULL pointer means that the user is responsible to add the SEI
@@ -293,6 +296,7 @@ SignedVideoReturnCode
 signed_video_get_sei(signed_video_t *self,
     uint8_t *sei,
     size_t *sei_size,
+    int *payload_offset,
     const uint8_t *peek_nalu,
     size_t peek_nalu_size,
     unsigned *num_pending_seis);

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1541,15 +1541,15 @@ START_TEST(vendor_axis_communications_operation)
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_add_nalu_for_signing(sv, i_nalu_2->data, i_nalu_2->data_size);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, NULL, 0, NULL);
   ck_assert(sei_size > 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   sei_item = test_stream_item_create(sei, sei_size, codec);
   ck_assert(tag_is_present(sei_item, codec, VENDOR_AXIS_COMMUNICATIONS_TAG));
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
 
@@ -1635,14 +1635,14 @@ generate_and_set_private_key_on_camera_side(struct sv_setting setting,
   ck_assert_int_eq(sv_rc, SV_OK);
 
   size_t sei_size = 0;
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, NULL, 0, NULL);
   ck_assert(sei_size > 0);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   *sei_item = test_stream_item_create(sei, sei_size, setting.codec);
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, NULL, 0, NULL);
 
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
@@ -1902,10 +1902,10 @@ START_TEST(no_emulation_prevention_bytes)
       sv, i_nalu_2->data, i_nalu_2->data_size, &g_testTimestamp);
   ck_assert_int_eq(sv_rc, SV_OK);
 
-  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, 0, NULL);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size, NULL, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   uint8_t *sei = malloc(sei_size);
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, NULL, 0, NULL);
 
   ck_assert(sei_size != 0);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -1925,7 +1925,7 @@ START_TEST(no_emulation_prevention_bytes)
   // Create a SEI.
   sei_item = test_stream_item_create(sei_with_epb, sei_with_epb_size, codec);
 
-  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, 0, NULL);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size, NULL, NULL, 0, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
   ck_assert(sei_size == 0);
 

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -26,8 +26,8 @@
 #include "lib/src/includes/signed_video_common.h"
 #include "lib/src/includes/signed_video_openssl.h"
 #include "lib/src/includes/signed_video_sign.h"
-#include "lib/src/signed_video_h26x_internal.h"  // parse_nalu_info()
-#include "lib/src/signed_video_internal.h"  // _signed_video_t
+#include "lib/src/signed_video_h26x_internal.h"  // parse_nalu_info(), , kUuidSignedVideo
+#include "lib/src/signed_video_internal.h"  // _signed_video_t, UUID_LEN
 #include "lib/src/signed_video_tlv.h"  // tlv_find_tag()
 
 #define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
@@ -98,18 +98,22 @@ pull_seis(signed_video_t *sv, test_stream_item_t **item)
 {
   bool is_first_sei = true;
   int num_seis = 0;
+  int payload_offset = 0;
   size_t sei_size = 0;
   uint8_t *peek_nalu = (*item)->data;
   size_t peek_nalu_size = (*item)->data_size;
   // Only prepend the SEI if it follows the standard, by peeking the current NAL Unit.
   SignedVideoReturnCode sv_rc =
-      signed_video_get_sei(sv, NULL, &sei_size, peek_nalu, peek_nalu_size, NULL);
+      signed_video_get_sei(sv, NULL, &sei_size, &payload_offset, peek_nalu, peek_nalu_size, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   while (sv_rc == SV_OK && (sei_size != 0)) {
     uint8_t *sei = malloc(sei_size);
-    sv_rc = signed_video_get_sei(sv, sei, &sei_size, peek_nalu, peek_nalu_size, NULL);
+    sv_rc =
+        signed_video_get_sei(sv, sei, &sei_size, &payload_offset, peek_nalu, peek_nalu_size, NULL);
     ck_assert_int_eq(sv_rc, SV_OK);
+    // Check that the SEI payload starts with the Signed Video UUID.
+    ck_assert_int_eq(memcmp(sei + payload_offset, kUuidSignedVideo, UUID_LEN), 0);
     if (!is_first_sei) {
       // The first SEI could be a golden SEI, hence do not check.
       ck_assert(!signed_video_is_golden_sei(sv, sei, sei_size));
@@ -120,7 +124,8 @@ pull_seis(signed_video_t *sv, test_stream_item_t **item)
     test_stream_item_prepend(*item, new_item);
     num_seis++;
     // Ask for next completed SEI.
-    sv_rc = signed_video_get_sei(sv, NULL, &sei_size, peek_nalu, peek_nalu_size, NULL);
+    sv_rc =
+        signed_video_get_sei(sv, NULL, &sei_size, &payload_offset, peek_nalu, peek_nalu_size, NULL);
     ck_assert_int_eq(sv_rc, SV_OK);
     is_first_sei = false;
   }


### PR DESCRIPTION
It is in many situation convenient to know where the actual SEI
payload starts in the SEI data. In particular, when adding SEIs to
the stream through the encoder, the encoder itself adds header,
payload size and emulation prevention bytes. Knowing in advance
where the payload starts avoids searching the SEI data for it.
