### PR TITLE
Gets SEIs from ONVIF session if active

### DIFF
--- a/.github/workflows/meson-build.yml
+++ b/.github/workflows/meson-build.yml
@@ -22,11 +22,11 @@ jobs:
     - name: Install glib-2.0
       run: sudo apt-get install libglib2.0-dev
     - name: Setup meson using threaded plugin
-      run: meson -Ddebugprints=false -Dbuildtype=debug -Dsigningplugin=threaded . build_lib
+      run: meson setup -Ddebugprints=false -Dbuildtype=debug -Dsigningplugin=threaded . build_lib
     - name: Compile and run tests
       run: ninja -C build_lib test
     - name: Setup meson
-      run: meson -Dbuildtype=debug -Dsigningplugin=unthreaded --reconfigure . build_lib
+      run: meson setup -Dbuildtype=debug -Dsigningplugin=unthreaded --reconfigure . build_lib
     - name: Compile and run tests
       run: ninja -C build_lib test
     - name: Install valgrind manually

--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -21,6 +21,7 @@ signedvideoframework_sources = files(
   'sv_defines.h',
   'sv_defines_general.h',
   'sv_internal.h',
+  'sv_onvif.c',
   'sv_onvif.h',
   'sv_openssl.c',
   'sv_sign.c',

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -32,7 +32,9 @@
 #include "legacy_validation.h"  // legacy_sv_t
 #include "sv_defines.h"  // svrc_t, sv_tlv_tag_t
 #include "sv_defines_general.h"  // ATTR_UNUSED
-#include "sv_onvif.h"  // svrc_t, sv_tlv_tag_t
+#ifndef HAS_ONVIF
+#include "sv_onvif.h"  // Stubs for ONVIF APIs and structs
+#endif
 
 // Currently the largest supported hash is SHA-512.
 #define MAX_HASH_SIZE (512 / 8)

--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -18,35 +18,20 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifndef __SV_ONVIF_H__
-#define __SV_ONVIF_H__
+#include "sv_onvif.h"
 
-#include <stddef.h>  // size_t
-#include <stdint.h>  // uint8_t
-
-// Define a placeholder for onvif_media_signing_t to avoid compilation errors
-typedef void onvif_media_signing_t;
-// Define MediaSigningReturnCode to avoid compilation errors
-typedef enum {
-  OMS_OK = 0,
-  OMS_MEMORY = -1,
-  OMS_INVALID_PARAMETER = -10,
-  OMS_NOT_SUPPORTED = -12,
-  OMS_INCOMPATIBLE_VERSION = -15,
-  OMS_EXTERNAL_ERROR = -20,
-  OMS_AUTHENTICATION_ERROR = -30,
-  OMS_UNKNOWN_FAILURE = -100
-} MediaSigningReturnCode;
+#include "sv_defines_general.h"  // ATTR_UNUSED
 
 // Stubs for ONVIF APIs
 
 MediaSigningReturnCode
-onvif_media_signing_get_sei(onvif_media_signing_t *self,
-    uint8_t **sei,
-    size_t *sei_size,
-    unsigned *payload_offset,
-    const uint8_t *peek_nalu,
-    size_t peek_nalu_size,
-    unsigned *num_pending_seis);
-
-#endif  // __SV_ONVIF_H__
+onvif_media_signing_get_sei(onvif_media_signing_t ATTR_UNUSED *self,
+    uint8_t ATTR_UNUSED **sei,
+    size_t ATTR_UNUSED *sei_size,
+    unsigned ATTR_UNUSED *payload_offset,
+    const uint8_t ATTR_UNUSED *peek_nalu,
+    size_t ATTR_UNUSED peek_nalu_size,
+    unsigned ATTR_UNUSED *num_pending_seis)
+{
+  return OMS_NOT_SUPPORTED;
+}

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -21,7 +21,8 @@
 #ifndef __SV_ONVIF_H__
 #define __SV_ONVIF_H__
 
-#ifndef HAS_ONVIF
+#include "sv_defines_general.h"  // ATTR_UNUSED
+
 // Define a placeholder for onvif_media_signing_t to avoid compilation errors
 typedef void onvif_media_signing_t;
 // Define MediaSigningReturnCode to avoid compilation errors
@@ -35,6 +36,19 @@ typedef enum {
   OMS_AUTHENTICATION_ERROR = -30,
   OMS_UNKNOWN_FAILURE = -100
 } MediaSigningReturnCode;
-#endif
+
+// Stubs for ONVIF APIs
+
+inline MediaSigningReturnCode
+onvif_media_signing_get_sei(onvif_media_signing_t ATTR_UNUSED *self,
+    uint8_t ATTR_UNUSED **sei,
+    size_t ATTR_UNUSED *sei_size,
+    unsigned ATTR_UNUSED *payload_offset,
+    const uint8_t ATTR_UNUSED *peek_nalu,
+    size_t ATTR_UNUSED peek_nalu_size,
+    unsigned ATTR_UNUSED *num_pending_seis)
+{
+  return OMS_NOT_SUPPORTED;
+}
 
 #endif  // __SV_ONVIF_H__

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -30,6 +30,9 @@
 #include "sv_codec_internal.h"  // METADATA_TYPE_USER_PRIVATE
 #include "sv_defines.h"  // svrc_t, sv_tlv_tag_t
 #include "sv_internal.h"  // gop_info_t
+#ifndef HAS_ONVIF
+#include "sv_onvif.h"  // Stubs for ONVIF APIs and structs
+#endif
 #include "sv_openssl_internal.h"
 #include "sv_tlv.h"  // tlv_list_encode_or_get_size()
 

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -631,7 +631,15 @@ signed_video_get_sei(signed_video_t *self,
     unsigned *num_pending_seis)
 {
 
-  if (!self || !sei || !sei_size) return SV_INVALID_PARAMETER;
+  if (!self || !sei || !sei_size) {
+    return SV_INVALID_PARAMETER;
+  }
+
+  if (self->onvif) {
+    return msrc_to_svrc(onvif_media_signing_get_sei(
+        self->onvif, sei, sei_size, payload_offset, peek_bu, peek_bu_size, num_pending_seis));
+  }
+
   *sei = NULL;
   *sei_size = 0;
   if (payload_offset) {


### PR DESCRIPTION
When the signing session runs as ONVIF Media Signing, media
signing is generating the SEIs. Ask the media signing sesssion
for the SEIs if active.

This commit adds a stub of the ONVIF public API if ONVIF
Media Signing is not installed.
