### PR TITLE
Remove validate_after_next_nalu member

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -953,9 +953,6 @@ has_pending_gop(signed_video_t *self)
     item = item->next;
   }
 
-  if (!found_pending_gop && last_hashable_item && last_hashable_item->nalu->is_gop_sei) {
-    gop_state->validate_after_next_nalu = true;
-  }
   gop_state->no_gop_end_before_sei = found_pending_nalu_after_gop_sei && (num_pending_gop_ends < 2);
 
   return found_pending_gop;

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -890,7 +890,6 @@ gop_state_print(const gop_state_t *gop_state)
   if (!gop_state) return;
 
   DEBUG_LOG("                 has_sei: %u", gop_state->has_sei);
-  DEBUG_LOG("validate_after_next_nalu: %u", gop_state->validate_after_next_nalu);
   DEBUG_LOG("   no_gop_end_before_sei: %u", gop_state->no_gop_end_before_sei);
   DEBUG_LOG("            has_lost_sei: %u", gop_state->has_lost_sei);
   DEBUG_LOG("  gop_transition_is_lost: %u", gop_state->gop_transition_is_lost);
@@ -922,7 +921,6 @@ gop_state_reset(gop_state_t *gop_state)
   gop_state->gop_transition_is_lost = false;
   gop_state->has_sei = false;
   gop_state->no_gop_end_before_sei = false;
-  gop_state->validate_after_next_nalu = false;
 }
 
 /* Others */

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -97,8 +97,6 @@ struct _gop_state_t {
   bool gop_transition_is_lost;  // The transition between GOPs has been lost.
   // This can be detected if a lost SEI is detected, and at the same time waiting for an I NALU. An
   // example when this happens is if an entire AU is lost including both the SEI and the I NALU.
-  bool validate_after_next_nalu;  // State to inform the algorithm to perform validation up the next
-  // hashable NALU.
 };
 
 // Buffer of |last_two_bytes| and pointers to |sei| memory and current |write_position|.


### PR DESCRIPTION
Removed the validate_after_next_nalu member as it is no longer required for the current validation process.

Change-Id: I7259d2a858e740dc8cd649f74ef2aefd4dc28b2d

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
