### PR TITLE
Passes on BU for signing to ONVIF if available

### DIFF
--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -42,3 +42,12 @@ onvif_media_signing_set_max_signing_frames(onvif_media_signing_t ATTR_UNUSED *se
 {
   return OMS_NOT_SUPPORTED;
 }
+
+MediaSigningReturnCode
+onvif_media_signing_add_nalu_for_signing(onvif_media_signing_t ATTR_UNUSED *self,
+    const uint8_t ATTR_UNUSED *nalu,
+    size_t ATTR_UNUSED nalu_size,
+    int64_t ATTR_UNUSED timestamp)
+{
+  return OMS_NOT_SUPPORTED;
+}

--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -25,6 +25,16 @@
 // Stubs for ONVIF APIs
 
 MediaSigningReturnCode
+onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t ATTR_UNUSED *self,
+    const uint8_t ATTR_UNUSED *nalu_part,
+    size_t ATTR_UNUSED nalu_part_size,
+    int64_t ATTR_UNUSED timestamp,
+    bool ATTR_UNUSED is_last_part)
+{
+  return OMS_NOT_SUPPORTED;
+}
+
+MediaSigningReturnCode
 onvif_media_signing_get_sei(onvif_media_signing_t ATTR_UNUSED *self,
     uint8_t ATTR_UNUSED **sei,
     size_t ATTR_UNUSED *sei_size,
@@ -39,15 +49,6 @@ onvif_media_signing_get_sei(onvif_media_signing_t ATTR_UNUSED *self,
 MediaSigningReturnCode
 onvif_media_signing_set_max_signing_frames(onvif_media_signing_t ATTR_UNUSED *self,
     unsigned ATTR_UNUSED max_signing_frames)
-{
-  return OMS_NOT_SUPPORTED;
-}
-
-MediaSigningReturnCode
-onvif_media_signing_add_nalu_for_signing(onvif_media_signing_t ATTR_UNUSED *self,
-    const uint8_t ATTR_UNUSED *nalu,
-    size_t ATTR_UNUSED nalu_size,
-    int64_t ATTR_UNUSED timestamp)
 {
   return OMS_NOT_SUPPORTED;
 }

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -53,4 +53,10 @@ MediaSigningReturnCode
 onvif_media_signing_set_max_signing_frames(onvif_media_signing_t *self,
     unsigned max_signing_frames);
 
-#endif  // __SV_ONVIF_H__
+MediaSigningReturnCode
+onvif_media_signing_add_nalu_for_signing(onvif_media_signing_t *self,
+    const uint8_t *nalu,
+    size_t nalu_size,
+    int64_t timestamp);
+
+    #endif  // __SV_ONVIF_H__

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -21,6 +21,7 @@
 #ifndef __SV_ONVIF_H__
 #define __SV_ONVIF_H__
 
+#include <stdbool.h>  // bool
 #include <stddef.h>  // size_t
 #include <stdint.h>  // uint8_t
 
@@ -41,6 +42,13 @@ typedef enum {
 // Stubs for ONVIF APIs
 
 MediaSigningReturnCode
+onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t *self,
+    const uint8_t *nalu_part,
+    size_t nalu_part_size,
+    int64_t timestamp,
+    bool is_last_part);
+
+MediaSigningReturnCode
 onvif_media_signing_get_sei(onvif_media_signing_t *self,
     uint8_t **sei,
     size_t *sei_size,
@@ -53,10 +61,4 @@ MediaSigningReturnCode
 onvif_media_signing_set_max_signing_frames(onvif_media_signing_t *self,
     unsigned max_signing_frames);
 
-MediaSigningReturnCode
-onvif_media_signing_add_nalu_for_signing(onvif_media_signing_t *self,
-    const uint8_t *nalu,
-    size_t nalu_size,
-    int64_t timestamp);
-
-    #endif  // __SV_ONVIF_H__
+#endif  // __SV_ONVIF_H__

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -23,7 +23,7 @@
 
 #include <stdbool.h>  // bool
 #include <stddef.h>  // size_t
-#include <stdint.h>  // uint8_t
+#include <stdint.h>  // uint8_t, int64_t
 
 // Define a placeholder for onvif_media_signing_t to avoid compilation errors
 typedef void onvif_media_signing_t;

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -466,11 +466,6 @@ prepare_for_signing(signed_video_t *self)
 SignedVideoReturnCode
 signed_video_add_nalu_for_signing(signed_video_t *self, const uint8_t *bu_data, size_t bu_data_size)
 {
-  if (self->onvif) {
-    int64_t timestamp = 0;  // Use 0 or another valid default timestamp
-    return msrc_to_svrc(
-        onvif_media_signing_add_nalu_for_signing(self, bu_data, bu_data_size, timestamp));
-  }
   return signed_video_add_nalu_for_signing_with_timestamp(self, bu_data, bu_data_size, NULL);
 }
 
@@ -494,6 +489,11 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
   if (!self || !bu_data || !bu_data_size) {
     DEBUG_LOG("Invalid input parameters: (%p, %p, %zu)", self, bu_data, bu_data_size);
     return SV_INVALID_PARAMETER;
+  }
+
+  if (self->onvif) {
+    return msrc_to_svrc(onvif_media_signing_add_nalu_part_for_signing(
+        self, bu_data, bu_data_size, *timestamp, is_last_part));
   }
 
   bu_info_t bu_info = {0};

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -466,6 +466,11 @@ prepare_for_signing(signed_video_t *self)
 SignedVideoReturnCode
 signed_video_add_nalu_for_signing(signed_video_t *self, const uint8_t *bu_data, size_t bu_data_size)
 {
+  if (self->onvif) {
+    int64_t timestamp = 0;  // Use 0 or another valid default timestamp
+    return msrc_to_svrc(
+        onvif_media_signing_add_nalu_for_signing(self, bu_data, bu_data_size, timestamp));
+  }
   return signed_video_add_nalu_for_signing_with_timestamp(self, bu_data, bu_data_size, NULL);
 }
 

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -491,9 +491,10 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
     return SV_INVALID_PARAMETER;
   }
 
-  if (self->onvif) {
+  if (self->onvif && timestamp) {
+    int64_t onvif_timestamp = convert_unix_us_to_1601(*timestamp);
     return msrc_to_svrc(onvif_media_signing_add_nalu_part_for_signing(
-        self, bu_data, bu_data_size, *timestamp, is_last_part));
+        self, bu_data, bu_data_size, onvif_timestamp, is_last_part));
   }
 
   bu_info_t bu_info = {0};

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -494,7 +494,7 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
   if (self->onvif && timestamp) {
     int64_t onvif_timestamp = convert_unix_us_to_1601(*timestamp);
     return msrc_to_svrc(onvif_media_signing_add_nalu_part_for_signing(
-        self, bu_data, bu_data_size, onvif_timestamp, is_last_part));
+        self->onvif, bu_data, bu_data_size, onvif_timestamp, is_last_part));
   }
 
   bu_info_t bu_info = {0};


### PR DESCRIPTION
The BU data  is passed on to the ONVIF Media Signing API using `onvif_media_signing_add_nalu_for_signing`
if ONVIF Media Signing is available.# Please enter the commit message for your changes.

Change-Id: I0b5c518692d03b494c78e61f62cb20f650df2511

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
