### PR TITLE
Adds an empty private key reader function

### DIFF
--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1618,9 +1618,7 @@ generate_and_set_private_key_on_camera_side(struct sv_setting setting,
   signed_video_t *sv = signed_video_create(setting.codec);
   ck_assert(sv);
   // Read and set content of private_key.
-  generate_key_fcn_t generate_key = setting.ec_key ? EC_KEY : RSA_KEY;
-  sv_rc = generate_key(NULL, &private_key, &private_key_size);
-  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(read_test_private_key(setting.ec_key, &private_key, &private_key_size));
   sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
 
@@ -1767,9 +1765,7 @@ START_TEST(test_public_key_scenarios)
     sign_or_verify_data_t sign_data_wrong_key = {0};
     // Generate a new private key in order to extract a bad private key (a key not compatible with
     // the one generated on the camera side)
-    generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
-    sv_rc = generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
-    ck_assert_int_eq(sv_rc, SV_OK);
+    ck_assert(read_test_private_key(settings[_i].ec_key, &tmp_private_key, &tmp_private_key_size));
     sv_rc = openssl_private_key_malloc(&sign_data_wrong_key, tmp_private_key, tmp_private_key_size);
     ck_assert_int_eq(sv_rc, SV_OK);
     openssl_read_pubkey_from_private_key(&sign_data_wrong_key, &wrong_public_key);
@@ -1820,9 +1816,7 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   // Generate a new private key in order to extract a bad private key (a key not compatible with the
   // one generated on the camera side)
   sign_or_verify_data_t sign_data = {0};
-  generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
-  sv_rc = generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
-  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(read_test_private_key(settings[_i].ec_key, &tmp_private_key, &tmp_private_key_size));
   sv_rc = openssl_private_key_malloc(&sign_data, tmp_private_key, tmp_private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   openssl_read_pubkey_from_private_key(&sign_data, &wrong_public_key);

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -178,21 +178,12 @@ START_TEST(api_inputs)
   size_t private_key_size = 0;
   size_t sei_size = 0;
 
-  // Check generate private key
   signed_video_t *sv = signed_video_create(codec);
   ck_assert(sv);
-  generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
-  sv_rc = generate_key(NULL, NULL, NULL);
-  ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
-  sv_rc = generate_key(NULL, NULL, &private_key_size);
-  ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
-  sv_rc = generate_key(NULL, &private_key, NULL);
-  ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
   // Read content of private_key.
-  sv_rc = generate_key("./", NULL, NULL);
-  ck_assert_int_eq(sv_rc, SV_OK);
-  sv_rc = generate_key(NULL, &private_key, &private_key_size);
-  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(!read_test_private_key(settings[_i].ec_key, NULL, &private_key_size));
+  ck_assert(!read_test_private_key(settings[_i].ec_key, &private_key, NULL));
+  ck_assert(read_test_private_key(settings[_i].ec_key, &private_key, &private_key_size));
   // Check set_private_key
   if (!settings[_i].ec_key) {
     algo = SIGN_ALGO_RSA;
@@ -383,9 +374,7 @@ START_TEST(incorrect_operation)
   SignedVideoReturnCode sv_rc =
       signed_video_add_nalu_for_signing(sv, i_nalu->data, i_nalu->data_size);
   ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
-  generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
-  sv_rc = generate_key(NULL, &private_key, &private_key_size);
-  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(read_test_private_key(settings[_i].ec_key, &private_key, &private_key_size));
   sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);
   sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
@@ -810,9 +799,7 @@ START_TEST(two_completed_seis_pending_legacy)
   test_stream_item_t *i_nalu_1 = test_stream_item_create_from_type('I', 0, codec);
   test_stream_item_t *i_nalu_2 = test_stream_item_create_from_type('I', 1, codec);
   // Setup the key
-  generate_key_fcn_t generate_key = settings[_i].ec_key ? EC_KEY : RSA_KEY;
-  sv_rc = generate_key(NULL, &private_key, &private_key_size);
-  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(read_test_private_key(settings[_i].ec_key, &private_key, &private_key_size));
 
   sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
   ck_assert_int_eq(sv_rc, SV_OK);

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -40,11 +40,6 @@
   "aaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbb" \
   "bbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaacc"
 
-/* Function pointer typedef for generating private key. */
-typedef SignedVideoReturnCode (*generate_key_fcn_t)(const char *, char **, size_t *);
-#define EC_KEY signed_video_generate_ecdsa_private_key
-#define RSA_KEY signed_video_generate_rsa_private_key
-
 struct sv_setting {
   SignedVideoCodec codec;
   SignedVideoAuthenticityLevel auth_level;
@@ -65,6 +60,24 @@ extern struct sv_setting settings[NUM_SETTINGS];
 extern const char *axisDummyCertificateChain;
 
 extern const int64_t g_testTimestamp;
+
+/**
+ * @brief Helper function to read test private key
+ *
+ * Reads either the pre-generated EC, or RSA, private key. The user can then pass the
+ * content to Signed Video through signed_video_set_private_key_new(). Memory is allocated
+ * for |private_key| and the content of |private_key_size| bytes is written. Note that the
+ * ownership is transferred.
+ *
+ * @param ec_key Selects the EC key if true, otherwise the RSA key.
+ * @param private_key Memory is allocated and the content of the private key PEM file is
+ *   copied to this output. Ownership is transferred.
+ * @param private_key_size Outputs the size of the |private_key|.
+ *
+ * @return true upon success, otherwise false.
+ */
+bool
+read_test_private_key(bool ec_key, char **private_key, size_t *private_key_size);
 
 /* Creates a signed_video_t session and initialize it from settings
  *


### PR DESCRIPTION
The function still generates the requested signing key.
Implementation and key files to be added in a separate commit.
