### PR TITLE
Renames internal files

### DIFF
--- a/lib/plugins/threaded-signing/plugin.c
+++ b/lib/plugins/threaded-signing/plugin.c
@@ -20,7 +20,7 @@
  */
 
 /**
- * This signing plugin sets up a worker thread and calls openssl_sign_hash(), from the worker
+ * This signing plugin sets up a worker thread and calls sv_openssl_sign_hash(), from the worker
  * thread, when there is a new hash to sign. To handle several signatures at the same time, the
  * plugin has two buffers. One for incomming hashes and another one for outgoing signatures.
  * The thread is stopped if 1) the out buffer is full, 2) there was a failure in the memory
@@ -119,7 +119,7 @@ sign_data_free(sign_or_verify_data_t *sign_data)
 {
   if (!sign_data) return;
 
-  openssl_free_key(sign_data->key);
+  sv_openssl_free_key(sign_data->key);
   free(sign_data->signature);
   free(sign_data->hash);
   free(sign_data);
@@ -445,7 +445,7 @@ central_worker_thread(void *user_data)
       // blocked, since variables need to be read under a lock.
       central.is_in_signing = true;
       g_mutex_unlock(&(central.mutex));
-      status = openssl_sign_hash(central.sign_data);
+      status = sv_openssl_sign_hash(central.sign_data);
       g_mutex_lock(&(central.mutex));
       central.is_in_signing = false;
 
@@ -600,7 +600,7 @@ local_worker_thread(void *user_data)
       // blocked, since variables need to be read under a lock.
       self->is_in_signing = true;
       g_mutex_unlock(&self->mutex);
-      SignedVideoReturnCode status = openssl_sign_hash(self->sign_data);
+      SignedVideoReturnCode status = sv_openssl_sign_hash(self->sign_data);
       g_mutex_lock(&self->mutex);
       self->is_in_signing = false;
 

--- a/lib/plugins/unthreaded-signing/plugin.c
+++ b/lib/plugins/unthreaded-signing/plugin.c
@@ -20,8 +20,8 @@
  */
 
 /**
- * This signing plugin calls openssl_sign_hash() and stores the generated signature before return.
- * This signature is then copied to the user when sv_signing_plugin_get_signature().
+ * This signing plugin calls sv_openssl_sign_hash() and stores the generated signature before
+ * return. This signature is then copied to the user when sv_signing_plugin_get_signature().
  */
 #include <assert.h>  // assert
 #include <stdlib.h>  // calloc, memcpy
@@ -94,7 +94,7 @@ unthreaded_openssl_sign_hash(sv_unthreaded_plugin_t *self, const uint8_t *hash, 
   }
 
   // Perform the signing operation.
-  status = openssl_sign_hash(&self->sign_data);
+  status = sv_openssl_sign_hash(&self->sign_data);
   if (status != SV_OK) goto done;
 
   // Check if a valid signature was generated.
@@ -196,7 +196,7 @@ sv_signing_plugin_session_teardown(void *handle)
   if (!self) return;
 
   out_buffer_teardown(self);
-  openssl_free_key(self->sign_data.key);
+  sv_openssl_free_key(self->sign_data.key);
   free(self->sign_data.signature);
   free(self);
 }

--- a/lib/src/includes/signed_video_openssl.h
+++ b/lib/src/includes/signed_video_openssl.h
@@ -67,7 +67,7 @@ typedef struct _pem_pkey_t {
  *         SV_EXTERNAL_ERROR Failure in OpenSSL.
  */
 SignedVideoReturnCode
-openssl_sign_hash(sign_or_verify_data_t *sign_data);
+sv_openssl_sign_hash(sign_or_verify_data_t *sign_data);
 
 /**
  * @brief Turns a private key on PEM form to EVP_PKEY form
@@ -75,7 +75,7 @@ openssl_sign_hash(sign_or_verify_data_t *sign_data);
  * and allocates memory for a signature
  *
  * The function allocates enough memory for a signature given the |private_key|.
- * Use openssl_free_key() to free the key context.
+ * Use sv_openssl_free_key() to free the key context.
  *
  * @param sign_data A pointer to the struct that holds all necessary information for signing.
  * @param private_key The content of the private key PEM file.
@@ -99,7 +99,7 @@ openssl_private_key_malloc(sign_or_verify_data_t *sign_data,
  * @param key A pointer to the key context which memory to free
  */
 void
-openssl_free_key(void *key);
+sv_openssl_free_key(void *key);
 
 /**
  * @brief Helper function to generate a private key

--- a/lib/src/legacy/legacy_auth.c
+++ b/lib/src/legacy/legacy_auth.c
@@ -31,8 +31,8 @@
 #include "legacy/legacy_internal.h"
 #include "legacy/legacy_tlv.h"  // legacy_tlv_decode()
 #include "sv_authenticity.h"  // update_accumulated_validation()
-#include "sv_openssl_internal.h"  // openssl_verify_hash()
-#include "sv_tlv.h"  // tlv_find_tag()
+#include "sv_openssl_internal.h"  // sv_openssl_verify_hash()
+#include "sv_tlv.h"  // sv_tlv_find_tag()
 
 static bool
 legacy_verify_hashes_without_sei(legacy_sv_t *self);
@@ -791,7 +791,7 @@ legacy_prepare_for_validation(legacy_sv_t *self)
       }
       printf("\n");
 #endif
-      SV_THROW(openssl_verify_hash(verify_data, &self->gop_info->verified_signature_hash));
+      SV_THROW(sv_openssl_verify_hash(verify_data, &self->gop_info->verified_signature_hash));
     }
 
   SV_CATCH()
@@ -1025,7 +1025,7 @@ legacy_update_hashable_data(legacy_bu_info_t *bu)
   // emulation prevention bytes) coresponding to that tag. This is done by scanning the TLV for that
   // tag.
   const uint8_t *signature_tag_ptr =
-      tlv_find_tag(bu->tlv_start_in_bu_data, bu->tlv_size, SIGNATURE_TAG, bu->with_epb);
+      sv_tlv_find_tag(bu->tlv_start_in_bu_data, bu->tlv_size, SIGNATURE_TAG, bu->with_epb);
 
   if (signature_tag_ptr) bu->hashable_data_size = signature_tag_ptr - bu->hashable_data;
 }

--- a/lib/src/sv_authenticity.c
+++ b/lib/src/sv_authenticity.c
@@ -164,7 +164,7 @@ transfer_authenticity(signed_video_authenticity_t *dst, const signed_video_authe
  */
 
 void
-latest_validation_init(signed_video_latest_validation_t *self)
+sv_latest_validation_init(signed_video_latest_validation_t *self)
 {
   // This call can be made before an authenticity report exists, e.g., if a reset is done right
   // after creating a session, or done on the signing side.
@@ -186,7 +186,7 @@ latest_validation_init(signed_video_latest_validation_t *self)
 }
 
 void
-accumulated_validation_init(signed_video_accumulated_validation_t *self)
+sv_accumulated_validation_init(signed_video_accumulated_validation_t *self)
 {
   // This call can be made before an authenticity report exists, e.g., if a reset is done right
   // after creating a session, or done on the signing side.
@@ -212,8 +212,8 @@ authenticity_report_init(signed_video_authenticity_t *authenticity_report)
   authenticity_report->version_on_signing_side = calloc(1, SV_VERSION_MAX_STRLEN);
   authenticity_report->this_version = calloc(1, SV_VERSION_MAX_STRLEN);
 
-  latest_validation_init(&authenticity_report->latest_validation);
-  accumulated_validation_init(&authenticity_report->accumulated_validation);
+  sv_latest_validation_init(&authenticity_report->latest_validation);
+  sv_accumulated_validation_init(&authenticity_report->accumulated_validation);
 }
 
 void
@@ -248,7 +248,7 @@ update_accumulated_validation(const signed_video_latest_validation_t *latest,
 }
 
 void
-update_authenticity_report(signed_video_t *self)
+sv_update_authenticity_report(signed_video_t *self)
 {
   assert(self && self->authenticity);
 
@@ -350,7 +350,7 @@ signed_video_get_authenticity_report(signed_video_t *self)
  */
 
 svrc_t
-create_local_authenticity_report_if_needed(signed_video_t *self)
+sv_create_local_authenticity_report_if_needed(signed_video_t *self)
 {
   if (!self) return SV_INVALID_PARAMETER;
 

--- a/lib/src/sv_authenticity.h
+++ b/lib/src/sv_authenticity.h
@@ -47,7 +47,7 @@ transfer_product_info(signed_video_product_info_t *dst, const signed_video_produ
  * @param self The struct to initialize.
  */
 void
-latest_validation_init(signed_video_latest_validation_t *self);
+sv_latest_validation_init(signed_video_latest_validation_t *self);
 
 /**
  * @brief Initializes a signed_video_accumulated_validation_t struct
@@ -57,7 +57,7 @@ latest_validation_init(signed_video_latest_validation_t *self);
  * @param self The struct to initialize.
  */
 void
-accumulated_validation_init(signed_video_accumulated_validation_t *self);
+sv_accumulated_validation_init(signed_video_accumulated_validation_t *self);
 
 /**
  * @brief Maybe creates a local authenticity report
@@ -70,7 +70,7 @@ accumulated_validation_init(signed_video_accumulated_validation_t *self);
  * @return A Signed Video Return Code
  */
 svrc_t
-create_local_authenticity_report_if_needed(signed_video_t *self);
+sv_create_local_authenticity_report_if_needed(signed_video_t *self);
 
 /**
  * @brief Copies a null-terminated string
@@ -87,7 +87,7 @@ svrc_t
 allocate_memory_and_copy_string(char **dst_str, const char *src_str);
 
 void
-update_authenticity_report(signed_video_t *self);
+sv_update_authenticity_report(signed_video_t *self);
 
 /**
  * @brief Updates a signed_video_accumulated_validation_t struct

--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -35,13 +35,13 @@
 #include "includes/signed_video_helpers.h"  // onvif_media_signing_parse_sei()
 #include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t
 #include "includes/signed_video_signing_plugin.h"
-#include "sv_authenticity.h"  // latest_validation_init()
+#include "sv_authenticity.h"  // sv_latest_validation_init()
 #include "sv_bu_list.h"  // bu_list_create(), bu_list_free()
 #include "sv_codec_internal.h"  // parse_h264_nalu_header(), parse_av1_obu_header()
 #include "sv_defines.h"  // svrc_t
 #include "sv_internal.h"  // gop_info_t, validation_flags_t, MAX_HASH_SIZE, DEFAULT_HASH_SIZE
 #include "sv_openssl_internal.h"
-#include "sv_tlv.h"  // read_32bits()
+#include "sv_tlv.h"  // sv_read_32bits()
 
 #define USER_DATA_UNREGISTERED 5
 #define H264_NALU_HEADER_LEN 1  // length of forbidden_zero_bit, nal_ref_idc and nal_unit_type
@@ -198,7 +198,7 @@ sign_or_verify_data_free(sign_or_verify_data_t *self)
 {
   if (!self) return;
 
-  openssl_free_key(self->key);
+  sv_openssl_free_key(self->key);
   free(self->hash);
   free(self->signature);
   free(self);
@@ -234,7 +234,7 @@ version_str_to_bytes(int *arr, const char *str)
 
 /* Puts Major, Minor and Patch from a version array to a version string */
 void
-bytes_to_version_str(const int *arr, char *str)
+sv_bytes_to_version_str(const int *arr, char *str)
 {
   if (!arr || !str) return;
   sprintf(str, "v%d.%d.%d", arr[0], arr[1], arr[2]);
@@ -400,7 +400,7 @@ remove_epb_from_sei_payload(bu_info_t *bu)
     // prevention bytes removed.
     const uint8_t *hashable_data_ptr = bu->hashable_data;
     for (size_t i = 0; i < data_size; i++) {
-      bu->nalu_data_wo_epb[i] = read_byte(&last_two_bytes, &hashable_data_ptr, true);
+      bu->nalu_data_wo_epb[i] = sv_read_byte(&last_two_bytes, &hashable_data_ptr, true);
     }
     // Point |tlv_data| to the first byte of the TLV part in |nalu_data_wo_epb|.
     bu->tlv_data = &bu->nalu_data_wo_epb[data_size - bu->payload_size + UUID_LEN];
@@ -455,7 +455,7 @@ parse_bu_info(const uint8_t *bu_data,
 
   if (codec != SV_CODEC_AV1) {
     // There is no start code for AV1.
-    read_bytes = read_32bits(bu_data, &start_code);
+    read_bytes = sv_read_32bits(bu_data, &start_code);
     if (start_code != kStartCode) {
       // Check if this is a 3 byte Start Code.
       read_bytes = 3;
@@ -668,7 +668,7 @@ check_and_copy_hash_to_hash_list(signed_video_t *self, const uint8_t *hash, size
   // If this is the start of the GOP, initialize |crypto_handle| to enable
   // updating the hash with each received BU.
   if (*list_idx == 0) {
-    openssl_init_hash(self->crypto_handle, true);
+    sv_openssl_init_hash(self->crypto_handle, true);
   }
   // If the upcoming hash doesn't fit in the hash list buffer, set *list_idx to -1
   // to indicate that the hash list is full, and the hash list is no longer accessible.
@@ -681,7 +681,7 @@ check_and_copy_hash_to_hash_list(signed_video_t *self, const uint8_t *hash, size
     memcpy(&hash_list[*list_idx], hash, hash_size);
     *list_idx += (int)hash_size;
   }
-  openssl_update_hash(self->crypto_handle, hash, hash_size, true);
+  sv_openssl_update_hash(self->crypto_handle, hash, hash_size, true);
 }
 
 /*
@@ -690,7 +690,7 @@ check_and_copy_hash_to_hash_list(signed_video_t *self, const uint8_t *hash, size
  * previous hash moved to the first slot.
  */
 svrc_t
-update_linked_hash(signed_video_t *self, uint8_t *hash, size_t hash_size)
+sv_update_linked_hash(signed_video_t *self, uint8_t *hash, size_t hash_size)
 {
   if (!self || !hash) return SV_INVALID_PARAMETER;
   if (self->authentication_started) {
@@ -748,7 +748,7 @@ update_hash(signed_video_t *self,
   const uint8_t *hashable_data = bu->hashable_data;
   size_t hashable_data_size = bu->hashable_data_size;
 
-  return openssl_update_hash(self->crypto_handle, hashable_data, hashable_data_size, false);
+  return sv_openssl_update_hash(self->crypto_handle, hashable_data, hashable_data_size, false);
 }
 
 /* simply_hash()
@@ -765,12 +765,12 @@ simply_hash(signed_video_t *self, const bu_info_t *bu, uint8_t *hash, size_t has
 
   if (bu->is_first_bu_part) {
     // Entire BU can be hashed in one part.
-    return openssl_hash_data(self->crypto_handle, hashable_data, hashable_data_size, hash);
+    return sv_openssl_hash_data(self->crypto_handle, hashable_data, hashable_data_size, hash);
   } else {
     svrc_t status = update_hash(self, bu, hash, hash_size);
     if (status == SV_OK) {
       // Finalize the ongoing hash of BU parts.
-      status = openssl_finalize_hash(self->crypto_handle, hash, false);
+      status = sv_openssl_finalize_hash(self->crypto_handle, hash, false);
     }
     return status;
   }
@@ -798,7 +798,7 @@ hash_and_copy_to_ref(signed_video_t *self, const bu_info_t *bu, uint8_t *hash, s
     memcpy(reference_hash, hash, hash_size);
     // Update |linked_hash| with |reference_hash| if applied on the signing side.
     if (!self->authentication_started) {
-      update_linked_hash(self, reference_hash, hash_size);
+      sv_update_linked_hash(self, reference_hash, hash_size);
     }
   SV_CATCH()
   SV_DONE(status)
@@ -833,12 +833,12 @@ hash_with_reference(signed_video_t *self,
     // Hash BU data and store as |bu_hash|.
     SV_THROW(simply_hash(self, bu, bu_hash, hash_size));
     // Hash reference hash together with the |bu_hash| and store in |buddy_hash|.
-    SV_THROW(
-        openssl_hash_data(self->crypto_handle, gop_info->hash_buddies, hash_size * 2, buddy_hash));
+    SV_THROW(sv_openssl_hash_data(
+        self->crypto_handle, gop_info->hash_buddies, hash_size * 2, buddy_hash));
     // Copy |buddy_hash| to |linked_hash| queue if signing is triggered. Only applies on
     // the signing side.
     if (gop_info->triggered_partial_gop && !self->authentication_started) {
-      update_linked_hash(self, buddy_hash, hash_size);
+      sv_update_linked_hash(self, buddy_hash, hash_size);
     }
   SV_CATCH()
   SV_DONE(status)
@@ -847,7 +847,7 @@ hash_with_reference(signed_video_t *self,
 }
 
 svrc_t
-hash_and_add(signed_video_t *self, const bu_info_t *bu)
+sv_hash_and_add(signed_video_t *self, const bu_info_t *bu)
 {
   if (!self || !bu) return SV_INVALID_PARAMETER;
 
@@ -866,7 +866,7 @@ hash_and_add(signed_video_t *self, const bu_info_t *bu)
     if (bu->is_first_bu_part && !bu->is_last_bu_part) {
       // If this is the first part of a non-complete BU, initialize the |crypto_handle| to
       // enable sequentially updating the hash with more parts.
-      SV_THROW(openssl_init_hash(self->crypto_handle, false));
+      SV_THROW(sv_openssl_init_hash(self->crypto_handle, false));
     }
     // Select hash function, hash the BU and store as 'latest hash'
     hash_wrapper_t hash_wrapper = get_hash_wrapper(self, bu);
@@ -946,7 +946,7 @@ signed_video_create(SignedVideoCodec codec)
     self->codec = codec;
 
     // Setup crypto handle.
-    self->crypto_handle = openssl_create_handle();
+    self->crypto_handle = sv_openssl_create_handle();
     SV_THROW_IF(!self->crypto_handle, SV_EXTERNAL_ERROR);
 
     self->gop_info = gop_info_create();
@@ -967,7 +967,7 @@ signed_video_create(SignedVideoCodec codec)
     self->sei_epb = codec != SV_CODEC_AV1;
     self->signing_started = false;
     self->sign_data = sign_or_verify_data_create();
-    self->sign_data->hash_size = openssl_get_hash_size(self->crypto_handle);
+    self->sign_data->hash_size = sv_openssl_get_hash_size(self->crypto_handle);
     // Make sure the hash size matches the default hash size.
     SV_THROW_IF(self->sign_data->hash_size != DEFAULT_HASH_SIZE, SV_EXTERNAL_ERROR);
 
@@ -991,7 +991,7 @@ signed_video_create(SignedVideoCodec codec)
     self->has_public_key = false;
 
     self->verify_data = sign_or_verify_data_create();
-    self->verify_data->hash_size = openssl_get_hash_size(self->crypto_handle);
+    self->verify_data->hash_size = sv_openssl_get_hash_size(self->crypto_handle);
   SV_CATCH()
   {
     signed_video_free(self);
@@ -1024,15 +1024,15 @@ signed_video_reset(signed_video_t *self)
     gop_info_reset(self->gop_info);
 
     validation_flags_init(&(self->validation_flags));
-    latest_validation_init(self->latest_validation);
-    accumulated_validation_init(self->accumulated_validation);
+    sv_latest_validation_init(self->latest_validation);
+    sv_accumulated_validation_init(self->accumulated_validation);
     // Empty the |bu_list|.
     bu_list_free_items(self->bu_list);
 
     memset(self->gop_info->linked_hashes, 0, sizeof(self->gop_info->linked_hashes));
     memset(self->last_bu, 0, sizeof(bu_info_t));
     self->last_bu->is_last_bu_part = true;
-    SV_THROW(openssl_init_hash(self->crypto_handle, false));
+    SV_THROW(sv_openssl_init_hash(self->crypto_handle, false));
 
     self->gop_info->num_in_partial_gop = 0;
   SV_CATCH()
@@ -1061,7 +1061,7 @@ signed_video_free(signed_video_t *self)
   sv_vendor_axis_communications_teardown(self->vendor_handle);
 #endif
   // Teardown the crypto handle.
-  openssl_free_handle(self->crypto_handle);
+  sv_openssl_free_handle(self->crypto_handle);
 
   // Free any pending SEIs
   free_sei_data_buffer(self->sei_data_buffer);
@@ -1140,7 +1140,7 @@ signed_video_parse_sei(uint8_t *bu, size_t bu_size, SignedVideoCodec codec)
     }
     printf("\n");
     signed_video_t *self = signed_video_create(codec);
-    tlv_decode(self, bu_info.tlv_data, bu_info.tlv_size);
+    sv_tlv_decode(self, bu_info.tlv_data, bu_info.tlv_size);
     signed_video_free(self);
   }
 

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -366,10 +366,10 @@ check_and_copy_hash_to_hash_list(signed_video_t *signed_video,
     size_t hash_size);
 
 svrc_t
-hash_and_add(signed_video_t *self, const bu_info_t *bu);
+sv_hash_and_add(signed_video_t *self, const bu_info_t *bu);
 
 svrc_t
-update_linked_hash(signed_video_t *self, uint8_t *hash, size_t hash_size);
+sv_update_linked_hash(signed_video_t *self, uint8_t *hash, size_t hash_size);
 
 svrc_t
 hash_and_add_for_auth(signed_video_t *signed_video, bu_list_item_t *item);
@@ -385,10 +385,10 @@ void
 copy_bu_except_pointers(bu_info_t *dst_bu, const bu_info_t *src_bu);
 
 void
-update_hashable_data(bu_info_t *bu);
+sv_update_hashable_data(bu_info_t *bu);
 
 void
-bytes_to_version_str(const int *arr, char *str);
+sv_bytes_to_version_str(const int *arr, char *str);
 
 int64_t
 convert_unix_us_to_1601(int64_t timestamp);

--- a/lib/src/sv_openssl.c
+++ b/lib/src/sv_openssl.c
@@ -86,7 +86,7 @@ static const int gop_hash_salt = 1;
 
 /* Frees a key represented by an EVP_PKEY_CTX object. */
 void
-openssl_free_key(void *key)
+sv_openssl_free_key(void *key)
 {
   EVP_PKEY_CTX_free((EVP_PKEY_CTX *)key);
 }
@@ -243,7 +243,7 @@ openssl_read_pubkey_from_private_key(sign_or_verify_data_t *sign_data, pem_pkey_
 
 /* Signs a hash. */
 SignedVideoReturnCode
-openssl_sign_hash(sign_or_verify_data_t *sign_data)
+sv_openssl_sign_hash(sign_or_verify_data_t *sign_data)
 {
   // Sanity check input
   if (!sign_data) return SV_INVALID_PARAMETER;
@@ -283,7 +283,7 @@ openssl_sign_hash(sign_or_verify_data_t *sign_data)
 
 /* Verifies the |signature|. */
 svrc_t
-openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_result)
+sv_openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_result)
 {
   if (!verify_data || !verified_result) return SV_INVALID_PARAMETER;
 
@@ -316,7 +316,7 @@ openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_resu
 
 /* Hashes the data using |hash_algo.type|. */
 svrc_t
-openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *hash)
+sv_openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *hash)
 {
   openssl_crypto_t *self = (openssl_crypto_t *)handle;
 
@@ -331,7 +331,7 @@ openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *
 
 /* Initializes a EVP_MD_CTX in |handle| with |hash_algo.type|. */
 svrc_t
-openssl_init_hash(void *handle, bool use_primary_ctx)
+sv_openssl_init_hash(void *handle, bool use_primary_ctx)
 {
   if (!handle) return SV_INVALID_PARAMETER;
   openssl_crypto_t *self = (openssl_crypto_t *)handle;
@@ -357,7 +357,7 @@ openssl_init_hash(void *handle, bool use_primary_ctx)
 
 /* Updates a EVP_MD_CTX in |handle| with |data|. */
 svrc_t
-openssl_update_hash(void *handle, const uint8_t *data, size_t data_size, bool use_primary_ctx)
+sv_openssl_update_hash(void *handle, const uint8_t *data, size_t data_size, bool use_primary_ctx)
 {
   if (!data || data_size == 0 || !handle) return SV_INVALID_PARAMETER;
 
@@ -373,7 +373,7 @@ openssl_update_hash(void *handle, const uint8_t *data, size_t data_size, bool us
 
 /* Finalizes a EVP_MD_CTX in |handle| and writes result to |hash|. */
 svrc_t
-openssl_finalize_hash(void *handle, uint8_t *hash, bool use_primary_ctx)
+sv_openssl_finalize_hash(void *handle, uint8_t *hash, bool use_primary_ctx)
 {
   if (!hash || !handle) return SV_INVALID_PARAMETER;
 
@@ -447,7 +447,7 @@ obj_to_oid_and_type(message_digest_t *self, const ASN1_OBJECT *obj)
 }
 
 svrc_t
-openssl_set_hash_algo(void *handle, const char *name_or_oid)
+sv_openssl_set_hash_algo(void *handle, const char *name_or_oid)
 {
   openssl_crypto_t *self = (openssl_crypto_t *)handle;
   if (!self) return SV_INVALID_PARAMETER;
@@ -468,7 +468,7 @@ openssl_set_hash_algo(void *handle, const char *name_or_oid)
     EVP_MD_CTX_free(self->secondary_ctx);
     self->secondary_ctx = NULL;
 
-    SV_THROW(openssl_init_hash(self, false));
+    SV_THROW(sv_openssl_init_hash(self, false));
     DEBUG_LOG("Setting hash algo %s that has ASN.1/DER coded OID length %zu", name_or_oid,
         self->hash_algo.encoded_oid_size);
   SV_CATCH()
@@ -478,7 +478,7 @@ openssl_set_hash_algo(void *handle, const char *name_or_oid)
 }
 
 svrc_t
-openssl_set_hash_algo_by_encoded_oid(void *handle,
+sv_openssl_set_hash_algo_by_encoded_oid(void *handle,
     const unsigned char *encoded_oid,
     size_t encoded_oid_size)
 {
@@ -511,7 +511,7 @@ openssl_set_hash_algo_by_encoded_oid(void *handle,
 }
 
 const unsigned char *
-openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size)
+sv_openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size)
 {
   openssl_crypto_t *self = (openssl_crypto_t *)handle;
   if (!self || encoded_oid_size == 0) return NULL;
@@ -521,7 +521,7 @@ openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size)
 }
 
 char *
-openssl_encoded_oid_to_str(const unsigned char *encoded_oid, size_t encoded_oid_size)
+sv_openssl_encoded_oid_to_str(const unsigned char *encoded_oid, size_t encoded_oid_size)
 {
   ASN1_OBJECT *obj = NULL;
   char *algo_name = calloc(1, 50);
@@ -549,11 +549,12 @@ openssl_get_hash_algo(const void *handle)
   if (!self) {
     return NULL;
   }
-  return openssl_encoded_oid_to_str(self->hash_algo.encoded_oid, self->hash_algo.encoded_oid_size);
+  return sv_openssl_encoded_oid_to_str(
+      self->hash_algo.encoded_oid, self->hash_algo.encoded_oid_size);
 }
 
 size_t
-openssl_get_hash_size(void *handle)
+sv_openssl_get_hash_size(void *handle)
 {
   if (!handle) return 0;
 
@@ -562,13 +563,13 @@ openssl_get_hash_size(void *handle)
 
 /* Creates a |handle| with a EVP_MD_CTX and hash algo. */
 void *
-openssl_create_handle(void)
+sv_openssl_create_handle(void)
 {
   openssl_crypto_t *self = (openssl_crypto_t *)calloc(1, sizeof(openssl_crypto_t));
   if (!self) return NULL;
 
-  if (openssl_set_hash_algo(self, DEFAULT_HASH_ALGO) != SV_OK) {
-    openssl_free_handle(self);
+  if (sv_openssl_set_hash_algo(self, DEFAULT_HASH_ALGO) != SV_OK) {
+    sv_openssl_free_handle(self);
     self = NULL;
   }
 
@@ -577,7 +578,7 @@ openssl_create_handle(void)
 
 /* Frees the |handle|. */
 void
-openssl_free_handle(void *handle)
+sv_openssl_free_handle(void *handle)
 {
   openssl_crypto_t *self = (openssl_crypto_t *)handle;
   if (!self) return;

--- a/lib/src/sv_openssl_internal.h
+++ b/lib/src/sv_openssl_internal.h
@@ -33,22 +33,22 @@
  *
  * Allocates the memory for a crypthographic |handle| holding specific OpenSSL information. This
  * handle should be created when starting the session and freed at teardown with
- * openssl_free_handle().
+ * sv_openssl_free_handle().
  *
  * @return Pointer to the OpenSSL cryptographic handle.
  */
 void *
-openssl_create_handle(void);
+sv_openssl_create_handle(void);
 
 /**
  * @brief Free cryptographic handle
  *
- * Frees a crypthographic |handle| created with openssl_create_handle().
+ * Frees a crypthographic |handle| created with sv_openssl_create_handle().
  *
  * @param handle Pointer to the OpenSSL cryptographic handle.
  */
 void
-openssl_free_handle(void *handle);
+sv_openssl_free_handle(void *handle);
 
 /**
  * @brief Sets hashing algorithm
@@ -63,7 +63,7 @@ openssl_free_handle(void *handle);
  *         SV_INVALID_PARAMETER Null pointer |handle| or invalid |name_or_oid|.
  */
 svrc_t
-openssl_set_hash_algo(void *handle, const char *name_or_oid);
+sv_openssl_set_hash_algo(void *handle, const char *name_or_oid);
 
 /**
  * @brief Sets the hashing algorithm given by its OID on ASN.1/DER form
@@ -78,7 +78,7 @@ openssl_set_hash_algo(void *handle, const char *name_or_oid);
  *         Other appropriate error.
  */
 svrc_t
-openssl_set_hash_algo_by_encoded_oid(void *handle,
+sv_openssl_set_hash_algo_by_encoded_oid(void *handle,
     const unsigned char *encoded_oid,
     size_t encoded_oid_size);
 
@@ -94,7 +94,7 @@ openssl_set_hash_algo_by_encoded_oid(void *handle,
  *         and a NULL pointer upon failure.
  */
 const unsigned char *
-openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size);
+sv_openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size);
 
 /**
  * @brief Converts hashing algorithm from OID form to readable string
@@ -107,7 +107,7 @@ openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size);
  * @return A string.
  */
 char *
-openssl_encoded_oid_to_str(const unsigned char *encoded_oid, size_t encoded_oid_size);
+sv_openssl_encoded_oid_to_str(const unsigned char *encoded_oid, size_t encoded_oid_size);
 
 /**
  * @brief Gets the hash algorithm
@@ -131,17 +131,17 @@ openssl_get_hash_algo(const void *handle);
  * @return The size of the hash.
  */
 size_t
-openssl_get_hash_size(void *handle);
+sv_openssl_get_hash_size(void *handle);
 
 /**
  * @brief Hashes data
  *
- * Uses the hash algorithm set through openssl_set_hash_algo() to hash data. The memory
- * for the |hash| has to be pre-allocated by the user. Use openssl_get_hash_size() to get
+ * Uses the hash algorithm set through sv_openssl_set_hash_algo() to hash data. The memory
+ * for the |hash| has to be pre-allocated by the user. Use sv_openssl_get_hash_size() to get
  * the hash size.
  *
- * This is a simplification for calling openssl_init_hash(), openssl_update_hash() and
- * openssl_finalize_hash() done in one go.
+ * This is a simplification for calling sv_openssl_init_hash(), sv_openssl_update_hash() and
+ * sv_openssl_finalize_hash() done in one go.
  *
  * @param data Pointer to the data to hash.
  * @param data_size Size of the |data| to hash.
@@ -152,7 +152,7 @@ openssl_get_hash_size(void *handle);
  *         SV_EXTERNAL_ERROR Failed to hash.
  */
 svrc_t
-openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *hash);
+sv_openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *hash);
 
 /**
  * @brief Initiates the cryptographic handle for hashing data
@@ -167,7 +167,7 @@ openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *
  *         SV_EXTERNAL_ERROR Failed to initialize.
  */
 svrc_t
-openssl_init_hash(void *handle, bool use_primary_ctx);
+sv_openssl_init_hash(void *handle, bool use_primary_ctx);
 
 /**
  * @brief Updates the cryptographic handle with |data| for hashing
@@ -185,7 +185,7 @@ openssl_init_hash(void *handle, bool use_primary_ctx);
  *         SV_EXTERNAL_ERROR Failed to update.
  */
 svrc_t
-openssl_update_hash(void *handle, const uint8_t *data, size_t data_size, bool use_primary_ctx);
+sv_openssl_update_hash(void *handle, const uint8_t *data, size_t data_size, bool use_primary_ctx);
 
 /**
  * @brief Finalizes the cryptographic handle and outputs the hash
@@ -202,7 +202,7 @@ openssl_update_hash(void *handle, const uint8_t *data, size_t data_size, bool us
  *         SV_EXTERNAL_ERROR Failed to finalize.
  */
 svrc_t
-openssl_finalize_hash(void *handle, uint8_t *hash, bool use_primary_ctx);
+sv_openssl_finalize_hash(void *handle, uint8_t *hash, bool use_primary_ctx);
 
 /**
  * @brief Verifies a signature against a hash
@@ -218,7 +218,7 @@ openssl_finalize_hash(void *handle, uint8_t *hash, bool use_primary_ctx);
  *         SV_INVALID_PARAMETER Errors in |verify_data|, or null pointer inputs,
  */
 svrc_t
-openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_result);
+sv_openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_result);
 
 /**
  * @brief Reads the public key from the private key
@@ -242,7 +242,7 @@ openssl_read_pubkey_from_private_key(sign_or_verify_data_t *sign_data, pem_pkey_
  *
  * The function takes the public key as a pem_pkey_t and stores it as |public_key| in
  * |verify_data| on the EVP_PKEY form.
- * Use openssl_free_key() to free the key context.
+ * Use sv_openssl_free_key() to free the key context.
  *
  * @param verify_data A pointer to the struct that holds all necessary information for signing.
  * @param pem_public_key A pointer to the PEM format struct.

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -257,44 +257,44 @@ encode_general(signed_video_t *self, uint8_t *data)
   bool epb = self->sei_epb;
 
   // Version
-  write_byte(last_two_bytes, &data_ptr, version, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, version, epb);
   // GOP counter; 4 bytes
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 24) & 0x000000ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 16) & 0x000000ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 8) & 0x000000ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter)&0x000000ff), epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 24) & 0x000000ff), epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 16) & 0x000000ff), epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 8) & 0x000000ff), epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter)&0x000000ff), epb);
   // Write num_in_partial_gop; 2 bytes
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((num_in_partial_gop >> 8) & 0x00ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((num_in_partial_gop)&0x00ff), epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((num_in_partial_gop >> 8) & 0x00ff), epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((num_in_partial_gop)&0x00ff), epb);
 
   for (int i = 0; i < SV_VERSION_BYTES; i++) {
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)self->code_version[i], epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)self->code_version[i], epb);
   }
 
   // Write bool flags; 1 byte | xxxxxx | triggered_partial_gop | has_timestamp |
   flags |= (gop_info->has_timestamp << 0) & 0x01;
   flags |= (gop_info->triggered_partial_gop << 1) & 0x02;
-  write_byte(last_two_bytes, &data_ptr, flags, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, flags, epb);
   if (gop_info->has_timestamp) {
     // Write timestamp; 8 bytes
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 56) & 0x000000ff), epb);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 48) & 0x000000ff), epb);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 40) & 0x000000ff), epb);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 32) & 0x000000ff), epb);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 24) & 0x000000ff), epb);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 16) & 0x000000ff), epb);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 8) & 0x000000ff), epb);
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp)&0x000000ff), epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 56) & 0x000000ff), epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 48) & 0x000000ff), epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 40) & 0x000000ff), epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 32) & 0x000000ff), epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 24) & 0x000000ff), epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 16) & 0x000000ff), epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp >> 8) & 0x000000ff), epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((timestamp)&0x000000ff), epb);
   }
 
   // Write linked hash; hash_size bytes
   for (size_t i = 0; i < self->sign_data->hash_size; i++) {
-    write_byte(last_two_bytes, &data_ptr, gop_info->linked_hashes[i], epb);
+    sv_write_byte(last_two_bytes, &data_ptr, gop_info->linked_hashes[i], epb);
   }
 
   // Write GOP hash; hash_size bytes
   for (size_t i = 0; i < self->sign_data->hash_size; i++) {
-    write_byte(last_two_bytes, &data_ptr, gop_info->computed_gop_hash[i], epb);
+    sv_write_byte(last_two_bytes, &data_ptr, gop_info->computed_gop_hash[i], epb);
   }
 
   gop_info->current_partial_gop = gop_counter;
@@ -322,9 +322,9 @@ decode_general(signed_video_t *self, const uint8_t *data, size_t data_size)
   SV_TRY()
     SV_THROW_IF(version < 1 || version > 3, SV_INCOMPATIBLE_VERSION);
 
-    data_ptr += read_32bits(data_ptr, &gop_info->current_partial_gop);
+    data_ptr += sv_read_32bits(data_ptr, &gop_info->current_partial_gop);
     DEBUG_LOG("Found GOP counter = %u", gop_info->current_partial_gop);
-    data_ptr += read_16bits(data_ptr, &gop_info->num_sent);
+    data_ptr += sv_read_16bits(data_ptr, &gop_info->num_sent);
     DEBUG_LOG("Number of sent Bitstream Units = %u", gop_info->num_sent);
 
     for (int i = 0; i < SV_VERSION_BYTES; i++) {
@@ -333,15 +333,15 @@ decode_general(signed_video_t *self, const uint8_t *data, size_t data_size)
     if (self->authenticity) {
       code_version_str = self->authenticity->version_on_signing_side;
     }
-    bytes_to_version_str(self->code_version, code_version_str);
+    sv_bytes_to_version_str(self->code_version, code_version_str);
 
     if (version >= 2) {
       // Read bool flags
-      data_ptr += read_8bits(data_ptr, &flags);
+      data_ptr += sv_read_8bits(data_ptr, &flags);
       gop_info->has_timestamp = flags & 0x01;
       gop_info->triggered_partial_gop = !!(flags & 0x02);
       if (gop_info->has_timestamp) {
-        data_ptr += read_64bits_signed(data_ptr, &gop_info->timestamp);
+        data_ptr += sv_read_64bits_signed(data_ptr, &gop_info->timestamp);
       }
       if (self->latest_validation) {
         self->latest_validation->has_timestamp = gop_info->has_timestamp;
@@ -438,33 +438,34 @@ encode_product_info(signed_video_t *self, uint8_t *data)
   uint16_t *last_two_bytes = &self->last_two_bytes;
   bool epb = self->sei_epb;
   // Version
-  write_byte(last_two_bytes, &data_ptr, version, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, version, epb);
 
   // Write |hardware_id|, i.e., size + string.
-  write_byte(last_two_bytes, &data_ptr, hardware_id_size, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, hardware_id_size, epb);
   // Write all but the null-terminated character.
-  write_byte_many(&data_ptr, product_info->hardware_id, hardware_id_size, last_two_bytes, epb);
+  sv_write_byte_many(&data_ptr, product_info->hardware_id, hardware_id_size, last_two_bytes, epb);
 
   // Write |firmware_version|, i.e., size + string.
-  write_byte(last_two_bytes, &data_ptr, firmware_version_size, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, firmware_version_size, epb);
   // Write all but the null-terminated character.
-  write_byte_many(
+  sv_write_byte_many(
       &data_ptr, product_info->firmware_version, firmware_version_size, last_two_bytes, epb);
 
   // Write |serial_number|, i.e., size + string.
-  write_byte(last_two_bytes, &data_ptr, serial_number_size, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, serial_number_size, epb);
   // Write all but the null-terminated character.
-  write_byte_many(&data_ptr, product_info->serial_number, serial_number_size, last_two_bytes, epb);
+  sv_write_byte_many(
+      &data_ptr, product_info->serial_number, serial_number_size, last_two_bytes, epb);
 
   // Write |manufacturer|, i.e., size + string.
-  write_byte(last_two_bytes, &data_ptr, manufacturer_size, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, manufacturer_size, epb);
   // Write all but the null-terminated character.
-  write_byte_many(&data_ptr, product_info->manufacturer, manufacturer_size, last_two_bytes, epb);
+  sv_write_byte_many(&data_ptr, product_info->manufacturer, manufacturer_size, last_two_bytes, epb);
 
   // Write |address|, i.e., size + string.
-  write_byte(last_two_bytes, &data_ptr, address_size, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, address_size, epb);
   // Write all but the null-terminated character.
-  write_byte_many(&data_ptr, product_info->address, address_size, last_two_bytes, epb);
+  sv_write_byte_many(&data_ptr, product_info->address, address_size, last_two_bytes, epb);
 
   return (data_ptr - data);
 }
@@ -560,10 +561,10 @@ encode_arbitrary_data(signed_video_t *self, uint8_t *data)
   uint16_t *last_two_bytes = &self->last_two_bytes;
   bool epb = self->sei_epb;
   // Version
-  write_byte(last_two_bytes, &data_ptr, version, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, version, epb);
 
   for (size_t ii = 0; ii < self->arbitrary_data_size; ++ii) {
-    write_byte(last_two_bytes, &data_ptr, self->arbitrary_data[ii], epb);
+    sv_write_byte(last_two_bytes, &data_ptr, self->arbitrary_data[ii], epb);
   }
 
   return (data_ptr - data);
@@ -641,11 +642,11 @@ encode_public_key(signed_video_t *self, uint8_t *data)
   uint8_t *public_key = (uint8_t *)pem_public_key->key;
 
   // Version
-  write_byte(last_two_bytes, &data_ptr, version, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, version, epb);
 
   // public_key; public_key_size bytes
   for (size_t ii = 0; ii < pem_public_key->key_size; ++ii) {
-    write_byte(last_two_bytes, &data_ptr, public_key[ii], epb);
+    sv_write_byte(last_two_bytes, &data_ptr, public_key[ii], epb);
   }
 
   return (data_ptr - data);
@@ -748,10 +749,10 @@ encode_hash_list(signed_video_t *self, uint8_t *data)
   uint16_t *last_two_bytes = &self->last_two_bytes;
   bool epb = self->sei_epb;
   // Write version
-  write_byte(last_two_bytes, &data_ptr, version, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, version, epb);
   // Write hash_list data
   for (int i = 0; i < gop_info->list_idx; i++) {
-    write_byte(last_two_bytes, &data_ptr, gop_info->hash_list[i], epb);
+    sv_write_byte(last_two_bytes, &data_ptr, gop_info->hash_list[i], epb);
   }
 
   return (data_ptr - data);
@@ -779,7 +780,7 @@ decode_hash_list(signed_video_t *self, const uint8_t *data, size_t data_size)
 
     SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
 #ifdef PRINT_DECODED_SEI
-    size_t hash_size = openssl_get_hash_size(self->crypto_handle);
+    size_t hash_size = sv_openssl_get_hash_size(self->crypto_handle);
     printf("\nHash list Tag\n");
     printf("             tag version: %u\n", version);
     printf("  hash list (%3zu hashes): \n", hash_list_size / hash_size);
@@ -826,21 +827,21 @@ encode_signature(signed_video_t *self, uint8_t *data)
   bool epb = self->sei_epb;
   uint16_t signature_size = (uint16_t)sign_data->signature_size;
   // Write version
-  write_byte(last_two_bytes, &data_ptr, version, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, version, epb);
   // Write info field
-  write_byte(last_two_bytes, &data_ptr, gop_info->encoding_status, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, gop_info->encoding_status, epb);
   // Write hash type
   // Write actual signature size (2 bytes)
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size >> 8) & 0x00ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size)&0x00ff), epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size >> 8) & 0x00ff), epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size)&0x00ff), epb);
   // Write signature
   size_t i = 0;
   for (; i < signature_size; i++) {
-    write_byte(last_two_bytes, &data_ptr, sign_data->signature[i], epb);
+    sv_write_byte(last_two_bytes, &data_ptr, sign_data->signature[i], epb);
   }
   for (; i < sign_data->max_signature_size; i++) {
     // Write 1's in the unused bytes to avoid emulation prevention bytes.
-    write_byte(last_two_bytes, &data_ptr, 1, epb);
+    sv_write_byte(last_two_bytes, &data_ptr, 1, epb);
   }
 
   return (data_ptr - data);
@@ -866,7 +867,7 @@ decode_signature(signed_video_t *self, const uint8_t *data, size_t data_size)
   size_t max_signature_size = 0;
 
   // Read true size of the signature.
-  data_ptr += read_16bits(data_ptr, &signature_size);
+  data_ptr += sv_read_16bits(data_ptr, &signature_size);
   // The rest of the value bytes should now be the allocated size for the signature.
   max_signature_size = data_size - (data_ptr - data);
 
@@ -912,7 +913,7 @@ encode_crypto_info(signed_video_t *self, uint8_t *data)
 {
   size_t hash_algo_encoded_oid_size = 0;
   const unsigned char *hash_algo_encoded_oid =
-      openssl_get_hash_algo_encoded_oid(self->crypto_handle, &hash_algo_encoded_oid_size);
+      sv_openssl_get_hash_algo_encoded_oid(self->crypto_handle, &hash_algo_encoded_oid_size);
   size_t data_size = 0;
   const uint8_t version = 1;
 
@@ -936,13 +937,13 @@ encode_crypto_info(signed_video_t *self, uint8_t *data)
   bool epb = self->sei_epb;
 
   // Version
-  write_byte(last_two_bytes, &data_ptr, version, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, version, epb);
   // OID size
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)hash_algo_encoded_oid_size, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)hash_algo_encoded_oid_size, epb);
 
   // OID data; hash_algo_encoded_oid_size bytes
   for (size_t ii = 0; ii < hash_algo_encoded_oid_size; ++ii) {
-    write_byte(last_two_bytes, &data_ptr, hash_algo_encoded_oid[ii], epb);
+    sv_write_byte(last_two_bytes, &data_ptr, hash_algo_encoded_oid[ii], epb);
   }
 
   return (data_ptr - data);
@@ -959,16 +960,16 @@ decode_crypto_info(signed_video_t *self, const uint8_t *data, size_t data_size)
   size_t hash_algo_encoded_oid_size = *data_ptr++;
   const unsigned char *hash_algo_encoded_oid = (const unsigned char *)data_ptr;
   char *hash_algo_name =
-      openssl_encoded_oid_to_str(hash_algo_encoded_oid, hash_algo_encoded_oid_size);
+      sv_openssl_encoded_oid_to_str(hash_algo_encoded_oid, hash_algo_encoded_oid_size);
 
   svrc_t status = SV_UNKNOWN_FAILURE;
   SV_TRY()
     SV_THROW_IF(version != 1, SV_INCOMPATIBLE_VERSION);
     SV_THROW_IF(hash_algo_encoded_oid_size == 0, SV_AUTHENTICATION_ERROR);
-    SV_THROW(openssl_set_hash_algo_by_encoded_oid(
+    SV_THROW(sv_openssl_set_hash_algo_by_encoded_oid(
         self->crypto_handle, hash_algo_encoded_oid, hash_algo_encoded_oid_size));
     self->validation_flags.hash_algo_known = true;
-    self->verify_data->hash_size = openssl_get_hash_size(self->crypto_handle);
+    self->verify_data->hash_size = sv_openssl_get_hash_size(self->crypto_handle);
     data_ptr += hash_algo_encoded_oid_size;
 
     SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
@@ -1070,12 +1071,12 @@ tlv_encode_or_get_size_generic(signed_video_t *self, const sv_tlv_tuple_t tlv, u
   uint16_t *last_two_bytes = &self->last_two_bytes;
   bool epb = self->sei_epb;
   // Write Tag
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)tlv.tag, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)tlv.tag, epb);
   // Write length
   if (tlv.bytes_for_length == 2) {
-    write_byte(last_two_bytes, &data_ptr, (uint8_t)((v_size >> 8) & 0x000000ff), epb);
+    sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)((v_size >> 8) & 0x000000ff), epb);
   }
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)(v_size & 0x000000ff), epb);
+  sv_write_byte(last_two_bytes, &data_ptr, (uint8_t)(v_size & 0x000000ff), epb);
 
   // Write value, i.e., the actual data of the TLV
   size_t v_size_written = tlv.encoder(self, data_ptr);
@@ -1090,7 +1091,7 @@ tlv_encode_or_get_size_generic(signed_video_t *self, const sv_tlv_tuple_t tlv, u
 }
 
 size_t
-tlv_list_encode_or_get_size(signed_video_t *self,
+sv_tlv_list_encode_or_get_size(signed_video_t *self,
     const sv_tlv_tag_t *tags,
     size_t num_tags,
     uint8_t *data)
@@ -1135,7 +1136,7 @@ decode_tlv_header(const uint8_t *data, size_t *data_bytes_read, sv_tlv_tag_t *ta
   *tag = tag_from_data;
 
   if (tlv.bytes_for_length == 2) {
-    data_ptr += read_16bits(data_ptr, (uint16_t *)length);
+    data_ptr += sv_read_16bits(data_ptr, (uint16_t *)length);
   } else {
     *length = *data_ptr++;
   }
@@ -1146,7 +1147,7 @@ decode_tlv_header(const uint8_t *data, size_t *data_bytes_read, sv_tlv_tag_t *ta
 }
 
 svrc_t
-tlv_decode(signed_video_t *self, const uint8_t *data, size_t data_size)
+sv_tlv_decode(signed_video_t *self, const uint8_t *data, size_t data_size)
 {
   svrc_t status = SV_INVALID_PARAMETER;
   const uint8_t *data_ptr = data;
@@ -1177,7 +1178,7 @@ tlv_decode(signed_video_t *self, const uint8_t *data, size_t data_size)
 }
 
 const uint8_t *
-tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bool with_ep)
+sv_tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bool with_ep)
 {
   const uint8_t *tlv_data_ptr = tlv_data;
   const uint8_t *latest_tag_location = NULL;
@@ -1188,21 +1189,21 @@ tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bo
   while (tlv_data_ptr < tlv_data + tlv_data_size) {
     latest_tag_location = tlv_data_ptr;
     // Read the tag
-    sv_tlv_tag_t this_tag = read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
+    sv_tlv_tag_t this_tag = sv_read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
     if (this_tag == tag) {
       return latest_tag_location;
     }
 
     // Read the length
-    uint16_t length = read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
+    uint16_t length = sv_read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
     sv_tlv_tuple_t tlv = get_tlv_tuple(this_tag);
     if (tlv.bytes_for_length == 2) {
       length <<= 8;
-      length |= read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
+      length |= sv_read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
     }
     // Scan past the data
     for (int i = 0; i < length; i++) {
-      read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
+      sv_read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
     }
   }
 
@@ -1210,7 +1211,7 @@ tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bo
 }
 
 bool
-tlv_find_and_decode_optional_tags(signed_video_t *self,
+sv_tlv_find_and_decode_optional_tags(signed_video_t *self,
     const uint8_t *tlv_data,
     size_t tlv_data_size)
 {
@@ -1246,21 +1247,21 @@ tlv_find_and_decode_optional_tags(signed_video_t *self,
 }
 
 const sv_tlv_tag_t *
-get_optional_tags(size_t *num_of_optional_tags)
+sv_get_optional_tags(size_t *num_of_optional_tags)
 {
   *num_of_optional_tags = ARRAY_SIZE(optional_tags);
   return optional_tags;
 }
 
 const sv_tlv_tag_t *
-get_mandatory_tags(size_t *num_of_mandatory_tags)
+sv_get_mandatory_tags(size_t *num_of_mandatory_tags)
 {
   *num_of_mandatory_tags = ARRAY_SIZE(mandatory_tags);
   return mandatory_tags;
 }
 
 size_t
-read_64bits(const uint8_t *p, uint64_t *val)
+sv_read_64bits(const uint8_t *p, uint64_t *val)
 {
   if (!p || !val) return 0;
   *val = ((uint64_t)p[0]) << 56;
@@ -1276,16 +1277,16 @@ read_64bits(const uint8_t *p, uint64_t *val)
 }
 
 size_t
-read_64bits_signed(const uint8_t *p, int64_t *val)
+sv_read_64bits_signed(const uint8_t *p, int64_t *val)
 {
   uint64_t tmp_val = 0;
-  size_t bytes_read = read_64bits(p, &tmp_val);
+  size_t bytes_read = sv_read_64bits(p, &tmp_val);
   *val = (int64_t)tmp_val;
   return bytes_read;
 }
 
 size_t
-read_32bits(const uint8_t *p, uint32_t *val)
+sv_read_32bits(const uint8_t *p, uint32_t *val)
 {
   if (!p || !val) return 0;
   *val = ((uint32_t)p[0]) << 24;
@@ -1297,7 +1298,7 @@ read_32bits(const uint8_t *p, uint32_t *val)
 }
 
 size_t
-read_16bits(const uint8_t *p, uint16_t *val)
+sv_read_16bits(const uint8_t *p, uint16_t *val)
 {
   if (!p || !val) return 0;
   *val = ((uint16_t)p[0]) << 8;
@@ -1307,7 +1308,7 @@ read_16bits(const uint8_t *p, uint16_t *val)
 }
 
 size_t
-read_8bits(const uint8_t *p, uint8_t *val)
+sv_read_8bits(const uint8_t *p, uint8_t *val)
 {
   if (!p || !val) return 0;
   *val = *p;
@@ -1316,7 +1317,7 @@ read_8bits(const uint8_t *p, uint8_t *val)
 }
 
 uint8_t
-read_byte(uint16_t *last_two_bytes, const uint8_t **data, bool do_emulation_prevention)
+sv_read_byte(uint16_t *last_two_bytes, const uint8_t **data, bool do_emulation_prevention)
 {
   uint8_t curr_byte = **data;
   if (do_emulation_prevention && curr_byte == 0x03 && *last_two_bytes == 0) {
@@ -1335,7 +1336,7 @@ read_byte(uint16_t *last_two_bytes, const uint8_t **data, bool do_emulation_prev
 }
 
 void
-write_byte(uint16_t *last_two_bytes,
+sv_write_byte(uint16_t *last_two_bytes,
     uint8_t **data,
     uint8_t curr_byte,
     bool do_emulation_prevention)
@@ -1355,7 +1356,7 @@ write_byte(uint16_t *last_two_bytes,
 }
 
 void
-write_byte_many(uint8_t **dst,
+sv_write_byte_many(uint8_t **dst,
     char *src,
     size_t size,
     uint16_t *last_two_bytes,
@@ -1365,6 +1366,6 @@ write_byte_many(uint8_t **dst,
 
   for (size_t ii = 0; ii < size; ++ii) {
     uint8_t ch = src[ii];
-    write_byte(last_two_bytes, dst, ch, do_emulation_prevention);
+    sv_write_byte(last_two_bytes, dst, ch, do_emulation_prevention);
   }
 }

--- a/lib/src/sv_tlv.h
+++ b/lib/src/sv_tlv.h
@@ -42,7 +42,7 @@
  * @return The size of the data encoded.
  */
 size_t
-tlv_list_encode_or_get_size(signed_video_t *signed_video,
+sv_tlv_list_encode_or_get_size(signed_video_t *signed_video,
     const sv_tlv_tag_t *tags,
     size_t num_tags,
     uint8_t *data);
@@ -60,7 +60,7 @@ tlv_list_encode_or_get_size(signed_video_t *signed_video,
  * @return SV_OK if decoding was successful, otherwise an error code.
  */
 svrc_t
-tlv_decode(signed_video_t *signed_video, const uint8_t *data, size_t data_size);
+sv_tlv_decode(signed_video_t *signed_video, const uint8_t *data, size_t data_size);
 
 /**
  * @brief Scans the TLV part of a SEI payload and stops when a given tag is detected.
@@ -77,7 +77,7 @@ tlv_decode(signed_video_t *signed_video, const uint8_t *data, size_t data_size);
  * @return A pointer to the location of the tag to scan for. Returns NULL if the tag was not found.
  */
 const uint8_t *
-tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bool with_ep);
+sv_tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bool with_ep);
 
 /**
  * @brief Reads bits from p into val.
@@ -85,15 +85,15 @@ tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag, bo
  * @return Number of bytes read.
  */
 size_t
-read_64bits_signed(const uint8_t *p, int64_t *val);
+sv_read_64bits_signed(const uint8_t *p, int64_t *val);
 size_t
-read_64bits(const uint8_t *p, uint64_t *val);
+sv_read_64bits(const uint8_t *p, uint64_t *val);
 size_t
-read_32bits(const uint8_t *p, uint32_t *val);
+sv_read_32bits(const uint8_t *p, uint32_t *val);
 size_t
-read_16bits(const uint8_t *p, uint16_t *val);
+sv_read_16bits(const uint8_t *p, uint16_t *val);
 size_t
-read_8bits(const uint8_t *p, uint8_t *val);
+sv_read_8bits(const uint8_t *p, uint8_t *val);
 
 /**
  * @brief Writes many bytes to payload w/wo emulation prevention
@@ -104,7 +104,7 @@ read_8bits(const uint8_t *p, uint8_t *val);
  * @param last_two_bytes For emulation prevention
  */
 void
-write_byte_many(uint8_t **dst,
+sv_write_byte_many(uint8_t **dst,
     char *src,
     size_t size,
     uint16_t *last_two_bytes,
@@ -119,7 +119,10 @@ write_byte_many(uint8_t **dst,
  * @param do_emulation_prevention If emulation prevention
  */
 void
-write_byte(uint16_t *last_two_bytes, uint8_t **payload, uint8_t byte, bool do_emulation_prevention);
+sv_write_byte(uint16_t *last_two_bytes,
+    uint8_t **payload,
+    uint8_t byte,
+    bool do_emulation_prevention);
 
 /**
  * @brief Reads a byte from payload w/wo emulation prevention
@@ -127,7 +130,7 @@ write_byte(uint16_t *last_two_bytes, uint8_t **payload, uint8_t byte, bool do_em
  * @return The byte read.
  */
 uint8_t
-read_byte(uint16_t *last_two_bytes, const uint8_t **payload, bool do_emulation_prevention);
+sv_read_byte(uint16_t *last_two_bytes, const uint8_t **payload, bool do_emulation_prevention);
 
 /**
  * @brief Scans the TLV part of a SEI payload and decodes all recurrent tags
@@ -142,7 +145,7 @@ read_byte(uint16_t *last_two_bytes, const uint8_t **payload, bool do_emulation_p
  * @return True if find and decoding tag was successful.
  */
 bool
-tlv_find_and_decode_optional_tags(signed_video_t *self,
+sv_tlv_find_and_decode_optional_tags(signed_video_t *self,
     const uint8_t *tlv_data,
     size_t tlv_data_size);
 
@@ -155,7 +158,7 @@ tlv_find_and_decode_optional_tags(signed_video_t *self,
  * @return Array that contains all optional tags.
  */
 const sv_tlv_tag_t *
-get_optional_tags(size_t *num_of_optional_tags);
+sv_get_optional_tags(size_t *num_of_optional_tags);
 
 /**
  * @brief Helper to get only the mandatory tags as an array
@@ -166,6 +169,6 @@ get_optional_tags(size_t *num_of_optional_tags);
  * @return Array that contains all mandatory tags.
  */
 const sv_tlv_tag_t *
-get_mandatory_tags(size_t *num_of_mandatory_tags);
+sv_get_mandatory_tags(size_t *num_of_mandatory_tags);
 
 #endif  // __SV_TLV_H__

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -586,15 +586,15 @@ encode_axis_communications_handle(void *handle, uint16_t *last_two_bytes, bool e
   uint8_t *attestation = self->attestation;
 
   // Write version.
-  write_byte(last_two_bytes, &data_ptr, version, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, version, epb);
   // Write |attestation_size|.
-  write_byte(last_two_bytes, &data_ptr, self->attestation_size, epb);
+  sv_write_byte(last_two_bytes, &data_ptr, self->attestation_size, epb);
   // Write |attestation|.
   for (size_t jj = 0; jj < self->attestation_size; ++jj) {
-    write_byte(last_two_bytes, &data_ptr, attestation[jj], epb);
+    sv_write_byte(last_two_bytes, &data_ptr, attestation[jj], epb);
   }
   // Write |certificate_chain|.
-  write_byte_many(
+  sv_write_byte_many(
       &data_ptr, self->certificate_chain, certificate_chain_encode_size, last_two_bytes, epb);
 
   return (data_ptr - data);

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -32,7 +32,7 @@
 #endif
 #include "sv_internal.h"  // set_hash_list_size()
 #include "sv_openssl_internal.h"  // openssl_read_pubkey_from_private_key()
-#include "sv_tlv.h"  // write_byte_many()
+#include "sv_tlv.h"  // sv_write_byte_many()
 #include "test_helpers.h"  // sv_setting, create_signed_stream()
 #include "test_stream.h"  // test_stream_create()
 
@@ -1891,7 +1891,7 @@ START_TEST(test_public_key_scenarios)
     signed_video_free(sv_camera);
     signed_video_free(sv_vms);
     free(tmp_private_key);
-    openssl_free_key(sign_data_wrong_key.key);
+    sv_openssl_free_key(sign_data_wrong_key.key);
     free(sign_data_wrong_key.signature);
     free(wrong_public_key.key);
     test_stream_item_free(sei);
@@ -1958,7 +1958,7 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
   signed_video_free(sv_vms);
   signed_video_free(sv_camera);
   free(tmp_private_key);
-  openssl_free_key(sign_data.key);
+  sv_openssl_free_key(sign_data.key);
   free(sign_data.signature);
   free(wrong_public_key.key);
 }
@@ -2021,7 +2021,7 @@ START_TEST(no_emulation_prevention_bytes)
   sei_p += 4;  // Move past the start code to avoid an incorrect emulation prevention byte.
   char *src = (char *)(sei + 4);
   size_t src_size = sei_size - 4;
-  write_byte_many(&sei_p, src, src_size, &last_two_bytes, true);
+  sv_write_byte_many(&sei_p, src, src_size, &last_two_bytes, true);
   size_t sei_with_epb_size = sei_p - sei_with_epb;
   free(sei);
 

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -822,7 +822,7 @@ START_TEST(w_wo_emulation_prevention_bytes)
     ck_assert(seis[ii]);
     sei_sizes[ii] = sei_size;
     bu[ii] = parse_bu_info(seis[ii], sei_sizes[ii], codec, false, true);
-    update_hashable_data(&bu[ii]);
+    sv_update_hashable_data(&bu[ii]);
     signed_video_free(sv);
     sv = NULL;
   }

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -33,7 +33,7 @@
 
 #include "includes/signed_video_openssl.h"
 #include "sv_internal.h"  // parse_bu_info(), kUuidSignedVideo
-#include "sv_tlv.h"  // tlv_find_tag()
+#include "sv_tlv.h"  // sv_tlv_find_tag()
 
 #define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
 #define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000
@@ -545,7 +545,7 @@ tag_is_present(const test_stream_item_t *item, SignedVideoCodec codec, sv_tlv_ta
   bu_info_t bu = parse_bu_info(item->data, item->data_size, codec, false, true);
   if (!bu.is_sv_sei) return false;
 
-  void *tag_ptr = (void *)tlv_find_tag(bu.tlv_data, bu.tlv_size, tag, false);
+  void *tag_ptr = (void *)sv_tlv_find_tag(bu.tlv_data, bu.tlv_size, tag, false);
   found_tag = (tag_ptr != NULL);
   // Free temporary data slot used if emulation prevention bytes are present.
   free(bu.nalu_data_wo_epb);
@@ -558,9 +558,9 @@ tlv_has_optional_tags(const uint8_t *tlv_data, size_t tlv_data_size)
 {
   bool has_optional_tags = false;
   size_t num_tags = 0;
-  const sv_tlv_tag_t *tags = get_optional_tags(&num_tags);
+  const sv_tlv_tag_t *tags = sv_get_optional_tags(&num_tags);
   for (size_t ii = 0; ii < num_tags; ii++) {
-    const uint8_t *this_tag = tlv_find_tag(tlv_data, tlv_data_size, tags[ii], false);
+    const uint8_t *this_tag = sv_tlv_find_tag(tlv_data, tlv_data_size, tags[ii], false);
     has_optional_tags |= (this_tag != NULL);
   }
   return has_optional_tags;
@@ -571,9 +571,9 @@ tlv_has_mandatory_tags(const uint8_t *tlv_data, size_t tlv_data_size)
 {
   bool has_mandatory_tags = false;
   size_t num_tags = 0;
-  const sv_tlv_tag_t *tags = get_mandatory_tags(&num_tags);
+  const sv_tlv_tag_t *tags = sv_get_mandatory_tags(&num_tags);
   for (size_t ii = 0; ii < num_tags; ii++) {
-    const uint8_t *this_tag = tlv_find_tag(tlv_data, tlv_data_size, tags[ii], false);
+    const uint8_t *this_tag = sv_tlv_find_tag(tlv_data, tlv_data_size, tags[ii], false);
     has_mandatory_tags |= (this_tag != NULL);
   }
   return has_mandatory_tags;


### PR DESCRIPTION
When bringing in ONVIF Media Signing as a submodule
some functions share the same name. This will cause
multiple definitions if building the library with a
populated submodule, like FilePlayer will.

This commit prepends internal functions with "sv_"
to make names unique. This only applies to function
names common to ONVIF Media Signing.
