### PR TITLE
Adds a setter for max_signing_frames

### DIFF
--- a/lib/src/includes/signed_video_sign.h
+++ b/lib/src/includes/signed_video_sign.h
@@ -609,6 +609,36 @@ signed_video_set_max_sei_payload_size(signed_video_t *self, size_t max_sei_paylo
 SignedVideoReturnCode
 signed_video_set_hash_algo(signed_video_t *self, const char *name_or_oid);
 
+/**
+ * @brief Sets an upper limit on number of frames before signing
+ *
+ * The default behavior of the Signed Video library is to sign and generate a SEI every
+ * GOP (Group Of Pictures). When very long GOPs are used, the duration between signatures
+ * can become impractically long, or even makes a file export on the validation side
+ * infeasible to validate because the segment lacks a SEI.
+ *
+ * This API allows the user to set an upper limit on how many frames that can be added
+ * before sending a signing request. If this limit is reached, an intermediate SEI is
+ * generated. This limit will not affect the normal behavior of signing when reaching the
+ * end of a GOP (or when the signing frequency set with
+ * signed_video_set_signing_frequency(...) (to be implemented)).
+ * If |max_signing_frames| = 0, no limit is used. This is the default behavior.
+ *
+ * @note the difference between 'frames' and 'Bitstream Units'. A frame can be split in
+ * several slices. To avoid creating a SEI and signing it in the middle of a frame only
+ * primary slices are counted.
+ * @note that it is the responsibility to set a value that will not jeopardize the signing
+ * functionality. For example, signing every frame (max_signing_frames = 1) can be
+ * infeasible in practice since signing takes longer than the duration between frames.
+ *
+ * @param self Pointer to the Signed Video session.
+ * @param max_signing_frames Maximum number of frames covered by a signatures.
+ *
+ * @return An appropriate Signed Video Return Code.
+ */
+SignedVideoReturnCode
+signed_viedo_set_max_signing_frames(signed_video_t *self, unsigned max_signing_frames);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -129,6 +129,7 @@ struct _signed_video_t {
   size_t max_sei_payload_size;  // Default 0 = unlimited
   unsigned signing_frequency;  // Number of GOPs per signature (default 1)
   unsigned recurrence;
+  unsigned max_signing_frames;
 
   // Flags
   bool add_public_key_to_sei;

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -958,3 +958,14 @@ signed_video_set_hash_algo(signed_video_t *self, const char *name_or_oid)
 
   return status;
 }
+
+SignedVideoReturnCode
+signed_viedo_set_max_signing_frames(signed_video_t *self, unsigned max_signing_frames)
+{
+  if (!self) {
+    return SV_INVALID_PARAMETER;
+  }
+  self->max_signing_frames = max_signing_frames;
+
+  return SV_OK;
+}

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1355,7 +1355,7 @@ mimic_file_export(struct sv_setting setting)
   if (setting.signing_frequency == 3) {
     // Only works for hard coded signing frequency.
     test_stream_check_types(list, "VIPPIsPPPPPIsPPISPPPPPPPPPIsPPPPPIsPISPP");
-  } else if (setting.max_signing_bu == 4) {
+  } else if (setting.max_signing_frames == 4) {
     // Only works for hard coded max signing BUs.
     // test_stream_check_types(list, "VIPPISPPPPSPISPPISPPPPSPPPPSPISPPPPSPISPISPP");
     test_stream_check_types(list, "VIPPISPPPPPISPPISPPPPPPPPPISPPPPPISPISPP");
@@ -1375,7 +1375,7 @@ mimic_file_export(struct sv_setting setting)
   test_stream_prepend_first_item(list, ps);
   if (setting.signing_frequency == 3) {
     test_stream_check_types(list, "VIsPPPPPIsPPISPPPPPPPPPIsPPPPPIsPISPP");
-  } else if (setting.max_signing_bu == 4) {
+  } else if (setting.max_signing_frames == 4) {
     // test_stream_check_types(list, "VISPPPPSPISPPISPPPPSPPPPSPISPPPPSPISPISPP");
     test_stream_check_types(list, "VISPPPPPISPPISPPPPPPPPPISPPPPPISPISPP");
   } else {
@@ -2186,8 +2186,8 @@ START_TEST(sign_partial_gops)
 {
   // Device side
   struct sv_setting setting = settings[_i];
-  const unsigned max_signing_bu = 4;  // Trigger signing after reaching 4 Bitstream Units.
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;  // Trigger signing after reaching 4 Bitstream Units.
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = create_signed_stream("IPPPPPIPPIPPPPPPPPPIP", setting);
   // Expected when activated
   // test_stream_check_types(list, "IPPPPSPISPPISPPPPSPPPPSPISP");
@@ -2222,8 +2222,8 @@ START_TEST(all_seis_arrive_late_partial_gops)
 {
   // Device side
   struct sv_setting setting = settings[_i];
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   const int delay = 3;
   setting.delay = delay;
   test_stream_t *list = create_signed_stream("IPPPPPIPPIPPPPPPPPPIPPPPP", setting);
@@ -2260,8 +2260,8 @@ START_TEST(file_export_and_scrubbing_partial_gops)
 {
   // Device side
   struct sv_setting setting = settings[_i];
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = mimic_file_export(setting);
 
   // Client side
@@ -2338,8 +2338,8 @@ START_TEST(modify_one_p_frame_partial_gops)
 {
   // Device side
   struct sv_setting setting = settings[_i];
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = create_signed_stream("IPPPPPIPPIPPPPPIP", setting);
   // Expected when activated
   // test_stream_check_types(list, "IPPPPSPISPPISPPPPSPISP");
@@ -2379,8 +2379,8 @@ START_TEST(remove_one_p_frame_partial_gops)
 {
   // Device side
   struct sv_setting setting = settings[_i];
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = create_signed_stream("IPPPPPIPPIPPPPPIP", setting);
   // Expected when activated
   // test_stream_check_types(list, "IPPPPSPISPPISPPPPSPISP");
@@ -2440,8 +2440,8 @@ START_TEST(add_one_p_frame_partial_gops)
 {
   // Device side
   struct sv_setting setting = settings[_i];
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = create_signed_stream("IPPPPPIPPIPPPPPIP", setting);
   // Expected when activated
   // test_stream_check_types(list, "IPPPPSPISPPISPPPPSPISP");
@@ -2500,8 +2500,8 @@ START_TEST(modify_one_i_frame_partial_gops)
   // Device side
   struct sv_setting setting = settings[_i];
   // Select a signing frequency longer than every GOP
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = create_signed_stream("IPPPPPIPPIPPPPPIPPIPIP", setting);
   // Expected when activated
   // test_stream_check_types(list, "IPPPPSPISPPISPPPPSPISPPISPISP");
@@ -2542,8 +2542,8 @@ START_TEST(remove_one_i_frame_partial_gops)
 {
   // Device side
   struct sv_setting setting = settings[_i];
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = create_signed_stream("IPPPPPIPPIPPPPPIPPIPIP", setting);
   // Expected when activated
   // test_stream_check_types(list, "IPPPPSPISPPISPPPPSPISPPISPISP");
@@ -2588,8 +2588,8 @@ START_TEST(modify_one_sei_frame_partial_gops)
 {
   // Device side
   struct sv_setting setting = settings[_i];
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = create_signed_stream("IPPPPPIPPIPPPPPIPPIPIP", setting);
   // Expected when activated
   // test_stream_check_types(list, "IPPPPSPISPPISPPPPSPISPPISPISP");
@@ -2635,8 +2635,8 @@ START_TEST(remove_one_sei_frame_partial_gops)
   // Device side
   struct sv_setting setting = settings[_i];
   // Select a signing frequency longer than every GOP
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = create_signed_stream("IPPPPPIPPIPPPPPIPPIPIP", setting);
   // Expected when activated
   // test_stream_check_types(list, "IPPPPSPISPPISPPPPSPISPPISPISP");

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -222,6 +222,12 @@ START_TEST(api_inputs)
   sv_rc = signed_video_set_recurrence_interval_frames(sv, 1);
   ck_assert_int_eq(sv_rc, SV_OK);
 
+  // Check setting max signing frames
+  sv_rc = signed_viedo_set_max_signing_frames(NULL, 1);
+  ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
+  sv_rc = signed_viedo_set_max_signing_frames(sv, 1);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
   // Setting validation level.
   sv_rc = signed_video_set_authenticity_level(NULL, SV_AUTHENTICITY_LEVEL_GOP);
   ck_assert_int_eq(sv_rc, SV_INVALID_PARAMETER);
@@ -1042,8 +1048,8 @@ START_TEST(signing_partial_gops)
 {
   struct sv_setting setting = settings[_i];
   // Select a maximum number of added Bitstream Units before signing.
-  const unsigned max_signing_bu = 4;
-  setting.max_signing_bu = max_signing_bu;
+  const unsigned max_signing_frames = 4;
+  setting.max_signing_frames = max_signing_frames;
   test_stream_t *list = create_signed_stream("IPPIPPPPPPPPPPPPIPPPIP", setting);
   // Expected when activated
   // test_stream_check_types(list, "IPPISPPPPSPPPPSPPPPSISPPPISP");

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -500,6 +500,7 @@ get_initialized_signed_video(struct sv_setting settings, bool new_private_key)
   ck_assert_int_eq(signed_video_set_product_info(sv, HW_ID, FW_VER, SER_NO, MANUFACT, ADDR), SV_OK);
   ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings.auth_level), SV_OK);
   ck_assert_int_eq(signed_video_set_max_sei_payload_size(sv, settings.max_sei_payload_size), SV_OK);
+  ck_assert_int_eq(signed_viedo_set_max_signing_frames(sv, settings.max_signing_frames), SV_OK);
   ck_assert_int_eq(signed_video_set_hash_algo(sv, settings.hash_algo_name), SV_OK);
   if (settings.codec != SV_CODEC_AV1) {
     ck_assert_int_eq(signed_video_set_sei_epb(sv, settings.ep_before_signing), SV_OK);

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -81,7 +81,7 @@ const int64_t g_testTimestamp = 42;
 //   bool with_golden_sei;
 //   size_t max_sei_payload_size;
 //   const char *hash_algo_name;
-//   unsigned max_signing_bu;
+//   unsigned max_signing_frames;
 //   unsigned signing_frequency;
 //   bool increased_sei_size;
 //   int vendor_axis_mode;

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -48,7 +48,7 @@ struct sv_setting {
   bool with_golden_sei;
   size_t max_sei_payload_size;
   const char *hash_algo_name;
-  unsigned max_signing_bu;  // Not yet activated
+  unsigned max_signing_frames;  // Not yet activated
   unsigned signing_frequency;  // Not yet activated
   bool increased_sei_size;
   int vendor_axis_mode;  // 0: not Axis, 1: attestation, 2: factory provisioned


### PR DESCRIPTION
The member name has changed from max_signing_bu because it is
easier for the user to count frames rather than Bitstream
Units.

API tests have been added.
