### PR TITLE
Synchronizes SEIs for legacy code

### DIFF
--- a/lib/src/legacy/legacy_h26x_common.c
+++ b/lib/src/legacy/legacy_h26x_common.c
@@ -819,7 +819,9 @@ legacy_hash_and_add_for_auth(legacy_sv_t *self, legacy_h26x_nalu_list_item_t *it
     // Check if we have a potential transition to a new GOP. This happens if the current NALU
     // |is_first_nalu_in_gop|. If we have lost the first NALU of a GOP we can still make a guess by
     // checking if |has_sei| flag is set. It is set if the previous hashable NALU was SEI.
-    if (nalu->is_first_nalu_in_gop || (gop_state->validate_after_next_nalu && !nalu->is_gop_sei)) {
+    if (nalu->is_first_nalu_in_gop ||
+        (gop_state->validate_after_next_nalu && !nalu->is_gop_sei &&
+            gop_info->global_gop_counter_is_synced)) {
       // Updates counters and reset flags.
       gop_info->has_reference_hash = false;
 

--- a/lib/src/legacy/legacy_h26x_internal.h
+++ b/lib/src/legacy/legacy_h26x_internal.h
@@ -118,6 +118,11 @@ struct _legacy_h26x_nalu_list_item_st {
   bool has_been_decoded;  // Marks a SEI as decoded. Decoding it twice might overwrite vital
   // information.
   bool used_in_gop_hash;  // Marks the NALU as being part of a computed |gop_hash|.
+  bool in_validation;  // Marks the SEI that is currently up for use. Necessary for synchronization.
+  // Temporary flags used before updating the final ones.
+  char tmp_validation_status;
+  bool tmp_need_second_verification;
+  bool tmp_first_verification_not_authentic;
 
   // Linked list
   legacy_h26x_nalu_list_item_t

--- a/lib/src/legacy/legacy_h26x_nalu_list.c
+++ b/lib/src/legacy/legacy_h26x_nalu_list.c
@@ -68,6 +68,7 @@ legacy_h26x_nalu_list_item_create(const legacy_h26x_nalu_t *nalu)
   item->nalu = (legacy_h26x_nalu_t *)nalu;
   item->taken_ownership_of_nalu = false;
   item->validation_status = legacy_get_validation_status_from_nalu(nalu);
+  item->tmp_validation_status = item->validation_status;
 
   return item;
 }
@@ -312,6 +313,8 @@ legacy_h26x_nalu_list_add_missing(legacy_h26x_nalu_list_t *list,
       SV_THROW_IF(!missing_nalu, SV_MEMORY);
 
       missing_nalu->validation_status = 'M';
+      missing_nalu->tmp_validation_status = 'M';
+      missing_nalu->in_validation = true;
       if (append) {
         legacy_h26x_nalu_list_item_append_item(item, missing_nalu);
       } else {
@@ -339,28 +342,30 @@ legacy_h26x_nalu_list_remove_missing_items(legacy_h26x_nalu_list_t *list)
 
   bool found_first_pending_nalu = false;
   bool found_decoded_sei = false;
+  int num_removed_items = 0;
   legacy_h26x_nalu_list_item_t *item = list->first_item;
   while (item && !(found_first_pending_nalu && found_decoded_sei)) {
     // Reset the invalid verification failure if we have not past the first pending item.
 
-    if (!found_first_pending_nalu) item->first_verification_not_authentic = false;
+    if (!found_first_pending_nalu) item->tmp_first_verification_not_authentic = false;
     // Remove the missing NALU in the front.
-    if (item->validation_status == 'M' && (item == list->first_item)) {
+    if (item->tmp_validation_status == 'M' && item->in_validation) {
       const legacy_h26x_nalu_list_item_t *item_to_remove = item;
       item = item->next;
       legacy_h26x_nalu_list_remove_and_free_item(list, item_to_remove);
+      num_removed_items++;
       continue;
     }
-    if (item->has_been_decoded && item->validation_status != 'U') {
+    if (item->has_been_decoded && item->tmp_validation_status != 'U' && item->in_validation) {
       // Usually, these items were added because we verified hashes with a SEI not associated with
       // this recording. This can happen if we export to file or fast forward in a recording. The
       // SEI used to generate these missing items is set to 'U'.
-      item->validation_status = 'U';
       found_decoded_sei = true;
     }
-    if (item->validation_status == 'P') found_first_pending_nalu = true;
+    if (item->tmp_validation_status == 'P') found_first_pending_nalu = true;
     item = item->next;
   }
+  if (num_removed_items > 0) DEBUG_LOG("Removed %d missing items to list", num_removed_items);
 }
 
 /* Searches for, and returns, the next pending SEI item. */
@@ -371,7 +376,7 @@ legacy_h26x_nalu_list_get_next_sei_item(const legacy_h26x_nalu_list_t *list)
 
   legacy_h26x_nalu_list_item_t *item = list->first_item;
   while (item) {
-    if (item->nalu && item->nalu->is_gop_sei && item->validation_status == 'P') break;
+    if (item->nalu && item->nalu->is_gop_sei && item->tmp_validation_status == 'P') break;
     item = item->next;
   }
   return item;
@@ -397,17 +402,25 @@ legacy_h26x_nalu_list_get_stats(const legacy_h26x_nalu_list_t *list,
   // From the list, get number of invalid NALUs and number of missing NALUs.
   legacy_h26x_nalu_list_item_t *item = list->first_item;
   while (item) {
-    if (item->validation_status == 'M') local_num_missing_nalus++;
-    if (item->validation_status == 'N' || item->validation_status == 'E') local_num_invalid_nalus++;
-    if (item->validation_status == '.') {
+    if (item->tmp_validation_status == 'M') local_num_missing_nalus++;
+    if (item->nalu && item->nalu->is_gop_sei) {
+      if (item->in_validation &&
+          (item->tmp_validation_status == 'N' || item->tmp_validation_status == 'E'))
+        local_num_invalid_nalus++;
+    } else {
+      if (item->tmp_validation_status == 'N' || item->tmp_validation_status == 'E')
+        local_num_invalid_nalus++;
+    }
+    if (item->tmp_validation_status == '.') {
       // Do not count SEIs, since they are marked valid if the signature could be verified, which
       // happens for out-of-sync SEIs for example.
       has_valid_nalus |= !(item->nalu && item->nalu->is_gop_sei);
     }
-    if (item->validation_status == 'P') {
+    if (item->tmp_validation_status == 'P') {
       // Count NALUs that were verified successfully the first time and waiting for a second
       // verification.
-      has_valid_nalus |= item->need_second_verification && !item->first_verification_not_authentic;
+      has_valid_nalus |=
+          item->tmp_need_second_verification && !item->tmp_first_verification_not_authentic;
     }
     item = item->next;
   }
@@ -427,7 +440,7 @@ legacy_h26x_nalu_list_num_pending_items(const legacy_h26x_nalu_list_t *list)
   int num_pending_nalus = 0;
   legacy_h26x_nalu_list_item_t *item = list->first_item;
   while (item) {
-    if (item->validation_status == 'P') num_pending_nalus++;
+    if (item->tmp_validation_status == 'P') num_pending_nalus++;
     item = item->next;
   }
 
@@ -485,4 +498,25 @@ legacy_h26x_nalu_list_clean_up(legacy_h26x_nalu_list_t *list)
   }
 
   return removed_items;
+}
+
+svrc_t
+legacy_h26x_nalu_list_update_status(legacy_h26x_nalu_list_t *list, bool update)
+{
+  if (!list) return SV_INVALID_PARAMETER;
+
+  legacy_h26x_nalu_list_item_t *item = list->first_item;
+  while (item) {
+    if (update) {
+      item->first_verification_not_authentic = item->tmp_first_verification_not_authentic;
+      item->need_second_verification = item->tmp_need_second_verification;
+      item->validation_status = item->tmp_validation_status;
+    } else {
+      item->tmp_first_verification_not_authentic = item->first_verification_not_authentic;
+      item->tmp_need_second_verification = item->need_second_verification;
+      item->tmp_validation_status = item->validation_status;
+    }
+    item = item->next;
+  }
+  return SV_OK;
 }

--- a/lib/src/legacy/legacy_h26x_nalu_list.h
+++ b/lib/src/legacy/legacy_h26x_nalu_list.h
@@ -197,4 +197,7 @@ legacy_h26x_nalu_list_get_str(const legacy_h26x_nalu_list_t* list,
 unsigned int
 legacy_h26x_nalu_list_clean_up(legacy_h26x_nalu_list_t* list);
 
+svrc_t
+legacy_h26x_nalu_list_update_status(legacy_h26x_nalu_list_t* nalu_list, bool update);
+
 #endif  // __LEGACY_H26X_NALU_LIST_H__


### PR DESCRIPTION
At validation starts, SEIs are not synchronized with an I-frame. It is
unknown how many SEIs that cannot be used to validate frames, since
they sign GOPs not present.

This commit loops through all possible validation cases with the SEI
by temporarily use tmp_validation_status and a few more flags. The
validation_status is then updated when the SEI is not feasible to use
in a validation.
