### PR TITLE
Remove unused member gop_hash_off

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -141,10 +141,6 @@ struct _signed_video_t {
                                 // the first signing attempt, triggering SEI generation at the end
                                 // of GOP.
 
-  // TODO: Once the transition to linking to previous GOP is complete, the following flag will be
-  // unnecessary.
-  bool gop_hash_off;  // Flag indicating if the GENERAL TAG doesn't include GOP hash.
-  // TODO: |gop_hash_off| will be deprecated when the feature is fully integrated.
   // TODO: Remove this flag when the deprecated API get_nalus_to_prepend have been removed.
   bool avoid_checking_available_seis;  // Temporary flag to avoid checking for available SEIs when
                                        // peek NAL Units are used when getting SEIs, since they

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -338,7 +338,7 @@ generate_sei(signed_video_t *self, uint8_t **payload, uint8_t **payload_signatur
     uint8_t reserved_byte = self->sei_epb << 7;
     reserved_byte |= self->is_golden_sei << 6;
     reserved_byte |= 1 << 5;
-    reserved_byte |= !self->gop_hash_off << 4;
+    reserved_byte |= 1 << 4;
     *payload_ptr++ = reserved_byte;
 
     size_t written_size = 0;


### PR DESCRIPTION
The member gop_hash_off was unused in the codebase and has been removed.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
