### PR TITLE
Add functions to convert between timestamps

### DIFF
--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -158,6 +158,20 @@ sign_or_verify_data_free(sign_or_verify_data_t *self)
   free(self);
 }
 
+// Convert Unix timestamp (seconds since 1970) to 1601-based timestamp
+void
+convert_unix_to_1601(int64_t *timestamp)
+{
+  *timestamp = (*timestamp + EPOCH_DIFF) * HUNDRED_NANOSECONDS;
+}
+
+// Convert 1601-based timestamp (100-nanosecond intervals since 1601) to Unix timestamp
+void
+convert_1601_to_unix(int64_t *timestamp)
+{
+  *timestamp = (*timestamp / HUNDRED_NANOSECONDS) - EPOCH_DIFF;
+}
+
 /* Reads the version string and puts the Major.Minor.Patch in the first, second and third element of
  * the array, respectively */
 static bool

--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -158,18 +158,20 @@ sign_or_verify_data_free(sign_or_verify_data_t *self)
   free(self);
 }
 
-// Convert Axis Unix timestamp (microseconds since 1970) to 1601-based timestamp (100-ns intervals)
+// Convert Unix timestamp (microseconds since 1970) to 1601-based timestamp (100-nanosecond
+// intervals)
 int64_t
-convert_unix_to_1601(int64_t timestamp)
+convert_unix_us_to_1601(int64_t timestamp)
 {
-   return (timestamp + (EPOCH_DIFF * 1000000LL)) * MICROSECONDS;
+  return (timestamp + EPOCH_DIFF_US) * MICROSEC_TO_100NSEC;
 }
 
-// Convert 1601-based timestamp (100-nanosecond intervals since 1601) to Axis Unix timestamp (microseconds)
+// Convert 1601-based timestamp (100-nanosecond intervals since 1601) to Unix timestamp
+// (microseconds)
 int64_t
-convert_1601_to_unix(int64_t timestamp)
+convert_1601_to_unix_us(int64_t timestamp)
 {
-  return (timestamp / MICROSECONDS) - (EPOCH_DIFF * 1000000LL);
+  return (timestamp / MICROSEC_TO_100NSEC) - EPOCH_DIFF_US;
 }
 
 /* Reads the version string and puts the Major.Minor.Patch in the first, second and third element of

--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -158,18 +158,18 @@ sign_or_verify_data_free(sign_or_verify_data_t *self)
   free(self);
 }
 
-// Convert Unix timestamp (seconds since 1970) to 1601-based timestamp
-void
-convert_unix_to_1601(int64_t *timestamp)
+// Convert Axis Unix timestamp (microseconds since 1970) to 1601-based timestamp (100-ns intervals)
+int64_t
+convert_unix_to_1601(int64_t timestamp)
 {
-  *timestamp = (*timestamp + EPOCH_DIFF) * HUNDRED_NANOSECONDS;
+   return (timestamp + (EPOCH_DIFF * 1000000LL)) * MICROSECONDS;
 }
 
-// Convert 1601-based timestamp (100-nanosecond intervals since 1601) to Unix timestamp
-void
-convert_1601_to_unix(int64_t *timestamp)
+// Convert 1601-based timestamp (100-nanosecond intervals since 1601) to Axis Unix timestamp (microseconds)
+int64_t
+convert_1601_to_unix(int64_t timestamp)
 {
-  *timestamp = (*timestamp / HUNDRED_NANOSECONDS) - EPOCH_DIFF;
+  return (timestamp / MICROSECONDS) - (EPOCH_DIFF * 1000000LL);
 }
 
 /* Reads the version string and puts the Major.Minor.Patch in the first, second and third element of

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -69,8 +69,7 @@
 #define HASH_LIST_SIZE (MAX_HASH_SIZE * MAX_GOP_LENGTH)
 
 #define EPOCH_DIFF 11644473600LL  // Difference between 1601 and 1970 in seconds
-#define HUNDRED_NANOSECONDS 10000000LL  // 1 second = 10^7 * 100-nanosecond
-
+#define MICROSECONDS 10LL         // 1 microsecond = 10 * 100-nanoseconds
 // Forward declare bu_list_t here for signed_video_t.
 typedef struct _bu_list_item_t bu_list_item_t;
 
@@ -388,11 +387,11 @@ update_hashable_data(bu_info_t *bu);
 void
 bytes_to_version_str(const int *arr, char *str);
 
-void
-convert_unix_to_1601(int64_t *timestamp);
+int64_t
+convert_unix_to_1601(int64_t timestamp);
 
-void
-convert_1601_to_unix(int64_t *timestamp);
+int64_t
+convert_1601_to_unix(int64_t timestamp);
 
 svrc_t
 struct_member_memory_allocated_and_copy(void **member_ptr,

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -68,8 +68,9 @@
 
 #define HASH_LIST_SIZE (MAX_HASH_SIZE * MAX_GOP_LENGTH)
 
-#define EPOCH_DIFF 11644473600LL  // Difference between 1601 and 1970 in seconds
-#define MICROSECONDS 10LL         // 1 microsecond = 10 * 100-nanoseconds
+#define EPOCH_DIFF_US 11644473600000000LL  // Difference between 1601 and 1970 in microseconds
+#define MICROSEC_TO_100NSEC 10LL  // 1 microsecond = 10 × 100-nanosecond intervals
+
 // Forward declare bu_list_t here for signed_video_t.
 typedef struct _bu_list_item_t bu_list_item_t;
 
@@ -388,10 +389,10 @@ void
 bytes_to_version_str(const int *arr, char *str);
 
 int64_t
-convert_unix_to_1601(int64_t timestamp);
+convert_unix_us_to_1601(int64_t timestamp);
 
 int64_t
-convert_1601_to_unix(int64_t timestamp);
+convert_1601_to_unix_us(int64_t timestamp);
 
 svrc_t
 struct_member_memory_allocated_and_copy(void **member_ptr,

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -68,6 +68,9 @@
 
 #define HASH_LIST_SIZE (MAX_HASH_SIZE * MAX_GOP_LENGTH)
 
+#define EPOCH_DIFF 11644473600LL  // Difference between 1601 and 1970 in seconds
+#define HUNDRED_NANOSECONDS 10000000LL  // 1 second = 10^7 * 100-nanosecond
+
 // Forward declare bu_list_t here for signed_video_t.
 typedef struct _bu_list_item_t bu_list_item_t;
 
@@ -384,6 +387,12 @@ update_hashable_data(bu_info_t *bu);
 
 void
 bytes_to_version_str(const int *arr, char *str);
+
+void
+convert_unix_to_1601(int64_t *timestamp);
+
+void
+convert_1601_to_unix(int64_t *timestamp);
 
 svrc_t
 struct_member_memory_allocated_and_copy(void **member_ptr,

--- a/tests/check/check_signed_video_common.c
+++ b/tests/check/check_signed_video_common.c
@@ -73,20 +73,21 @@ START_TEST(invalid_api_inputs)
 END_TEST
 
 /* Test description
- * Verify correct conversion between Axis Unix timestamp (microseconds) and 1601-based timestamp (100-nanosecond intervals).
+ * Verify correct conversion between Axis Unix timestamp (microseconds) and 1601-based timestamp
+ * (100-nanosecond intervals).
  */
 START_TEST(test_timestamp_conversion)
 {
-    int64_t unix_ts = 1708156800000000;  // Example: Unix time for 2025-02-17 in microseconds
-    int64_t expected_1601_ts = 133526304000000000; // Expected corresponding 1601-based timestamp
-    
-    // Convert Unix to 1601-based timestamp
-    int64_t converted_1601 = convert_unix_to_1601(unix_ts);
-    ck_assert_int_eq(converted_1601, expected_1601_ts);
+  int64_t unix_ts = 1708156800000000;  // Example: Unix time for 2025-02-17 in microseconds
+  int64_t expected_1601_ts = 133526304000000000;  // Expected corresponding 1601-based timestamp
 
-    // Convert back to Unix timestamp
-    int64_t converted_unix = convert_1601_to_unix(converted_1601);
-    ck_assert_int_eq(converted_unix, unix_ts);
+  // Convert Unix to 1601-based timestamp
+  int64_t converted_1601 = convert_unix_us_to_1601(unix_ts);
+  ck_assert_int_eq(converted_1601, expected_1601_ts);
+
+  // Convert back to Unix timestamp
+  int64_t converted_unix = convert_1601_to_unix_us(converted_1601);
+  ck_assert_int_eq(converted_unix, unix_ts);
 }
 END_TEST
 

--- a/tests/check/check_signed_video_common.c
+++ b/tests/check/check_signed_video_common.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>  // EXIT_SUCCESS, EXIT_FAILURE
 
 #include "lib/src/includes/signed_video_common.h"
+#include "lib/src/sv_internal.h"
 
 static void
 setup()
@@ -72,6 +73,24 @@ START_TEST(invalid_api_inputs)
 END_TEST
 
 /* Test description
+ * Verify correct conversion between Axis Unix timestamp (microseconds) and 1601-based timestamp (100-nanosecond intervals).
+ */
+START_TEST(test_timestamp_conversion)
+{
+    int64_t unix_ts = 1708156800000000;  // Example: Unix time for 2025-02-17 in microseconds
+    int64_t expected_1601_ts = 133526304000000000; // Expected corresponding 1601-based timestamp
+    
+    // Convert Unix to 1601-based timestamp
+    int64_t converted_1601 = convert_unix_to_1601(unix_ts);
+    ck_assert_int_eq(converted_1601, expected_1601_ts);
+
+    // Convert back to Unix timestamp
+    int64_t converted_unix = convert_1601_to_unix(converted_1601);
+    ck_assert_int_eq(converted_unix, unix_ts);
+}
+END_TEST
+
+/* Test description
  * Format check for the current software version.
  */
 START_TEST(correct_version)
@@ -115,6 +134,7 @@ signed_video_suite(void)
 
   // Add tests
   tcase_add_loop_test(tc, invalid_api_inputs, s, e);
+  tcase_add_loop_test(tc, test_timestamp_conversion, s, e);
   tcase_add_loop_test(tc, correct_version, s, e);
 
   // Add test case to suit


### PR DESCRIPTION
Add functions to convert between Unix and 1601-based timestamps

Change-Id: I0baf3c9a4b1d34ecde114fcb7344b4b97785ec21

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
