### PR TITLE
Updates include paths in test helper functions

### DIFF
--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -31,11 +31,9 @@
 #include <unistd.h>  // getcwd
 #endif
 
-#include "lib/src/includes/signed_video_common.h"
-#include "lib/src/includes/signed_video_openssl.h"
-#include "lib/src/includes/signed_video_sign.h"
-#include "lib/src/sv_internal.h"  // parse_bu_info(), kUuidSignedVideo
-#include "lib/src/sv_tlv.h"  // tlv_find_tag()
+#include "includes/signed_video_openssl.h"
+#include "sv_internal.h"  // parse_bu_info(), kUuidSignedVideo
+#include "sv_tlv.h"  // tlv_find_tag()
 
 #define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
 #define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -25,9 +25,9 @@
 #include <stdint.h>
 #include <stdlib.h>  // size_t
 
-#include "lib/src/includes/signed_video_common.h"  // signed_video_t, SignedVideoCodec
-#include "lib/src/includes/signed_video_sign.h"  // SignedVideoAuthenticityLevel
-#include "lib/src/sv_defines.h"  // sv_tlv_tag_t
+#include "includes/signed_video_common.h"  // signed_video_t, SignedVideoCodec
+#include "includes/signed_video_sign.h"  // SignedVideoAuthenticityLevel
+#include "sv_defines.h"  // sv_tlv_tag_t
 #include "test_stream.h"  // test_stream_t, test_stream_item_t
 
 #define HW_ID "hardware_id"

--- a/tests/check/test_stream.c
+++ b/tests/check/test_stream.c
@@ -25,7 +25,7 @@
 #include <stdlib.h>  // calloc, free
 #include <string.h>  // memcpy, memset, strcmp
 
-#include "lib/src/sv_internal.h"  // parse_bu_info()
+#include "sv_internal.h"  // parse_bu_info()
 
 #define START_CODE_SIZE 4
 #define DUMMY_NALU_SIZE 5

--- a/tests/check/test_stream.h
+++ b/tests/check/test_stream.h
@@ -24,7 +24,7 @@
 #include <stdint.h>  // uint8_t
 #include <string.h>  // size_t
 
-#include "lib/src/includes/signed_video_common.h"  // SignedVideoCodec
+#include "includes/signed_video_common.h"  // SignedVideoCodec
 
 /* A struct representing a Bitstream Unit in a test stream, the test stream being
  * represented as a linked list. Each object holds the data as well as pointers to the


### PR DESCRIPTION
Unnecessary includes and absolute paths have been removed.
