### PR TITLE
Ensure compilation when setting private key

### DIFF
--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -21,6 +21,10 @@
 #ifndef __SV_ONVIF_H__
 #define __SV_ONVIF_H__
 
+#include <stdbool.h>  // bool
+#include <stdint.h>  // uint8_t
+#include <string.h>  // size_t
+
 #ifndef HAS_ONVIF
 // Define a placeholder for onvif_media_signing_t to avoid compilation errors
 typedef void onvif_media_signing_t;
@@ -35,6 +39,26 @@ typedef enum {
   OMS_AUTHENTICATION_ERROR = -30,
   OMS_UNKNOWN_FAILURE = -100
 } MediaSigningReturnCode;
+
+// Dummy function to prevent compilation errors
+static inline MediaSigningReturnCode
+onvif_media_signing_set_signing_key_pair(onvif_media_signing_t *self,
+    const char *private_key,
+    size_t private_key_size,
+    const char *certificate_chain,
+    size_t certificate_chain_size,
+    bool user_provisioned)
+{
+
+  (void)self;  // Prevent unused variable warnings
+  (void)private_key;
+  (void)private_key_size;
+  (void)certificate_chain;
+  (void)certificate_chain_size;
+  (void)user_provisioned;
+
+  return OMS_NOT_SUPPORTED;  // Always return -12 when ONVIF is missing
+}
 #endif
 
 #endif  // __SV_ONVIF_H__

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -781,6 +781,13 @@ signed_video_set_private_key(signed_video_t *self, const char *private_key, size
   if (!self || !private_key || private_key_size == 0) return SV_INVALID_PARAMETER;
 
   svrc_t status = SV_UNKNOWN_FAILURE;
+  // If ONVIF is available, call its function and map the return code
+  if (self->onvif) {
+    MediaSigningReturnCode onvif_status = onvif_media_signing_set_signing_key_pair(
+        self->onvif, private_key, private_key_size, NULL, 0, false);
+
+    return msrc_to_svrc(onvif_status);
+  }
   SV_TRY()
     // Temporally turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
     SV_THROW(openssl_private_key_malloc(self->sign_data, private_key, private_key_size));


### PR DESCRIPTION
When ONVIF is missing, onvif_media_signing_set_signing_key_pair() now returns
OMS_NOT_SUPPORTED (-12) to prevent compilation issues.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
