### PR TITLE
Initializes the GOP hash with a salt

### DIFF
--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -47,8 +47,6 @@
 #define H264_NALU_HEADER_LEN 1  // length of forbidden_zero_bit, nal_ref_idc and nal_unit_type
 #define H265_NALU_HEADER_LEN 2  // length of nal_unit_header as per ISO/ITU spec
 #define AV1_OBU_HEADER_LEN 1
-// The salt added to the recursive hash to get the final gop_hash
-#define GOP_HASH_SALT 1
 
 static bool
 version_str_to_bytes(int *arr, const char *str);
@@ -228,7 +226,6 @@ gop_info_create(void)
   gop_info_t *gop_info = (gop_info_t *)calloc(1, sizeof(gop_info_t));
   if (!gop_info) return NULL;
 
-  gop_info->gop_hash_init = GOP_HASH_SALT;
   gop_info->global_gop_counter = 0;
   // Initialize |verified_signature_hash| as 'error', since we lack data.
   gop_info->verified_signature_hash = -1;

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -230,7 +230,6 @@ struct _gop_info_t {
   size_t hash_list_size;  // The allowed size of the |hash_list|. This can be less than allocated.
   int list_idx;  // Pointing to next available slot in the |hash_list|. If something has gone wrong,
   // like exceeding available memory, |list_idx| = -1.
-  uint8_t gop_hash_init;  // The initialization value for the |gop_hash|.
   uint8_t *nalu_hash;  // Pointing to the memory slot of the NALU hash in |hashes|.
   uint8_t document_hash[MAX_HASH_SIZE];  // Memory for storing the document hash to be signed
   // when SV_AUTHENTICITY_LEVEL_FRAME.

--- a/lib/src/signed_video_openssl.c
+++ b/lib/src/signed_video_openssl.c
@@ -81,6 +81,8 @@ get_path_to_key(const char *dir_to_key, const char *key_filename);
 #define PRIVATE_ECDSA_KEY_FILE "private_ecdsa_key.pem"
 
 #define DEFAULT_HASH_ALGO "sha256"
+// The salt added to the |gop_hash|.
+static const int gop_hash_salt = 1;
 
 /* Frees a key represented by an EVP_PKEY_CTX object. */
 void
@@ -345,6 +347,10 @@ openssl_init_hash(void *handle, bool use_primary_ctx)
     if (!(*ctx)) return SV_EXTERNAL_ERROR;
     // Set a message digest type and initialize the hashing function.
     ret = EVP_DigestInit_ex(*ctx, self->hash_algo.type, NULL);
+  }
+  if (use_primary_ctx && ret == 1) {
+    // Initialize GOP hash with the salt.
+    ret = EVP_DigestUpdate(*ctx, &gop_hash_salt, 1);
   }
   return ret == 1 ? SV_OK : SV_EXTERNAL_ERROR;
 }


### PR DESCRIPTION
Also removes the dead code of the gop_hash_init from the
deprecated recursive procedure.
