### PR TITLE
Remove gop_state struct and migrate relevant members

### DIFF
--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -916,7 +916,7 @@ has_pending_gop(signed_video_t *self)
   bool found_pending_gop_sei = false;
   bool found_pending_gop = false;
 
-  // Reset the GOP-related |has_lost_sei|member before running through the NALUs in |nalu_list|.
+  // Reset the GOP-related |has_lost_sei| member before running through the NALUs in |nalu_list|.
   self->validation_flags.has_lost_sei = false;
 
   while (item && !found_pending_gop) {

--- a/lib/src/signed_video_h26x_auth.c
+++ b/lib/src/signed_video_h26x_auth.c
@@ -29,9 +29,9 @@
 #include "legacy_validation.h"
 #include "signed_video_authenticity.h"  // create_local_authenticity_report_if_needed()
 #include "signed_video_defines.h"  // svrc_t
-#include "signed_video_h26x_internal.h"  // gop_state_*(), update_validation_flags()
+#include "signed_video_h26x_internal.h"  // update_validation_flags()
 #include "signed_video_h26x_nalu_list.h"  // h26x_nalu_list_append()
-#include "signed_video_internal.h"  // gop_info_t, gop_state_t
+#include "signed_video_internal.h"  // gop_info_t, validation_flags_t
 #include "signed_video_openssl_internal.h"  // openssl_{verify_hash, public_key_malloc}()
 #include "signed_video_tlv.h"  // tlv_find_tag()
 
@@ -90,12 +90,6 @@ decode_sei_data(signed_video_t *self, const uint8_t *payload, size_t payload_siz
   SV_TRY()
     SV_THROW_WITH_MSG(tlv_decode(self, payload, payload_size), "Failed decoding SEI payload");
     detect_lost_sei(self);
-    // Every SEI is associated with a GOP. If a lost SEI has been detected, and no GOP end has been
-    // found prior to this SEI, it means both a SEI and an I-frame was lost. This is defined as a
-    // lost GOP transition.
-    if (self->gop_state.no_gop_end_before_sei && self->gop_state.has_lost_sei) {
-      self->gop_state.gop_transition_is_lost = true;
-    }
   SV_CATCH()
   SV_DONE(status)
 
@@ -124,7 +118,7 @@ detect_lost_sei(signed_video_t *self)
 
   // It is only possible to know if a SEI has been lost if the |global_gop_counter| is in sync.
   // Otherwise, the counter cannot be trusted.
-  self->gop_state.has_lost_sei =
+  self->validation_flags.has_lost_sei =
       (potentially_missed_gops > 0) && self->gop_info->global_gop_counter_is_synced;
 }
 
@@ -629,7 +623,6 @@ validate_authenticity(signed_video_t *self)
 {
   assert(self);
 
-  gop_state_t *gop_state = &(self->gop_state);
   validation_flags_t *validation_flags = &(self->validation_flags);
   signed_video_latest_validation_t *latest = self->latest_validation;
 
@@ -641,7 +634,7 @@ validate_authenticity(signed_video_t *self)
   int num_missed_nalus = -1;
   bool verify_success = false;
 
-  if (gop_state->has_lost_sei && !gop_state->gop_transition_is_lost) {
+  if (validation_flags->has_lost_sei) {
     DEBUG_LOG("We never received the SEI associated with this GOP");
     // We never received the SEI nalu, but we know we have passed a GOP transition. Hence, we cannot
     // verify this GOP. Marking this GOP as not OK by verify_hashes_without_sei().
@@ -727,7 +720,7 @@ validate_authenticity(signed_video_t *self)
     latest->authenticity = valid;
   }
   latest->number_of_received_picture_nalus += num_received_nalus;
-  if (self->gop_state.has_lost_sei) {
+  if (self->validation_flags.has_lost_sei) {
     latest->number_of_expected_picture_nalus = -1;
   } else if (latest->number_of_expected_picture_nalus != -1) {
     latest->number_of_expected_picture_nalus += num_expected_nalus;
@@ -802,7 +795,6 @@ prepare_golden_sei(signed_video_t *self, h26x_nalu_list_item_t *sei)
     SV_THROW(hash_and_add_for_auth(self, sei));
     memcpy(verify_data->hash, sei->hash, verify_data->hash_size);
 
-    self->gop_state.has_sei = true;
     SV_THROW(prepare_for_validation(self));
   SV_CATCH()
   SV_DONE(status)
@@ -880,7 +872,7 @@ prepare_for_validation(signed_video_t *self)
 #endif
 
     // If we have received a SEI there is a signature to use for verification.
-    if (self->gop_state.has_sei) {
+    if (sei) {
       SV_THROW(openssl_verify_hash(verify_data, &self->gop_info->verified_signature_hash));
     }
 
@@ -918,7 +910,7 @@ static bool
 has_pending_gop(signed_video_t *self)
 {
   assert(self && self->nalu_list);
-  gop_state_t *gop_state = &(self->gop_state);
+  validation_flags_t *validation_flags = &(self->validation_flags);
   h26x_nalu_list_item_t *item = self->nalu_list->first_item;
   h26x_nalu_list_item_t *last_hashable_item = NULL;
   // Statistics collected while looping through the NALUs.
@@ -927,11 +919,10 @@ has_pending_gop(signed_video_t *self)
   bool found_pending_nalu_after_gop_sei = false;
   bool found_pending_gop = false;
 
-  // Reset the |gop_state| members before running through the NALUs in |nalu_list|.
-  gop_state_reset(gop_state);
+  // Reset the |validation_flags| members before running through the NALUs in |nalu_list|.
+  reset_gop_info_from_validation_flags(validation_flags);
 
   while (item && !found_pending_gop) {
-    gop_state_update(gop_state, item->nalu);
     // Collect statistics from pending and hashable NALUs only. The others are either out of date or
     // not part of the validation.
     if (item->tmp_validation_status == 'P' && item->nalu && item->nalu->is_hashable) {
@@ -952,8 +943,6 @@ has_pending_gop(signed_video_t *self)
     found_pending_gop |= found_pending_nalu_after_gop_sei;
     item = item->next;
   }
-
-  gop_state->no_gop_end_before_sei = found_pending_nalu_after_gop_sei && (num_pending_gop_ends < 2);
 
   return found_pending_gop;
 }

--- a/lib/src/signed_video_h26x_common.c
+++ b/lib/src/signed_video_h26x_common.c
@@ -869,7 +869,6 @@ validation_flags_init(validation_flags_t *validation_flags)
 
   memset(validation_flags, 0, sizeof(validation_flags_t));
   validation_flags->is_first_validation = true;
-  validation_flags->has_lost_sei = false;
 }
 
 void
@@ -1251,7 +1250,6 @@ signed_video_reset(signed_video_t *self)
     SV_THROW(legacy_sv_reset(self->legacy_sv));
     self->signing_started = false;
     self->sei_generation_enabled = false;
-    self->validation_flags.has_lost_sei = false;
     gop_info_reset(self->gop_info);
 
     validation_flags_init(&(self->validation_flags));

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -147,7 +147,7 @@ struct _h26x_nalu_t {
   bool is_golden_sei;
 };
 
-/* Internal APIs for gop_state_t functions */
+/* Internal APIs for validation_flags_t functions */
 
 void
 validation_flags_print(const validation_flags_t *validation_flags);
@@ -155,13 +155,9 @@ validation_flags_print(const validation_flags_t *validation_flags);
 void
 validation_flags_init(validation_flags_t *validation_flags);
 
-/* Updates the |gop_state| w.r.t. a |nalu|. */
+/* Updates the |validation_flags| w.r.t. a |nalu|. */
 void
 update_validation_flags(validation_flags_t *validation_flags, h26x_nalu_t *nalu);
-
-/* Resets/Initializes the gop information in |validation_flags_t| after validating a GOP. */
-void
-reset_gop_info_from_validation_flags(validation_flags_t *gop_state);
 
 /* Others */
 void

--- a/lib/src/signed_video_h26x_internal.h
+++ b/lib/src/signed_video_h26x_internal.h
@@ -159,16 +159,9 @@ validation_flags_init(validation_flags_t *validation_flags);
 void
 update_validation_flags(validation_flags_t *validation_flags, h26x_nalu_t *nalu);
 
+/* Resets/Initializes the gop information in |validation_flags_t| after validating a GOP. */
 void
-gop_state_print(const gop_state_t *gop_state);
-
-/* Updates the |gop_state| w.r.t. a |nalu|. */
-void
-gop_state_update(gop_state_t *gop_state, h26x_nalu_t *nalu);
-
-/* Resets/Initializes the |gop_state| after validating a GOP. */
-void
-gop_state_reset(gop_state_t *gop_state);
+reset_gop_info_from_validation_flags(validation_flags_t *gop_state);
 
 /* Others */
 void

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -87,10 +87,9 @@ struct _validation_flags_t {
   // from false to true unless a reset is performed.
   bool is_first_sei;  // Indicates that this is the first received SEI.
   bool hash_algo_known;  // Information on what hash algorithm to use has been received.
+
+  // GOP-related flags.
   bool has_lost_sei;  // Has detected a lost SEI since last validation.
-  bool gop_transition_is_lost;  // The transition between GOPs has been lost.
-  // This can be detected if a lost SEI is detected, and at the same time waiting for an I NALU. An
-  // example when this happens is if an entire AU is lost including both the SEI and the I NALU.
 };
 
 // Buffer of |last_two_bytes| and pointers to |sei| memory and current |write_position|.

--- a/lib/src/signed_video_internal.h
+++ b/lib/src/signed_video_internal.h
@@ -34,7 +34,6 @@
 
 typedef struct _gop_info_t gop_info_t;
 typedef struct _validation_flags_t validation_flags_t;
-typedef struct _gop_state_t gop_state_t;
 typedef struct _sei_data_t sei_data_t;
 
 // Forward declare h26x_nalu_list_t here for signed_video_t.
@@ -88,12 +87,7 @@ struct _validation_flags_t {
   // from false to true unless a reset is performed.
   bool is_first_sei;  // Indicates that this is the first received SEI.
   bool hash_algo_known;  // Information on what hash algorithm to use has been received.
-};
-
-struct _gop_state_t {
-  bool has_sei;  // The GOP includes a SEI.
   bool has_lost_sei;  // Has detected a lost SEI since last validation.
-  bool no_gop_end_before_sei;  // No GOP end (I-frame) has been found before the SEI.
   bool gop_transition_is_lost;  // The transition between GOPs has been lost.
   // This can be detected if a lost SEI is detected, and at the same time waiting for an I NALU. An
   // example when this happens is if an entire AU is lost including both the SEI and the I NALU.
@@ -190,7 +184,6 @@ struct _signed_video_t {
   // authenticating. |received_gop_hash| will be compared against |computed_gop_hash|.
 
   validation_flags_t validation_flags;
-  gop_state_t gop_state;
   bool has_public_key;  // State to indicate if public key is received/added
   // For signature verification
   sign_or_verify_data_t *verify_data;  // All necessary information to verify a signature.


### PR DESCRIPTION
The gop_state struct is now obsolete following the removal of the state
machine. Its functionality has been replaced by validation_flags. Most
members of gop_state are unnecessary and have been removed. Any remaining
relevant members have been migrated to validation_flags.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
