### PR TITLE
Remove unused member gop_hash from gop_info_t struct

### DIFF
--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -227,9 +227,8 @@ gop_info_create(void)
   // Initialize |verified_signature_hash| as 'error', since we lack data.
   gop_info->verified_signature_hash = -1;
 
-  // Set shortcut pointers to the gop_hash and BU hash parts of the memory.
-  gop_info->gop_hash = gop_info->hashes;
-  gop_info->bu_hash = gop_info->hashes + DEFAULT_HASH_SIZE;
+  // Set shortcut pointers to the BU hash part of the memory.
+  gop_info->bu_hash = gop_info->hashes;
 
   // Set hash_list_size to same as what is allocated.
   if (set_hash_list_size(gop_info, HASH_LIST_SIZE) != SV_OK) {

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -214,8 +214,7 @@ typedef enum { GOP_HASH = 0, DOCUMENT_HASH = 1, NUM_HASH_TYPES } hash_type_t;
 struct _gop_info_t {
   uint8_t hash_buddies[2 * MAX_HASH_SIZE];  // Memory for two hashes organized as
   // [reference_hash, bu_hash].
-  uint8_t hashes[MAX_HASH_SIZE];  // Memory for storing, in order, the gop_hash and
-  // 'latest hash'.
+  uint8_t hashes[MAX_HASH_SIZE];  // Memory for storing 'latest hash'.
   uint8_t hash_list[HASH_LIST_SIZE];  // Pointer to the list of hashes used for
   // SV_AUTHENTICITY_LEVEL_FRAME.
   size_t hash_list_size;  // The allowed size of the |hash_list|. This can be less than allocated.

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -214,9 +214,8 @@ typedef enum { GOP_HASH = 0, DOCUMENT_HASH = 1, NUM_HASH_TYPES } hash_type_t;
 struct _gop_info_t {
   uint8_t hash_buddies[2 * MAX_HASH_SIZE];  // Memory for two hashes organized as
   // [reference_hash, bu_hash].
-  uint8_t hashes[2 * MAX_HASH_SIZE];  // Memory for storing, in order, the gop_hash and
+  uint8_t hashes[MAX_HASH_SIZE];  // Memory for storing, in order, the gop_hash and
   // 'latest hash'.
-  uint8_t *gop_hash;  // Pointing to the memory slot of the gop_hash in |hashes|.
   uint8_t hash_list[HASH_LIST_SIZE];  // Pointer to the list of hashes used for
   // SV_AUTHENTICITY_LEVEL_FRAME.
   size_t hash_list_size;  // The allowed size of the |hash_list|. This can be less than allocated.

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -944,8 +944,6 @@ signed_video_set_hash_algo(signed_video_t *self, const char *name_or_oid)
     SV_THROW_IF(hash_size == 0 || hash_size > MAX_HASH_SIZE, SV_NOT_SUPPORTED);
 
     self->sign_data->hash_size = hash_size;
-    // Point |bu_hash| to the correct location in the |hashes| buffer.
-    self->gop_info->bu_hash = self->gop_info->hashes;
   SV_CATCH()
   SV_DONE(status)
 

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -389,11 +389,7 @@ generate_sei(signed_video_t *self, uint8_t **payload, uint8_t **payload_signatur
     }
 
     gop_info_t *gop_info = self->gop_info;
-    if (gop_info->signature_hash_type == DOCUMENT_HASH) {
-      memcpy(sign_data->hash, gop_info->document_hash, hash_size);
-    } else {
-      memcpy(sign_data->hash, gop_info->gop_hash, hash_size);
-    }
+    memcpy(sign_data->hash, gop_info->document_hash, hash_size);
 
     // Reset the |num_in_partial_gop| since we start a new GOP.
     gop_info->num_in_partial_gop = 0;
@@ -949,7 +945,7 @@ signed_video_set_hash_algo(signed_video_t *self, const char *name_or_oid)
 
     self->sign_data->hash_size = hash_size;
     // Point |bu_hash| to the correct location in the |hashes| buffer.
-    self->gop_info->bu_hash = self->gop_info->hashes + hash_size;
+    self->gop_info->bu_hash = self->gop_info->hashes;
   SV_CATCH()
   SV_DONE(status)
 

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -1015,7 +1015,6 @@ decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size)
         self->crypto_handle, hash_algo_encoded_oid, hash_algo_encoded_oid_size));
     self->validation_flags.hash_algo_known = true;
     self->verify_data->hash_size = openssl_get_hash_size(self->crypto_handle);
-    self->gop_info->bu_hash = self->gop_info->hashes;
     data_ptr += hash_algo_encoded_oid_size;
 
     SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -1015,7 +1015,7 @@ decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size)
         self->crypto_handle, hash_algo_encoded_oid, hash_algo_encoded_oid_size));
     self->validation_flags.hash_algo_known = true;
     self->verify_data->hash_size = openssl_get_hash_size(self->crypto_handle);
-    self->gop_info->bu_hash = self->gop_info->hashes + self->verify_data->hash_size;
+    self->gop_info->bu_hash = self->gop_info->hashes;
     data_ptr += hash_algo_encoded_oid_size;
 
     SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);


### PR DESCRIPTION
The gop_hash member in the gop_info_t struct was unused and has
been removed.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
