### PR TITLE
Passes on sei_epb setter to ONVIF if active

### DIFF
--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -56,3 +56,10 @@ onvif_media_signing_set_max_sei_payload_size(onvif_media_signing_t ATTR_UNUSED *
 {
   return OMS_NOT_SUPPORTED;
 }
+
+MediaSigningReturnCode
+onvif_media_signing_set_emulation_prevention_before_signing(onvif_media_signing_t ATTR_UNUSED *self,
+    bool ATTR_UNUSED enable)
+{
+  return OMS_NOT_SUPPORTED;
+}

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -60,4 +60,8 @@ MediaSigningReturnCode
 onvif_media_signing_set_max_sei_payload_size(onvif_media_signing_t *self,
     size_t max_sei_payload_size);
 
+MediaSigningReturnCode
+onvif_media_signing_set_emulation_prevention_before_signing(onvif_media_signing_t *self,
+    bool enable);
+
 #endif  // __SV_ONVIF_H__

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -863,6 +863,11 @@ signed_video_set_sei_epb(signed_video_t *self, bool sei_epb)
   if (!self) return SV_INVALID_PARAMETER;
   if (self->codec == SV_CODEC_AV1) return SV_NOT_SUPPORTED;
   self->sei_epb = sei_epb;
+  if (self->onvif) {
+    return msrc_to_svrc(
+        onvif_media_signing_set_emulation_prevention_before_signing(self->onvif, sei_epb));
+  }
+
   return SV_OK;
 }
 


### PR DESCRIPTION
The sei_epb parameter is passed on to ONVIF if Media Signing is
active.
