### PR TITLE
Updates use_in_gop_hash wrt partial GOPs

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -229,8 +229,8 @@ prepare_for_link_and_gop_hash_verification(signed_video_t *self, bu_list_item_t 
       assert(item->bu);
       num_i_frames += item->bu->is_first_bu_in_gop;
       if (num_i_frames > 1) break;  // Break if encountered second I frame.
-      // Break at I-frame if NAL Units have been added to GOP hash, since a GOP hash cannot span
-      // across multiple GOPs.
+      // Break at I-frame if Bitstream Units have been added to GOP hash, since a GOP hash
+      // cannot span across multiple GOPs.
       if (item->bu->is_first_bu_in_gop && (num_in_partial_gop > 0)) {
         break;
       }


### PR DESCRIPTION
When preparing for validation the number of BUs marked now
depends on the number of sent BUs if a partial GOP was triggered.
If validation fails, the number of marked items are extended to
avoid aborting validation too early.
Last, when verifying individual hashes the number of verified
ones will not exceed the number sent.
