### PR TITLE
Fix compile error if warning treated as error

### DIFF
--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -465,9 +465,9 @@ static onvif_media_signing_vendor_info_t
 convert_product_info(const signed_video_product_info_t *product_info)
 {
   onvif_media_signing_vendor_info_t vendor_info = {0};
-  strncpy(vendor_info.firmware_version, product_info->firmware_version, 255);
-  strncpy(vendor_info.serial_number, product_info->serial_number, 255);
-  strncpy(vendor_info.manufacturer, product_info->manufacturer, 255);
+  memcpy(vendor_info.firmware_version, product_info->firmware_version, 255);
+  memcpy(vendor_info.serial_number, product_info->serial_number, 255);
+  memcpy(vendor_info.manufacturer, product_info->manufacturer, 255);
 
   return vendor_info;
 }


### PR DESCRIPTION
This solves the warning -Werror=stringop-truncation.
The structures are identical in length, so it is fine to simply
copy all the content even though there are null-terminated
characters.
