### PR TITLE
Passes on setter to ONVIF if active

### DIFF
--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -42,3 +42,10 @@ onvif_media_signing_set_max_signing_frames(onvif_media_signing_t ATTR_UNUSED *se
 {
   return OMS_NOT_SUPPORTED;
 }
+
+MediaSigningReturnCode
+onvif_media_signing_set_hash_algo(onvif_media_signing_t ATTR_UNUSED *self,
+    const char ATTR_UNUSED *name_or_oid)
+{
+  return OMS_NOT_SUPPORTED;
+}

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -53,4 +53,7 @@ MediaSigningReturnCode
 onvif_media_signing_set_max_signing_frames(onvif_media_signing_t *self,
     unsigned max_signing_frames);
 
+MediaSigningReturnCode
+onvif_media_signing_set_hash_algo(onvif_media_signing_t *self, const char *name_or_oid);
+
 #endif  // __SV_ONVIF_H__

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -899,6 +899,9 @@ signed_video_set_hash_algo(signed_video_t *self, const char *name_or_oid)
     SV_THROW_IF(hash_size == 0 || hash_size > MAX_HASH_SIZE, SV_NOT_SUPPORTED);
 
     self->sign_data->hash_size = hash_size;
+    if (self->onvif) {
+      SV_THROW(msrc_to_svrc(onvif_media_signing_set_hash_algo(self->onvif, name_or_oid)));
+    }
   SV_CATCH()
   SV_DONE(status)
 


### PR DESCRIPTION
The hash_algo parameter is passed on to ONVIF if Media Signing
is active.
