### PR TITLE
Implements a converter for authenticity report

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -1399,9 +1399,7 @@ onvif_add_and_authenticate(onvif_media_signing_t *self,
   SignedVideoReturnCode status = msrc_to_svrc(
       onvif_media_signing_add_nalu_and_authenticate(self, bu_data, bu_data_size, auth_ptr));
   if (authenticity && onvif_auth) {
-    // TODO: Copy |onvif_auth| to |authenticity|.
-    // Free the ONVIF report.
-    onvif_media_signing_authenticity_report_free(onvif_auth);
+    *authenticity = convert_onvif_authenticity_report(onvif_auth);
   }
 
   return status;

--- a/lib/src/sv_authenticity.c
+++ b/lib/src/sv_authenticity.c
@@ -396,3 +396,27 @@ signed_video_authenticity_report_free(signed_video_authenticity_t *authenticity_
 
   free(authenticity_report);
 }
+
+signed_video_authenticity_t *
+convert_onvif_authenticity_report(onvif_media_signing_authenticity_t *onvif_authenticity)
+{
+  // Sanity check.
+  if (!onvif_authenticity) return NULL;
+
+  signed_video_authenticity_t *authenticity = signed_video_authenticity_report_create();
+
+  // Add a 'ONVIF' prefix to the versions so users can identify the difference.
+  strcpy(authenticity->version_on_signing_side, "ONVIF ");
+  strcat(authenticity->version_on_signing_side, onvif_authenticity->version_on_signing_side);
+  strcpy(authenticity->this_version, "ONVIF ");
+  strcat(authenticity->this_version, onvif_authenticity->this_version);
+
+  // TODO: Port |vendor_info|
+  // TODO: Port |latest_validation|
+  // TODO: Port |accumulated_validation|
+
+  // Free the ONVIF report.
+  onvif_media_signing_authenticity_report_free(onvif_authenticity);
+
+  return authenticity;
+}

--- a/lib/src/sv_authenticity.h
+++ b/lib/src/sv_authenticity.h
@@ -24,6 +24,9 @@
 #include "includes/signed_video_auth.h"  // signed_video_product_info_t
 #include "sv_defines.h"  // svrc_t
 #include "sv_internal.h"
+#ifndef HAS_ONVIF
+#include "sv_onvif.h"  // Stubs for ONVIF APIs and structs
+#endif
 
 /**
  * @brief Transfers all members in signed_video_product_info_t from |src| to |dst|
@@ -97,5 +100,18 @@ update_authenticity_report(signed_video_t *self);
 void
 update_accumulated_validation(const signed_video_latest_validation_t *latest,
     signed_video_accumulated_validation_t *accumulated);
+
+/**
+ * @brief Converts an ONVIF Media Signing authenticity report
+ *
+ * The function consumes the |onvif_authenticity| and returns a new Signed Video
+ * report.
+ *
+ * @param onvif_authenticity A pointer to the authenticity report to convert.
+ *
+ * @return A Signed Video authenticity report.
+ */
+signed_video_authenticity_t *
+convert_onvif_authenticity_report(onvif_media_signing_authenticity_t *onvif_authenticity);
 
 #endif  // __SV_AUTHENTICITY_H__

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -43,7 +43,7 @@
 
 #define SV_VERSION_BYTES 3
 #define SIGNED_VIDEO_VERSION "v2.0.4"
-#define SV_VERSION_MAX_STRLEN 13  // Longest possible string
+#define SV_VERSION_MAX_STRLEN 19  // Longest possible string including 'ONVIF' prefix
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME
 

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -711,7 +711,7 @@ signed_video_set_end_of_stream(signed_video_t *self)
 
   if (self->onvif) {
     return msrc_to_svrc(onvif_media_signing_set_end_of_stream(self->onvif));
-  } 
+  }
   uint8_t *payload = NULL;
   uint8_t *payload_signature_ptr = NULL;
   svrc_t status = SV_UNKNOWN_FAILURE;


### PR DESCRIPTION
Takes an ONVIF Media Signing authenticity report and
copies the content to a Signed Video authenticity report.
This commits only copies the version strings and adds
an 'ONVIF' prefix to them.
