### PR TITLE
Includes ONVIF Media Signing if present

### DIFF
--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -39,7 +39,7 @@ legacy_sources = files(
   'legacy/legacy_tlv.h',
 )
 
-# Until plugin management is in place the plugin file(s) are added to the sources.
+# Add source files from plugins, vendors, legacy code
 signedvideoframework_sources += plugin_sources
 signedvideoframework_sources += vendor_sources
 signedvideoframework_sources += legacy_sources
@@ -47,6 +47,11 @@ signedvideoframework_sources += legacy_sources
 # Add vendor specific public headers
 if build_with_axis
   signedvideoframework_public_headers += files('includes/sv_vendor_axis_communications.h')
+endif
+# Add ONVIF Media Signing source files and public headers
+if populated_media_signing_submodule
+  signedvideoframework_sources += mediasigningframework_sources
+  signedvideoframework_public_headers += mediasigningframework_public_headers
 endif
 
 svsrcinc = include_directories('.')

--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -31,11 +31,19 @@
 #include "sv_bu_list.h"  // bu_list_append()
 #include "sv_defines.h"  // svrc_t
 #include "sv_internal.h"  // gop_info_t, validation_flags_t
-#ifndef HAS_ONVIF
-#include "sv_onvif.h"  // Stubs for ONVIF APIs and structs
-#endif
 #include "sv_openssl_internal.h"  // openssl_{verify_hash, public_key_malloc}()
 #include "sv_tlv.h"  // sv_tlv_find_tag()
+
+// Include ONVIF Media Signing
+#if defined(NO_ONVIF_MEDIA_SIGNING)
+#include "sv_onvif.h"  // Stubs for ONVIF APIs and structs
+#elif defined(ONVIF_MEDIA_SIGNING_INSTALLED)
+// ONVIF Media Signing is installed separately; Camera
+#include <media-signing-framework/onvif_media_signing_validator.h>
+#else
+// ONVIF Media Signing is dragged in as a submodule; FilePlayer
+#include "includes/onvif_media_signing_validator.h"
+#endif
 
 static svrc_t
 decode_sei_data(signed_video_t *signed_video, const uint8_t *payload, size_t payload_size);

--- a/lib/src/sv_authenticity.h
+++ b/lib/src/sv_authenticity.h
@@ -24,8 +24,16 @@
 #include "includes/signed_video_auth.h"  // signed_video_product_info_t
 #include "sv_defines.h"  // svrc_t
 #include "sv_internal.h"
-#ifndef HAS_ONVIF
+
+// Include ONVIF Media Signing
+#if defined(NO_ONVIF_MEDIA_SIGNING)
 #include "sv_onvif.h"  // Stubs for ONVIF APIs and structs
+#elif defined(ONVIF_MEDIA_SIGNING_INSTALLED)
+// ONVIF Media Signing is installed separately; Camera
+#include <media-signing-framework/onvif_media_signing_validator.h>
+#else
+// ONVIF Media Signing is dragged in as a submodule; FilePlayer
+#include "includes/onvif_media_signing_validator.h"
 #endif
 
 /**

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -32,8 +32,16 @@
 #include "legacy_validation.h"  // legacy_sv_t
 #include "sv_defines.h"  // svrc_t, sv_tlv_tag_t
 #include "sv_defines_general.h"  // ATTR_UNUSED
-#ifndef HAS_ONVIF
+
+// Include ONVIF Media Signing
+#if defined(NO_ONVIF_MEDIA_SIGNING)
 #include "sv_onvif.h"  // Stubs for ONVIF APIs and structs
+#elif defined(ONVIF_MEDIA_SIGNING_INSTALLED)
+// ONVIF Media Signing is installed separately; Camera
+#include <media-signing-framework/onvif_media_signing_common.h>
+#else
+// ONVIF Media Signing is dragged in as a submodule; FilePlayer
+#include "includes/onvif_media_signing_common.h"
 #endif
 
 // Currently the largest supported hash is SHA-512.

--- a/lib/src/sv_onvif.c
+++ b/lib/src/sv_onvif.c
@@ -20,6 +20,9 @@
  */
 #include "sv_onvif.h"
 
+// Add empty definitions if ONVIF Media Signing code is not present.
+#ifdef NO_ONVIF_MEDIA_SIGNING
+
 #include "sv_defines_general.h"  // ATTR_UNUSED
 
 // Stubs for ONVIF APIs
@@ -157,3 +160,5 @@ onvif_media_signing_set_trusted_certificate(onvif_media_signing_t ATTR_UNUSED *s
 {
   return OMS_NOT_SUPPORTED;
 }
+
+#endif  // NO_ONVIF_MEDIA_SIGNING

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -21,6 +21,8 @@
 #ifndef __SV_ONVIF_H__
 #define __SV_ONVIF_H__
 
+#ifdef NO_ONVIF_MEDIA_SIGNING
+
 #include <stdbool.h>  // bool
 #include <stddef.h>  // size_t
 #include <stdint.h>  // uint8_t, int64_t
@@ -180,5 +182,6 @@ onvif_media_signing_set_trusted_certificate(onvif_media_signing_t *self,
     const char *trusted_certificate,
     size_t trusted_certificate_size,
     bool user_provisioned);
+#endif  // NO_ONVIF_MEDIA_SIGNING
 
 #endif  // __SV_ONVIF_H__

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -30,11 +30,21 @@
 #include "sv_codec_internal.h"  // METADATA_TYPE_USER_PRIVATE
 #include "sv_defines.h"  // svrc_t, sv_tlv_tag_t
 #include "sv_internal.h"  // gop_info_t
-#ifndef HAS_ONVIF
-#include "sv_onvif.h"  // Stubs for ONVIF APIs and structs
-#endif
 #include "sv_openssl_internal.h"
 #include "sv_tlv.h"  // sv_tlv_list_encode_or_get_size()
+
+// Include ONVIF Media Signing
+#if defined(NO_ONVIF_MEDIA_SIGNING)
+#include "sv_onvif.h"  // Stubs for ONVIF APIs and structs
+#elif defined(ONVIF_MEDIA_SIGNING_INSTALLED)
+// ONVIF Media Signing is installed separately; Camera
+#include <media-signing-framework/onvif_media_signing_common.h>
+#include <media-signing-framework/onvif_media_signing_signer.h>
+#else
+// ONVIF Media Signing is dragged in as a submodule; FilePlayer
+#include "includes/onvif_media_signing_common.h"
+#include "includes/onvif_media_signing_signer.h"
+#endif
 
 static void
 bu_set_uuid_type(signed_video_t *self, uint8_t **payload, SignedVideoUUIDType uuid_type);

--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,9 @@ configinc = include_directories('.')
 # Fetch ONVIF Media Signing files if submodule is populated
 if populated_media_signing_submodule
   subdir('media-signing-framework/lib')
+else
+  # No ONVIF include files, add current directory
+  omssrcinc = include_directories('.')
 endif
 
 # Propagate through the file structure

--- a/meson.build
+++ b/meson.build
@@ -1,15 +1,29 @@
 project('signed-video-framework', 'c',
   version : '2.0.4',
-  meson_version : '>= 0.47.0',
+  meson_version : '>= 0.53.0',
   default_options : [ 'warning_level=2',
                       'werror=true',
                       'buildtype=debugoptimized' ])
 
+fs = import('fs')
 cc = meson.get_compiler('c')
 
 # General dependencies
 openssl_dep = dependency('openssl', required : true, version : '>=3.0.0')
 check_dep = dependency('check', required : false)
+mediasigningframework_dep = dependency('media-signing-framework', required : false)
+
+populated_media_signing_submodule = false
+
+if mediasigningframework_dep.found()
+  add_global_arguments('-DONVIF_MEDIA_SIGNING_INSTALLED', language : 'c')
+else
+  if fs.is_dir('media-signing-framework') and fs.is_file('media-signing-framework/meson.build')
+    populated_media_signing_submodule = true
+  else
+    add_global_arguments('-DNO_ONVIF_MEDIA_SIGNING', language : 'c')
+  endif
+endif
 
 if check_dep.found()
   # Option for code related to unit tests
@@ -47,6 +61,11 @@ configure_file(output : 'signed-video-framework.pc', configuration : cdata)
 
 configinc = include_directories('.')
 
+# Fetch ONVIF Media Signing files if submodule is populated
+if populated_media_signing_submodule
+  subdir('media-signing-framework/lib')
+endif
+
 # Propagate through the file structure
 subdir('lib')
 
@@ -55,12 +74,12 @@ install_headers(
     signedvideoframework_public_headers,
     install_dir : '@0@/signed-video-framework'.format(get_option('includedir')))
 
-signedvideoframework_deps = [ openssl_dep, plugin_deps ]
+signedvideoframework_deps = [ openssl_dep, plugin_deps, mediasigningframework_dep ]
 
 signedvideoframework = shared_library(
     'signed-video-framework',
     signedvideoframework_sources,
-    include_directories : [ svsrcinc, vendorinc ],
+    include_directories : [ svsrcinc, vendorinc, omssrcinc ],
     version : meson.project_version(),
     dependencies : signedvideoframework_deps,
     install : true,

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1656,6 +1656,11 @@ START_TEST(factory_provisioned_key)
 
   SignedVideoReturnCode sv_rc;
   SignedVideoCodec codec = setting.codec;
+  // If the test has been built with ONVIF Media Signing, factory provisioned keys will
+  // use Media Signing for H.264 and H.265.
+#ifndef NO_ONVIF_MEDIA_SIGNING
+  if (codec != SV_CODEC_AV1) return;
+#endif
   test_stream_item_t *i_item = test_stream_item_create_from_type('I', 0, codec);
   test_stream_item_t *p_item = test_stream_item_create_from_type('P', 1, codec);
   test_stream_item_t *i_item_2 = test_stream_item_create_from_type('I', 2, codec);

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -459,6 +459,11 @@ START_TEST(factory_provisioned_key)
   struct sv_setting setting = settings[_i];
   // Only EC keys are tested.
   if (!setting.ec_key) return;
+    // If the test has been built with ONVIF Media Signing, factory provisioned keys will
+    // use Media Signing for H.264 and H.265.
+#ifndef NO_ONVIF_MEDIA_SIGNING
+  if (setting.codec != SV_CODEC_AV1) return;
+#endif
 
   signed_video_t *sv = get_initialized_signed_video(setting, false);
   ck_assert(sv);

--- a/tests/check/meson.build
+++ b/tests/check/meson.build
@@ -49,7 +49,7 @@ test_env.append('G_DEBUG', 'gc-friendly')
 foreach t : tests
   testexe = executable(t[0],
                        t[1],
-                       include_directories : [ configinc, svsrcinc, testinc ],
+                       include_directories : [ configinc, svsrcinc, testinc, omssrcinc ],
                        dependencies : [ check_dep ],
                        link_with : signedvideoframework)
   # run tests in own directories


### PR DESCRIPTION
The meson build structure has been updated to support ONVIF
Media Signing, either through a submodule or if installed
separately.
Includes have been updated and tests can now run if ONVIF
Media Signing code is present.
