### PR TITLE
Changes to boolean for key creation

### DIFF
--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1618,7 +1618,8 @@ generate_and_set_private_key_on_camera_side(struct sv_setting setting,
   signed_video_t *sv = signed_video_create(setting.codec);
   ck_assert(sv);
   // Read and set content of private_key.
-  sv_rc = setting.generate_key(NULL, &private_key, &private_key_size);
+  generate_key_fcn_t generate_key = setting.ec_key ? EC_KEY : RSA_KEY;
+  sv_rc = generate_key(NULL, &private_key, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -1766,7 +1767,9 @@ START_TEST(test_public_key_scenarios)
     sign_or_verify_data_t sign_data_wrong_key = {0};
     // Generate a new private key in order to extract a bad private key (a key not compatible with
     // the one generated on the camera side)
-    settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
+    generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
+    sv_rc = generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
+    ck_assert_int_eq(sv_rc, SV_OK);
     sv_rc = openssl_private_key_malloc(&sign_data_wrong_key, tmp_private_key, tmp_private_key_size);
     ck_assert_int_eq(sv_rc, SV_OK);
     openssl_read_pubkey_from_private_key(&sign_data_wrong_key, &wrong_public_key);
@@ -1817,7 +1820,9 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   // Generate a new private key in order to extract a bad private key (a key not compatible with the
   // one generated on the camera side)
   sign_or_verify_data_t sign_data = {0};
-  settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
+  generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
+  sv_rc = generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = openssl_private_key_malloc(&sign_data, tmp_private_key, tmp_private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   openssl_read_pubkey_from_private_key(&sign_data, &wrong_public_key);

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -181,19 +181,20 @@ START_TEST(api_inputs)
   // Check generate private key
   signed_video_t *sv = signed_video_create(codec);
   ck_assert(sv);
-  sv_rc = settings[_i].generate_key(NULL, NULL, NULL);
+  generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
+  sv_rc = generate_key(NULL, NULL, NULL);
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
-  sv_rc = settings[_i].generate_key(NULL, NULL, &private_key_size);
+  sv_rc = generate_key(NULL, NULL, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
-  sv_rc = settings[_i].generate_key(NULL, &private_key, NULL);
+  sv_rc = generate_key(NULL, &private_key, NULL);
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
   // Read content of private_key.
-  sv_rc = settings[_i].generate_key("./", NULL, NULL);
+  sv_rc = generate_key("./", NULL, NULL);
   ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = settings[_i].generate_key(NULL, &private_key, &private_key_size);
+  sv_rc = generate_key(NULL, &private_key, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   // Check set_private_key
-  if (settings[_i].generate_key == signed_video_generate_rsa_private_key) {
+  if (!settings[_i].ec_key) {
     algo = SIGN_ALGO_RSA;
   }
   sv_rc = signed_video_set_private_key(NULL, algo, private_key, private_key_size);
@@ -382,7 +383,8 @@ START_TEST(incorrect_operation)
   SignedVideoReturnCode sv_rc =
       signed_video_add_nalu_for_signing(sv, i_nalu->data, i_nalu->data_size);
   ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
-  sv_rc = settings[_i].generate_key(NULL, &private_key, &private_key_size);
+  generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
+  sv_rc = generate_key(NULL, &private_key, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
@@ -808,7 +810,8 @@ START_TEST(two_completed_seis_pending_legacy)
   test_stream_item_t *i_nalu_1 = test_stream_item_create_from_type('I', 0, codec);
   test_stream_item_t *i_nalu_2 = test_stream_item_create_from_type('I', 1, codec);
   // Setup the key
-  sv_rc = settings[_i].generate_key(NULL, &private_key, &private_key_size);
+  generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
+  sv_rc = generate_key(NULL, &private_key, &private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
   sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -42,11 +42,13 @@
 
 /* Function pointer typedef for generating private key. */
 typedef SignedVideoReturnCode (*generate_key_fcn_t)(const char *, char **, size_t *);
+#define EC_KEY signed_video_generate_ecdsa_private_key
+#define RSA_KEY signed_video_generate_rsa_private_key
 
 struct sv_setting {
   SignedVideoCodec codec;
   SignedVideoAuthenticityLevel auth_level;
-  generate_key_fcn_t generate_key;
+  bool ec_key;
   bool ep_before_signing;
   bool with_golden_sei;
   size_t max_sei_payload_size;


### PR DESCRIPTION
As a first step to change from generating new signing keys for
every test to a pre-created signing key, a boolean member is used
to select between EC and RSA.
