### PR TITLE
Passes on setter to ONVIF if active

### DIFF
--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -35,3 +35,10 @@ onvif_media_signing_get_sei(onvif_media_signing_t ATTR_UNUSED *self,
 {
   return OMS_NOT_SUPPORTED;
 }
+
+MediaSigningReturnCode
+onvif_media_signing_set_max_signing_frames(onvif_media_signing_t ATTR_UNUSED *self,
+    unsigned ATTR_UNUSED max_signing_frames)
+{
+  return OMS_NOT_SUPPORTED;
+}

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -49,4 +49,8 @@ onvif_media_signing_get_sei(onvif_media_signing_t *self,
     size_t peek_nalu_size,
     unsigned *num_pending_seis);
 
+MediaSigningReturnCode
+onvif_media_signing_set_max_signing_frames(onvif_media_signing_t *self,
+    unsigned max_signing_frames);
+
 #endif  // __SV_ONVIF_H__

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -913,5 +913,10 @@ signed_viedo_set_max_signing_frames(signed_video_t *self, unsigned max_signing_f
   }
   self->max_signing_frames = max_signing_frames;
 
+  if (self->onvif) {
+    return msrc_to_svrc(
+        onvif_media_signing_set_max_signing_frames(self->onvif, max_signing_frames));
+  }
+
   return SV_OK;
 }


### PR DESCRIPTION
The max_signing_frames parameter is passed on to ONVIF if
Media Signing is active.
