### PR TITLE
Implements signing for AV1

### DIFF
--- a/lib/src/includes/signed_video_sign.h
+++ b/lib/src/includes/signed_video_sign.h
@@ -502,10 +502,13 @@ signed_video_set_recurrence_interval_frames(signed_video_t *self, unsigned recur
  * If this API is not used, SEI payload is written with EPBs, hence equivalent with setting
  * |sei_epb| to True.
  *
+ * NOTE: AV1 does not have emulation prevention. Therefore, this API is not supported for AV1.
+ *
  * @param self Session struct pointer
  * @param sei_epb SEI payload written with EPB (default True)
  *
  * @returns SV_OK SEI w/o EPB was successfully set,
+ *          SV_NOT_SUPPORTED if codec is AV1,
  *          SV_INVALID_PARAMETER Invalid parameter.
  */
 SignedVideoReturnCode

--- a/lib/src/legacy/legacy_h26x_common.c
+++ b/lib/src/legacy/legacy_h26x_common.c
@@ -156,7 +156,7 @@ legacy_gop_info_reset(legacy_gop_info_t *gop_info)
   gop_info->verified_signature_hash = -1;
   // If a reset is forced, the stored hashes in |hash_list| have no meaning anymore.
   gop_info->list_idx = 0;
-  gop_info->has_reference_hash = false;
+  gop_info->has_reference_hash = true;
   gop_info->global_gop_counter_is_synced = false;
 }
 

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -26,6 +26,8 @@
 #include "signed_video_defines.h"  // svrc_t
 #include "signed_video_internal.h"  // gop_info_t, gop_state_t, MAX_HASH_SIZE
 
+#define METADATA_TYPE_USER_PRIVATE 25
+
 typedef struct _h26x_nalu_list_item_t h26x_nalu_list_item_t;
 
 typedef enum {

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -96,8 +96,8 @@ struct sv_setting settings[NUM_SETTINGS] = {
     {SV_CODEC_H264, SV_AUTHENTICITY_LEVEL_FRAME, true, true, false, 0, "sha512", 0, 1, false,
         false},
     // AV1 tests
-    {SV_CODEC_AV1, SV_AUTHENTICITY_LEVEL_GOP, true, true, false, 0, NULL, 0, 1, false, false},
-    {SV_CODEC_AV1, SV_AUTHENTICITY_LEVEL_FRAME, true, true, false, 0, NULL, 0, 1, false, false},
+    {SV_CODEC_AV1, SV_AUTHENTICITY_LEVEL_GOP, true, false, false, 0, NULL, 0, 1, false, false},
+    {SV_CODEC_AV1, SV_AUTHENTICITY_LEVEL_FRAME, true, false, false, 0, NULL, 0, 1, false, false},
 };
 
 static char private_key_rsa[RSA_PRIVATE_KEY_ALLOC_BYTES];
@@ -388,7 +388,9 @@ get_initialized_signed_video(struct sv_setting settings, bool new_private_key)
   ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings.auth_level), SV_OK);
   ck_assert_int_eq(signed_video_set_max_sei_payload_size(sv, settings.max_sei_payload_size), SV_OK);
   ck_assert_int_eq(signed_video_set_hash_algo(sv, settings.hash_algo_name), SV_OK);
-  ck_assert_int_eq(signed_video_set_sei_epb(sv, settings.ep_before_signing), SV_OK);
+  if (settings.codec != SV_CODEC_AV1) {
+    ck_assert_int_eq(signed_video_set_sei_epb(sv, settings.ep_before_signing), SV_OK);
+  }
   ck_assert_int_eq(signed_video_set_using_golden_sei(sv, settings.with_golden_sei), SV_OK);
 
   if (settings.with_golden_sei) {


### PR DESCRIPTION
All signing tests have been enabled.
In addition, has_reference_hash is correctly reset, emulation
prevention API returns NOT SUPPORTED for AV1 and some comment
cleanup in signing tests.
