### PR TITLE
Remove unused flags from old linking approach

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -366,8 +366,8 @@ verify_hashes_with_hash_list(signed_video_t *self,
         latest_match_idx = compare_idx;
         num_invalid_nalus_since_latest_match = 0;
         // If the order is not correct, the validation status of the first NALU in the GOP should be
-        // 'N'. If that is the case, set |first_verification_not_authentic| to true and set
-        // |order_ok| to true for the next NALUs, so they are not affected by this issue.
+        // 'N'. If that is the case, set |order_ok| to true for the next NALUs, so they are not
+        // affected by this issue.
         if (!order_ok) {
           order_ok = true;
         }
@@ -688,9 +688,7 @@ validate_authenticity(signed_video_t *self)
       // part of the original stream not present in the file. Hence, mark as
       // SV_AUTH_RESULT_SIGNATURE_PRESENT instead.
       DEBUG_LOG("This first validation cannot be performed");
-      // Since we verify the linking hash twice we need to remove the set
-      // |first_verification_not_authentic|. Otherwise, the false failure leaks into the next GOP.
-      // Further, empty items marked 'M', may have been added at the beginning. These have no
+      // Empty items marked 'M', may have been added at the beginning. These have no
       // meaning and may only confuse the user. These should be removed. This is handled in
       // h26x_nalu_list_remove_missing_items().
       h26x_nalu_list_remove_missing_items(self->nalu_list);
@@ -1025,18 +1023,6 @@ maybe_validate_gop(signed_video_t *self, h26x_nalu_t *nalu)
       // validation in the middle of a stream. Now it is time to reset it.
       validation_flags->is_first_validation = !validation_flags->signing_present;
 
-      if (validation_flags->reset_first_validation) {
-        validation_flags->is_first_validation = true;
-        h26x_nalu_list_item_t *item = self->nalu_list->first_item;
-        while (item) {
-          if (item->nalu && item->nalu->is_first_nalu_in_gop) {
-            item->need_second_verification = false;
-            item->first_verification_not_authentic = false;
-            break;
-          }
-          item = item->next;
-        }
-      }
       self->gop_info->verified_signature_hash = -1;
       self->validation_flags.has_auth_result = true;
 

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -97,11 +97,7 @@ struct _h26x_nalu_list_item_t {
   // Flags
   bool taken_ownership_of_nalu;  // Flag to indicate if the item has taken ownership of the |nalu|
   // memory, hence need to free the memory if the item is released.
-  bool need_second_verification;  // This NALU need another verification, either due to failures or
-  // because it is a chained hash, that is, used in two GOPs. The second verification is done with
-  // |second_hash|.
-  bool first_verification_not_authentic;  // Marks the NALU as not authentic so the second one does
-  // not overwrite with an acceptable status.
+
   bool has_been_decoded;  // Marks a SEI as decoded. Decoding it twice might overwrite vital
   // information.
   bool used_in_gop_hash;  // Marks the NALU as being part of a computed |gop_hash|.

--- a/lib/src/signed_video_h26x_nalu_list.h
+++ b/lib/src/signed_video_h26x_nalu_list.h
@@ -111,8 +111,7 @@ h26x_nalu_list_add_missing(h26x_nalu_list_t* list,
  * @brief Removes 'M' items present at the beginning of a |list|
  *
  * There are scenarios when missing items are added to the front of the |list|, when the framework
- * actually could not verify the hashes. This function removes them and resets the flag
- * |first_verification_not_authentic| of non-pending items. Further, marks the decoded SEI as 'U',
+ * actually could not verify the hashes. This function marks the decoded SEI as 'U',
  * even if it could be verified, because it is not associated with this recording.
  *
  * @param list The |list| to remove items from.

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1091,6 +1091,8 @@ START_TEST(remove_two_gop_in_start_of_stream)
   //     PIS           MMMNP.                  -> (invalid)
   //      ISPPPPIS              ......P.       -> (valid)
   //            ISPPIS                 ....P.  -> (valid)
+  // TODO: There is a flaw in this scenario. It would be best to expect no invalid GOPs in the
+  // stream, as the first validation should reset the validation status to ensure consistency.
   struct validation_stats expected = {.valid_gops = 2,
       .invalid_gops = 2,
       .pending_nalus = 4,


### PR DESCRIPTION
With the transition to the new linking principle now complete, this commit removes
flags that were needed for the previous approach. These flags are no longer relevant
or used in the current implementation.

Change-Id: I6adb35497df6a7845225534a9ac4fe18980007c7

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
