### PR TITLE
Transfer validation to ONVIF if detected

### DIFF
--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -1012,6 +1012,9 @@ signed_video_reset(signed_video_t *self)
     SV_THROW_IF(!self, SV_INVALID_PARAMETER);
     DEBUG_LOG("Resetting signed session");
     // Reset session states
+    if (self->onvif) {
+      SV_THROW(msrc_to_svrc(onvif_media_signing_reset(self->onvif)));
+    }
     SV_THROW(legacy_sv_reset(self->legacy_sv));
     if (self->onvif) {
       SV_THROW(msrc_to_svrc(onvif_media_signing_reset(self->onvif)));
@@ -1044,6 +1047,8 @@ signed_video_free(signed_video_t *self)
   DEBUG_LOG("Free signed video %p", self);
   if (!self) return;
 
+  // Free the ONVIF Media Signing session if present.
+  onvif_media_signing_free(self->onvif);
   // Free the legacy validation if present.
   legacy_sv_free(self->legacy_sv);
   // Free the onvif object if present.

--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -148,3 +148,12 @@ onvif_media_signing_authenticity_report_free(
     onvif_media_signing_authenticity_t ATTR_UNUSED *authenticity_report)
 {
 }
+
+MediaSigningReturnCode
+onvif_media_signing_set_trusted_certificate(onvif_media_signing_t ATTR_UNUSED *self,
+    const char ATTR_UNUSED *trusted_certificate,
+    size_t ATTR_UNUSED trusted_certificate_size,
+    bool ATTR_UNUSED user_provisioned)
+{
+  return OMS_NOT_SUPPORTED;
+}

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -175,4 +175,10 @@ void
 onvif_media_signing_authenticity_report_free(
     onvif_media_signing_authenticity_t *authenticity_report);
 
+MediaSigningReturnCode
+onvif_media_signing_set_trusted_certificate(onvif_media_signing_t *self,
+    const char *trusted_certificate,
+    size_t trusted_certificate_size,
+    bool user_provisioned);
+
 #endif  // __SV_ONVIF_H__


### PR DESCRIPTION
If an ONVIF Media Signing SEI is detected and the library
is build with Axis Communications vendor, an ONVIF Media
Signing session is created. The trusted anchor certificate
is passed in to the new session and all queued Bitstream
Units are transferred to the new session.

Stubs have been added for compilation purpose.
