### PR TITLE
Adds a getter for the Axis Communications root CA

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -1325,7 +1325,7 @@ detect_onvif_media_signing(signed_video_t *self, const bu_info_t *bu)
     return SV_OK;
   }
 
-  char *trusted_certificate = NULL;
+  const char *trusted_certificate = NULL;
   size_t trusted_certificate_size = 0;
   // Map codec to ONVIF enum.
   MediaSigningCodec codec = OMS_CODEC_NUM;
@@ -1345,7 +1345,9 @@ detect_onvif_media_signing(signed_video_t *self, const bu_info_t *bu)
     self->onvif = onvif_media_signing_create(codec);
     SV_THROW_IF(!self->onvif, SV_EXTERNAL_ERROR);
 #ifdef SV_VENDOR_AXIS_COMMUNICATIONS
-    // TODO: Get the root CA certificate from Axis code.
+    // Get the root CA certificate from Axis code.
+    trusted_certificate = get_axis_communications_trusted_certificate();
+    trusted_certificate_size = strlen(trusted_certificate);
 #endif
     SV_THROW(msrc_to_svrc(onvif_media_signing_set_trusted_certificate(
         self->onvif, trusted_certificate, trusted_certificate_size, false)));
@@ -1360,8 +1362,6 @@ detect_onvif_media_signing(signed_video_t *self, const bu_info_t *bu)
     self->onvif = NULL;
   }
   SV_DONE(status)
-
-  free(trusted_certificate);
 
   return status;
 }

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -885,3 +885,9 @@ catch_error:
 
   return SV_MEMORY;
 }
+
+const char *
+get_axis_communications_trusted_certificate(void)
+{
+  return kTrustedAxisRootCA;
+}

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
@@ -140,4 +140,14 @@ svrc_t
 get_axis_communications_supplemental_authenticity(void *handle,
     sv_vendor_axis_supplemental_authenticity_t **supplemental_authenticity);
 
+/**
+ * @brief Returns the trusted anchor certificate of the certificate chain
+ *
+ * The memory is NOT transferred to the user.
+ *
+ * @return A pointer to the trusted certificate as a null-terminated string.
+ */
+const char *
+get_axis_communications_trusted_certificate(void);
+
 #endif  // __SV_VENDOR_AXIS_COMMUNICATIONS_INTERNAL_H__


### PR DESCRIPTION
This is needed when a validation session for the ONVIF Media
Signing is set up.
