### PR TITLE
Remove unused second_hash and has_reference_hash members

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -409,6 +409,8 @@ verify_hashes_with_hash_list(signed_video_t *self,
     int num_missing_nalus = num_expected_hashes - num_invalid_nalus_since_latest_match;
     // No need to check the return value. A failure only affects the statistics. In the worst case
     // we may signal SV_AUTH_RESULT_OK instead of SV_AUTH_RESULT_OK_WITH_MISSING_INFO.
+    // TODO: Investigate whether adding missing items to the start of the list could cause problems
+    // during the validation of multiple GOPs in one go.
     h26x_nalu_list_add_missing(nalu_list, num_missing_nalus, true, nalu_list->first_item);
   }
 

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -209,7 +209,6 @@ prepare_for_link_and_gop_hash_verification(signed_video_t *self, h26x_nalu_list_
   h26x_nalu_list_t *nalu_list = self->nalu_list;
   const size_t hash_size = self->verify_data->hash_size;
   h26x_nalu_list_item_t *item = NULL;
-  const uint8_t *hash_to_add = NULL;
   int num_nalus_in_gop = 0;
   assert(nalu_list);
 
@@ -244,9 +243,8 @@ prepare_for_link_and_gop_hash_verification(signed_video_t *self, h26x_nalu_list_
       if (item == sei) {
         break;  // Break if encountered SEI frame.
       }
-      hash_to_add = item->hash;
       // Since the GOP hash is initialized, it can be updated with each incoming NALU hash.
-      SV_THROW(openssl_update_hash(self->crypto_handle, hash_to_add, hash_size, true));
+      SV_THROW(openssl_update_hash(self->crypto_handle, item->hash, hash_size, true));
       item->used_in_gop_hash = true;  // Mark the item as used in the GOP hash
       num_nalus_in_gop++;
 
@@ -336,7 +334,7 @@ verify_hashes_with_hash_list(signed_video_t *self,
   // Initialization
   int latest_match_idx = -1;  // The latest matching hash in |hash_list|
   int compare_idx = 0;  // The offset in |hash_list| selecting the hash to compared
-                        // against the |hash_to_verify|
+                        // against the |item->hash|
   bool found_next_gop = false;
   bool found_item_after_sei = false;
   h26x_nalu_list_item_t *item = nalu_list->first_item;
@@ -362,16 +360,14 @@ verify_hashes_with_hash_list(signed_video_t *self,
     }
     num_verified_hashes++;
 
-    // Fetch the |hash_to_verify|
-    uint8_t *hash_to_verify = item->hash;
-    // Compare |hash_to_verify| against all the |expected_hashes| since the |latest_match_idx|. Stop
+    // Compare |item->hash| against all the |expected_hashes| since the |latest_match_idx|. Stop
     // when we get a match or reach the end.
     compare_idx = latest_match_idx + 1;
     // This while-loop searches for a match among the feasible hashes in |hash_list|.
     while (compare_idx < num_expected_hashes) {
       uint8_t *expected_hash = &expected_hashes[compare_idx * hash_size];
 
-      if (memcmp(hash_to_verify, expected_hash, hash_size) == 0) {
+      if (memcmp(item->hash, expected_hash, hash_size) == 0) {
         // We have a match. Set tmp_validation_status and add missing nalus if we have detected any.
         item->tmp_validation_status = order_ok ? '.' : 'N';
         // Add missing items to |nalu_list|.
@@ -411,13 +407,9 @@ verify_hashes_with_hash_list(signed_video_t *self,
   if (latest_match_idx == -1) {
     DEBUG_LOG("Never found a matching hash at all");
     int num_missing_nalus = num_expected_hashes - num_invalid_nalus_since_latest_match;
-    // We do not know where in the sequence of NALUs they were lost. Simply add them before the
-    // first item. If the first item needs a second opinion, that is, it has already been verified
-    // once, we append that item. Otherwise, prepend it with missing items.
-    const bool append = !!nalu_list->first_item->nalu->is_first_nalu_in_gop;
     // No need to check the return value. A failure only affects the statistics. In the worst case
     // we may signal SV_AUTH_RESULT_OK instead of SV_AUTH_RESULT_OK_WITH_MISSING_INFO.
-    h26x_nalu_list_add_missing(nalu_list, num_missing_nalus, append, nalu_list->first_item);
+    h26x_nalu_list_add_missing(nalu_list, num_missing_nalus, true, nalu_list->first_item);
   }
 
   // If the last invalid NALU is the first NALU in a GOP or the NALU after the SEI, keep it

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -92,10 +92,6 @@ struct _h26x_nalu_list_item_t {
   //       invalid NALU.
   uint8_t hash[MAX_HASH_SIZE];  // The hash of the NALU is stored in this memory slot, if it is
   // hashable that is.
-  uint8_t *second_hash;  // The hash used for a second verification. Some NALUs, for example the
-  // first NALU in a GOP is used in two neighboring GOPs, but with different hashes. The NALU might
-  // also require a second verification due to lost NALUs. Memory for this hash is allocated when
-  // needed.
   size_t hash_size;
   // Flags
   bool taken_ownership_of_nalu;  // Flag to indicate if the item has taken ownership of the |nalu|

--- a/lib/src/signed_video_h26x_nalu_list.c
+++ b/lib/src/signed_video_h26x_nalu_list.c
@@ -111,7 +111,6 @@ h26x_nalu_list_item_free(h26x_nalu_list_item_t *item)
     }
     free(item->nalu);
   }
-  free(item->second_hash);
   free(item);
 }
 
@@ -155,7 +154,6 @@ h26x_nalu_list_item_print(const h26x_nalu_list_item_t *item)
   // h26x_nalu_t *nalu;
   // char validation_status;
   // uint8_t hash[MAX_HASH_SIZE];
-  // uint8_t *second_hash;
   // bool taken_ownership_of_nalu;
   // bool has_been_decoded;
   // bool used_in_gop_hash;
@@ -174,7 +172,6 @@ h26x_nalu_list_item_print(const h26x_nalu_list_item_t *item)
       (item->has_been_decoded ? ", has_been_decoded" : ""),
       (item->used_in_gop_hash ? ", used_in_gop_hash" : ""));
   sv_print_hex_data(item->hash, item->hash_size, "item->hash     ");
-  sv_print_hex_data(item->second_hash, item->hash_size, "item->second_hash ");
 }
 #endif
 

--- a/lib/src/signed_video_h26x_sign.c
+++ b/lib/src/signed_video_h26x_sign.c
@@ -403,8 +403,6 @@ generate_sei_nalu(signed_video_t *self, uint8_t **payload, uint8_t **payload_sig
     // Reset the |hash_list| by rewinding the |list_idx| since we start a new GOP.
     gop_info->list_idx = 0;
 
-    // End of GOP. Reset flag to get new reference.
-    self->gop_info->has_reference_hash = false;
     // Reset the timestamp to avoid including a duplicate in the next SEI.
     gop_info->has_timestamp = false;
 

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -221,7 +221,6 @@ typedef enum { GOP_HASH = 0, DOCUMENT_HASH = 1, NUM_HASH_TYPES } hash_type_t;
 struct _gop_info_t {
   uint8_t hash_buddies[2 * MAX_HASH_SIZE];  // Memory for two hashes organized as
   // [reference_hash, nalu_hash].
-  bool has_reference_hash;  // Flags if the reference hash in |hash_buddies| is valid.
   uint8_t hashes[2 * MAX_HASH_SIZE];  // Memory for storing, in order, the gop_hash and
   // 'latest hash'.
   uint8_t *gop_hash;  // Pointing to the memory slot of the gop_hash in |hashes|.


### PR DESCRIPTION
The second_hash member is no longer required as linking is now handled
with a separate hash in the TLV instead of being part of the hash list.
Consequently, the I-frame is now hashed in only one way. Additionally,
the has_reference_hash member has been removed as part of this cleanup.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
