### PR TITLE
Passes on setter to ONVIF if active

### DIFF
--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -49,3 +49,10 @@ onvif_media_signing_set_hash_algo(onvif_media_signing_t ATTR_UNUSED *self,
 {
   return OMS_NOT_SUPPORTED;
 }
+
+MediaSigningReturnCode
+onvif_media_signing_set_max_sei_payload_size(onvif_media_signing_t ATTR_UNUSED *self,
+    size_t ATTR_UNUSED max_sei_payload_size)
+{
+  return OMS_NOT_SUPPORTED;
+}

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -56,4 +56,8 @@ onvif_media_signing_set_max_signing_frames(onvif_media_signing_t *self,
 MediaSigningReturnCode
 onvif_media_signing_set_hash_algo(onvif_media_signing_t *self, const char *name_or_oid);
 
+MediaSigningReturnCode
+onvif_media_signing_set_max_sei_payload_size(onvif_media_signing_t *self,
+    size_t max_sei_payload_size);
+
 #endif  // __SV_ONVIF_H__

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -882,6 +882,11 @@ signed_video_set_max_sei_payload_size(signed_video_t *self, size_t max_sei_paylo
   if (!self) return SV_INVALID_PARAMETER;
 
   self->max_sei_payload_size = max_sei_payload_size;
+  if (self->onvif) {
+    return msrc_to_svrc(
+        onvif_media_signing_set_max_sei_payload_size(self->onvif, max_sei_payload_size));
+  }
+
   return SV_OK;
 }
 


### PR DESCRIPTION
The max_sei_payload_size parameter is passed on to ONVIF if Media
Signing is active.
