### PR TITLE
Passes on NALU for signing to ONVIF if active

### DIFF
--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -20,6 +20,8 @@
  */
 #include "sv_onvif.h"
 
+#include <stdbool.h>
+
 #include "sv_defines_general.h"  // ATTR_UNUSED
 
 // Stubs for ONVIF APIs
@@ -39,6 +41,15 @@ onvif_media_signing_get_sei(onvif_media_signing_t ATTR_UNUSED *self,
 MediaSigningReturnCode
 onvif_media_signing_set_max_signing_frames(onvif_media_signing_t ATTR_UNUSED *self,
     unsigned ATTR_UNUSED max_signing_frames)
+{
+  return OMS_NOT_SUPPORTED;
+}
+
+MediaSigningReturnCode
+onvif_media_signing_add_nalu_for_signing(onvif_media_signing_t ATTR_UNUSED *self,
+    const uint8_t ATTR_UNUSED *nalu,
+    size_t ATTR_UNUSED nalu_size,
+    int64_t ATTR_UNUSED timestamp)
 {
   return OMS_NOT_SUPPORTED;
 }

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -53,4 +53,10 @@ MediaSigningReturnCode
 onvif_media_signing_set_max_signing_frames(onvif_media_signing_t *self,
     unsigned max_signing_frames);
 
+MediaSigningReturnCode
+onvif_media_signing_add_nalu_for_signing(onvif_media_signing_t *self,
+    const uint8_t *nalu,
+    size_t nalu_size,
+    int64_t timestamp);
+
 #endif  // __SV_ONVIF_H__


### PR DESCRIPTION
The NALU data passes to ONVIF Media Signing API using
`onvif_media_signing_add_nalu_for_signing` if ONVIF Media
Signing is availible.

Change-Id: Ife6a03c42d7267193fbc08a9a8d7cde8d9fcb07d

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
