### PR TITLE
Remove unused member signature_hash_type

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -203,8 +203,6 @@ struct _signed_video_t {
   legacy_sv_t *legacy_sv;
 };
 
-typedef enum { GOP_HASH = 0, DOCUMENT_HASH = 1, NUM_HASH_TYPES } hash_type_t;
-
 /**
  * Information related to the GOP signature.
  * The |gop_hash| is a recursive hash. It is the hash of the memory [gop_hash, latest hash] and then
@@ -236,7 +234,6 @@ struct _gop_info_t {
   // side.
   uint16_t num_in_gop_hash;  // Counted number of BUs in the currently recursively updated
   // |gop_hash|.
-  hash_type_t signature_hash_type;  // The type of hash signed, either gop_hash or document hash.
   uint32_t global_gop_counter;  // The index of the current GOP, incremented when encoded in the
   // TLV.
   uint32_t latest_validated_gop;  // The index of latest validated GOP.

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -208,11 +208,6 @@ generate_sei(signed_video_t *self, uint8_t **payload, uint8_t **payload_signatur
     return SV_NOT_SUPPORTED;
   }
 
-  // The |signature_hash_type| is now always set to |DOCUMENT_HASH|. The use of |GOP_HASH|
-  // has been removed. If the |hash_list| is successfully added, |signature_hash_type|
-  // remains |DOCUMENT_HASH|. This behavior applies consistently, including for golden SEI hashes.
-  self->gop_info->signature_hash_type = DOCUMENT_HASH;
-
   svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     // Get the total payload size of all TLVs. Then compute the total size of the SEI to be
@@ -389,11 +384,8 @@ generate_sei(signed_video_t *self, uint8_t **payload, uint8_t **payload_signatur
     }
 
     gop_info_t *gop_info = self->gop_info;
-    if (gop_info->signature_hash_type == DOCUMENT_HASH) {
-      memcpy(sign_data->hash, gop_info->document_hash, hash_size);
-    } else {
-      memcpy(sign_data->hash, gop_info->gop_hash, hash_size);
-    }
+
+    memcpy(sign_data->hash, gop_info->document_hash, hash_size);
 
     // Reset the |num_in_gop_hash| since we start a new GOP.
     gop_info->num_in_gop_hash = 0;

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -913,7 +913,7 @@ decode_signature(signed_video_t *self, const uint8_t *data, size_t data_size)
   svrc_t status = SV_UNKNOWN_FAILURE;
 
   SV_TRY()
-    SV_THROW_IF(version > 0 && version < 3, SV_OK);
+    SV_THROW_IF(version < 1 || version > 2, SV_INCOMPATIBLE_VERSION);
     SV_THROW_IF(max_signature_size < signature_size, SV_AUTHENTICATION_ERROR);
     if (!*signature_ptr) {
       verify_data->max_signature_size = 0;

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -842,7 +842,7 @@ encode_signature(signed_video_t *self, uint8_t *data)
   gop_info_t *gop_info = self->gop_info;
   sign_or_verify_data_t *sign_data = self->sign_data;
   size_t data_size = 0;
-  const uint8_t version = 1;  // Increment when the change breaks the format
+  const uint8_t version = 2;  // Increment when the change breaks the format
 
   // Value fields:
   //  - version (1 byte)
@@ -898,6 +898,7 @@ decode_signature(signed_video_t *self, const uint8_t *data, size_t data_size)
   uint8_t **signature_ptr = &verify_data->signature;
   uint8_t version = *data_ptr++;
   uint8_t encoding_status = *data_ptr++;
+  if(version < 2) (void)(*data_ptr++); //If the version is older than 2 move past the hash_type byte.
   uint16_t signature_size = 0;
   size_t max_signature_size = 0;
 

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -898,7 +898,10 @@ decode_signature(signed_video_t *self, const uint8_t *data, size_t data_size)
   uint8_t **signature_ptr = &verify_data->signature;
   uint8_t version = *data_ptr++;
   uint8_t encoding_status = *data_ptr++;
-  if(version < 2) (void)(*data_ptr++); //If the version is older than 2 move past the hash_type byte.
+  if (version < 2) {
+    // Move past the written hash type since it is never used.
+    data_ptr++;
+  }
   uint16_t signature_size = 0;
   size_t max_signature_size = 0;
 

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -913,7 +913,7 @@ decode_signature(signed_video_t *self, const uint8_t *data, size_t data_size)
   svrc_t status = SV_UNKNOWN_FAILURE;
 
   SV_TRY()
-    SV_THROW_IF(version == 0, SV_INCOMPATIBLE_VERSION);
+    SV_THROW_IF(version > 0 && version < 3, SV_OK);
     SV_THROW_IF(max_signature_size < signature_size, SV_AUTHENTICATION_ERROR);
     if (!*signature_ptr) {
       verify_data->max_signature_size = 0;


### PR DESCRIPTION
The member signature_hash_type was unused in the codebase and
has been removed

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
