### PR TITLE
Statically allocates memory for product info

### DIFF
--- a/lib/src/includes/signed_video_auth.h
+++ b/lib/src/includes/signed_video_auth.h
@@ -189,13 +189,16 @@ typedef struct {
 
 /**
  * Struct for holding strings to selected product information
+ *
+ * Note that the SEIs can only handle string lengths that can be represented by one byte,
+ * that is, up to 255 character strings. If longer names are set, they will be truncated.
  */
 typedef struct {
-  char *hardware_id;  // Hardware ID
-  char *firmware_version;  // Firmware version
-  char *serial_number;  // Serial number
-  char *manufacturer;  // Manufacturer
-  char *address;  // Address to manufacturer, contact info like url/email/mail address.
+  char hardware_id[256];  // Hardware ID
+  char firmware_version[256];  // Firmware version
+  char serial_number[256];  // Serial number
+  char manufacturer[256];  // Manufacturer
+  char address[256];  // Address to manufacturer, contact info like url/email/mail address.
 } signed_video_product_info_t;
 
 /**

--- a/lib/src/legacy/legacy_auth.c
+++ b/lib/src/legacy/legacy_auth.c
@@ -757,8 +757,7 @@ legacy_prepare_for_validation(legacy_sv_t *self)
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
     // If "Axis Communications AB" can be identified from the |product_info|, get
     // |supplemental_authenticity| from |vendor_handle|.
-    if (sei && self->product_info->manufacturer &&
-        strcmp(self->product_info->manufacturer, "Axis Communications AB") == 0) {
+    if (sei && strcmp(self->product_info->manufacturer, "Axis Communications AB") == 0) {
 
       sv_vendor_axis_supplemental_authenticity_t *supplemental_authenticity = NULL;
       SV_THROW(get_axis_communications_supplemental_authenticity(

--- a/lib/src/legacy/legacy_common.c
+++ b/lib/src/legacy/legacy_common.c
@@ -967,7 +967,7 @@ legacy_sv_create(signed_video_t *parent)
     self->codec = parent->codec;
 
     // Borrow product_info from |parent|.
-    self->product_info = parent->product_info;
+    self->product_info = &parent->product_info;
 
     // Borrow crypto handle from |parent|.
     self->crypto_handle = parent->crypto_handle;

--- a/lib/src/legacy/legacy_tlv.c
+++ b/lib/src/legacy/legacy_tlv.c
@@ -253,24 +253,33 @@ legacy_decode_product_info(legacy_sv_t *self, const uint8_t *data, size_t data_s
     signed_video_product_info_t *product_info = self->product_info;
 
     uint8_t hardware_id_size = *data_ptr++;
-    SV_THROW(allocate_memory_and_copy_string(&product_info->hardware_id, (const char *)data_ptr));
+    strncpy(product_info->hardware_id, (const char *)data_ptr, hardware_id_size);
+    // Note that all legacy video have been recorded with version 1 which writes
+    // |hardware_id| including null-terminated character. Adding another null-terminated
+    // character after the string does not affect its content. Therefore, there is no need
+    // to treat the legacy code differently from the code in the main library. This holds
+    // for all members in |product_info|.
+    product_info->hardware_id[hardware_id_size] = '\0';
     data_ptr += hardware_id_size;
 
     uint8_t firmware_version_size = *data_ptr++;
-    SV_THROW(
-        allocate_memory_and_copy_string(&product_info->firmware_version, (const char *)data_ptr));
+    strncpy(product_info->firmware_version, (const char *)data_ptr, firmware_version_size);
+    product_info->firmware_version[firmware_version_size] = '\0';
     data_ptr += firmware_version_size;
 
     uint8_t serial_number_size = *data_ptr++;
-    SV_THROW(allocate_memory_and_copy_string(&product_info->serial_number, (const char *)data_ptr));
+    strncpy(product_info->serial_number, (const char *)data_ptr, serial_number_size);
+    product_info->serial_number[serial_number_size] = '\0';
     data_ptr += serial_number_size;
 
     uint8_t manufacturer_size = *data_ptr++;
-    SV_THROW(allocate_memory_and_copy_string(&product_info->manufacturer, (const char *)data_ptr));
+    strncpy(product_info->manufacturer, (const char *)data_ptr, manufacturer_size);
+    product_info->manufacturer[manufacturer_size] = '\0';
     data_ptr += manufacturer_size;
 
     uint8_t address_size = *data_ptr++;
-    SV_THROW(allocate_memory_and_copy_string(&product_info->address, (const char *)data_ptr));
+    strncpy(product_info->address, (const char *)data_ptr, address_size);
+    product_info->address[address_size] = '\0';
     data_ptr += address_size;
 
     // Transfer the decoded |product_info| to the authenticity report.
@@ -375,8 +384,7 @@ legacy_decode_public_key(legacy_sv_t *self, const uint8_t *data, size_t data_siz
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
     // If "Axis Communications AB" can be identified from the |product_info|, set |public_key| to
     // |vendor_handle|.
-    if (self->product_info->manufacturer &&
-        strcmp(self->product_info->manufacturer, "Axis Communications AB") == 0) {
+    if (strcmp(self->product_info->manufacturer, "Axis Communications AB") == 0) {
       // Set public key.
       SV_THROW(set_axis_communications_public_key(self->vendor_handle, self->verify_data->key,
           self->latest_validation->public_key_has_changed));

--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -959,13 +959,12 @@ prepare_for_validation(signed_video_t *self)
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
     // If "Axis Communications AB" can be identified from the |product_info|, get
     // |supplemental_authenticity| from |vendor_handle|.
-    if (self->product_info->manufacturer &&
-        strcmp(self->product_info->manufacturer, "Axis Communications AB") == 0) {
+    if (strcmp(self->product_info.manufacturer, "Axis Communications AB") == 0) {
 
       sv_vendor_axis_supplemental_authenticity_t *supplemental_authenticity = NULL;
       SV_THROW(get_axis_communications_supplemental_authenticity(
           self->vendor_handle, &supplemental_authenticity));
-      if (strcmp(self->product_info->serial_number, supplemental_authenticity->serial_number)) {
+      if (strcmp(self->product_info.serial_number, supplemental_authenticity->serial_number)) {
         self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_NOT_OK;
       } else {
         // Convert to SignedVideoPublicKeyValidation

--- a/lib/src/sv_authenticity.c
+++ b/lib/src/sv_authenticity.c
@@ -89,17 +89,15 @@ transfer_product_info(signed_video_product_info_t *dst, const signed_video_produ
   // SV_OK.
   if (!src || !dst) return SV_OK;
 
-  svrc_t status = SV_UNKNOWN_FAILURE;
-  SV_TRY()
-    SV_THROW(allocate_memory_and_copy_string(&dst->hardware_id, src->hardware_id));
-    SV_THROW(allocate_memory_and_copy_string(&dst->firmware_version, src->firmware_version));
-    SV_THROW(allocate_memory_and_copy_string(&dst->serial_number, src->serial_number));
-    SV_THROW(allocate_memory_and_copy_string(&dst->manufacturer, src->manufacturer));
-    SV_THROW(allocate_memory_and_copy_string(&dst->address, src->address));
-  SV_CATCH()
-  SV_DONE(status)
+  product_info_reset_members(dst);
 
-  return status;
+  strcpy(dst->hardware_id, src->hardware_id);
+  strcpy(dst->firmware_version, src->firmware_version);
+  strcpy(dst->serial_number, src->serial_number);
+  strcpy(dst->manufacturer, src->manufacturer);
+  strcpy(dst->address, src->address);
+
+  return SV_OK;
 }
 
 static svrc_t
@@ -359,7 +357,7 @@ create_local_authenticity_report_if_needed(signed_video_t *self)
     signed_video_authenticity_t *auth_report = signed_video_authenticity_report_create();
     SV_THROW_IF(auth_report == NULL, SV_MEMORY);
     // Transfer |product_info| from |self|.
-    SV_THROW(transfer_product_info(&auth_report->product_info, self->product_info));
+    SV_THROW(transfer_product_info(&auth_report->product_info, &self->product_info));
 
     self->authenticity = auth_report;
     set_authenticity_shortcuts(self);
@@ -391,8 +389,6 @@ signed_video_authenticity_report_free(signed_video_authenticity_t *authenticity_
   if (!authenticity_report) return;
 
   // Free the memory.
-  product_info_free_members(&authenticity_report->product_info);
-
   free(authenticity_report->version_on_signing_side);
   free(authenticity_report->this_version);
   free(authenticity_report->latest_validation.nalu_str);

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -251,7 +251,7 @@ struct _signed_video_t {
   // Members common to both signing and validation
   int code_version[SV_VERSION_BYTES];
   SignedVideoCodec codec;  // Codec used in this session.
-  signed_video_product_info_t *product_info;
+  signed_video_product_info_t product_info;
 
   // For cryptographic functions, like OpenSSL
   void *crypto_handle;
@@ -401,7 +401,7 @@ svrc_t
 set_hash_list_size(gop_info_t *gop_info, size_t hash_list_size);
 
 void
-product_info_free_members(signed_video_product_info_t *product_info);
+product_info_reset_members(signed_video_product_info_t *product_info);
 
 /* Defined in sv_sign.c */
 

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -21,7 +21,7 @@
 #include <assert.h>  // assert
 #include <stdint.h>  // uint8_t
 #include <stdlib.h>  // free, malloc
-#include <string.h>  // size_t
+#include <string.h>  // size_t, strncpy
 
 #include "includes/signed_video_openssl.h"  // pem_pkey_t
 #include "includes/signed_video_sign.h"
@@ -821,24 +821,30 @@ signed_video_set_product_info(signed_video_t *self,
     const char *manufacturer,
     const char *address)
 {
-  if (!self || !self->product_info) return SV_INVALID_PARAMETER;
+  if (!self) return SV_INVALID_PARAMETER;
 
-  signed_video_product_info_t *product_info = self->product_info;
-
-  svrc_t status = SV_UNKNOWN_FAILURE;
-  SV_TRY()
-    SV_THROW(allocate_memory_and_copy_string(&product_info->hardware_id, hardware_id));
-    SV_THROW(allocate_memory_and_copy_string(&product_info->firmware_version, firmware_version));
-    SV_THROW(allocate_memory_and_copy_string(&product_info->serial_number, serial_number));
-    SV_THROW(allocate_memory_and_copy_string(&product_info->manufacturer, manufacturer));
-    SV_THROW(allocate_memory_and_copy_string(&product_info->address, address));
-  SV_CATCH()
-  {
-    product_info_free_members(product_info);
+  if (hardware_id) {
+    strncpy(self->product_info.hardware_id, hardware_id, 255);
+    self->product_info.hardware_id[255] = '\0';
   }
-  SV_DONE(status)
+  if (firmware_version) {
+    strncpy(self->product_info.firmware_version, firmware_version, 255);
+    self->product_info.firmware_version[255] = '\0';
+  }
+  if (serial_number) {
+    strncpy(self->product_info.serial_number, serial_number, 255);
+    self->product_info.serial_number[255] = '\0';
+  }
+  if (manufacturer) {
+    strncpy(self->product_info.manufacturer, manufacturer, 255);
+    self->product_info.manufacturer[255] = '\0';
+  }
+  if (address) {
+    strncpy(self->product_info.address, address, 255);
+    self->product_info.address[255] = '\0';
+  }
 
-  return status;
+  return SV_OK;
 }
 
 SignedVideoReturnCode


### PR DESCRIPTION
When the signed_video_t object is created the
signed_video_product_info_t is statically allocated where
all strings have a preset fixed length of 255 bytes. This
makes it more clear to the user that strings longer than
255 characters will be truncated.

In the TLV, the strings are now encoded without null-terminated
characters. The operation is backward compatible.
