### PR TITLE
Moves Axis vendor tag to optional tags

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -294,10 +294,6 @@ struct _signed_video_t {
   void *plugin_handle;
   sign_or_verify_data_t *sign_data;  // Pointer to all necessary information to sign in a plugin.
 
-  // Vendor encoders for signing. Only works with one vendor.
-  const sv_tlv_tag_t *vendor_encoders;
-  size_t num_vendor_encoders;
-
   // Frame counter and flag to handle recurrence
   bool has_recurrent_data;
   int frame_count;

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -194,7 +194,6 @@ generate_sei(signed_video_t *self, uint8_t **payload, uint8_t **payload_signatur
   size_t optional_tags_size = 0;
   size_t mandatory_tags_size = 0;
   size_t gop_info_size = 0;
-  size_t vendor_size = 0;
   size_t sei_buffer_size = 0;
   const size_t num_gop_encoders = ARRAY_SIZE(gop_info_encoders);
 
@@ -218,12 +217,8 @@ generate_sei(signed_video_t *self, uint8_t **payload, uint8_t **payload_signatur
         tlv_list_encode_or_get_size(self, mandatory_tags, num_mandatory_tags, NULL);
     if (self->is_golden_sei) mandatory_tags_size = 0;
     gop_info_size = tlv_list_encode_or_get_size(self, gop_info_encoders, num_gop_encoders, NULL);
-    if (self->num_vendor_encoders > 0 && self->vendor_encoders) {
-      vendor_size =
-          tlv_list_encode_or_get_size(self, self->vendor_encoders, self->num_vendor_encoders, NULL);
-    }
 
-    payload_size = gop_info_size + vendor_size + optional_tags_size + mandatory_tags_size;
+    payload_size = gop_info_size + optional_tags_size + mandatory_tags_size;
     payload_size += UUID_LEN;  // UUID
     payload_size += 1;  // One byte for reserved data.
     if ((self->max_sei_payload_size > 0) && (payload_size > self->max_sei_payload_size) &&
@@ -340,13 +335,6 @@ generate_sei(signed_video_t *self, uint8_t **payload, uint8_t **payload_signatur
     if (mandatory_tags_size > 0) {
       written_size =
           tlv_list_encode_or_get_size(self, mandatory_tags, num_mandatory_tags, payload_ptr);
-      SV_THROW_IF(written_size == 0, SV_MEMORY);
-      payload_ptr += written_size;
-    }
-
-    if (vendor_size > 0) {
-      written_size = tlv_list_encode_or_get_size(
-          self, self->vendor_encoders, self->num_vendor_encoders, payload_ptr);
       SV_THROW_IF(written_size == 0, SV_MEMORY);
       payload_ptr += written_size;
     }

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -141,6 +141,7 @@ static const sv_tlv_tag_t optional_tags[] = {
     PUBLIC_KEY_TAG,
     PRODUCT_INFO_TAG,
     CRYPTO_INFO_TAG,
+    VENDOR_AXIS_COMMUNICATIONS_TAG,
 };
 
 /*

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -33,12 +33,6 @@
 #include "sv_tlv.h"
 #include "sv_vendor_axis_communications_internal.h"
 
-// List of TLV encoders to include in SEI.
-#define AXIS_COMMUNICATIONS_NUM_ENCODERS 1
-static const sv_tlv_tag_t axis_communications_encoders[AXIS_COMMUNICATIONS_NUM_ENCODERS] = {
-    VENDOR_AXIS_COMMUNICATIONS_TAG,
-};
-
 #define NUM_UNTRUSTED_CERTIFICATES 2  // |certificate_chain| has 2 untrusted certificates.
 #define CHIP_ID_SIZE 18
 #define CHIP_ID_PREFIX_SIZE 4
@@ -875,9 +869,6 @@ sv_vendor_axis_communications_set_attestation_report(signed_video_t *sv,
     self->factory_provisioned = true;
     sv->add_public_key_to_sei = false;
   }
-
-  sv->vendor_encoders = axis_communications_encoders;
-  sv->num_vendor_encoders = AXIS_COMMUNICATIONS_NUM_ENCODERS;
 
   return SV_OK;
 


### PR DESCRIPTION
This commit lets the TLV code handle vendor tags. The Axis
vendor tag is now part of the optional tags and if built
without Axis Communication, the encoder will be empty and
by default not be added.
