### PR TITLE
Passes on BUs to ONVIF Media Signing if active

### DIFF
--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -88,3 +88,9 @@ onvif_media_signing_add_nalu_and_authenticate(onvif_media_signing_t ATTR_UNUSED 
 {
   return OMS_NOT_SUPPORTED;
 }
+
+void
+onvif_media_signing_authenticity_report_free(
+    onvif_media_signing_authenticity_t ATTR_UNUSED *authenticity_report)
+{
+}

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -91,4 +91,8 @@ onvif_media_signing_add_nalu_and_authenticate(onvif_media_signing_t *self,
     size_t nalu_size,
     onvif_media_signing_authenticity_t **authenticity);
 
+void
+onvif_media_signing_authenticity_report_free(
+    onvif_media_signing_authenticity_t *authenticity_report);
+
 #endif  // __SV_ONVIF_H__


### PR DESCRIPTION
If Media Signing has been detected, the incoming Bitstream
Units are then passed on to ONVIF API. If an authenticity
has been received that report is freed. Copying the content
is done in a separate commit.

In addition adds necessary stub for freeing the report.
