### PR TITLE
Changes behavior when comparing versions

### DIFF
--- a/lib/src/includes/signed_video_common.h
+++ b/lib/src/includes/signed_video_common.h
@@ -121,6 +121,9 @@ signed_video_get_version();
 /**
  * @brief Compares two Signed Video versions
  *
+ * The comparison is only done on major and minor, hence leaves out patch number. A patch
+ * update should not affect the validation. If so, the change should be made to minor.
+ *
  * @param version1 Version string to compare against |version2|
  * @param version2 Version string to compare against |version1|
  *

--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -1097,7 +1097,7 @@ signed_video_compare_versions(const char *version1, const char *version2)
 
   int result = 0;
   int j = 0;
-  while (result == 0 && j < SV_VERSION_BYTES) {
+  while (result == 0 && j < SV_VERSION_BYTES - 1) {  // Skip patch number
     result = arr1[j] - arr2[j];
     j++;
   }

--- a/tests/check/check_signed_video_common.c
+++ b/tests/check/check_signed_video_common.c
@@ -100,8 +100,11 @@ START_TEST(correct_version)
   const char *kVer1 = "v0.1.0";
   const char *kVer2 = "v0.10.0";
   const char *kVer3 = "R0.1.0";
+  const char *kVer4 = "v0.1.1";
   int check = 0;
   check = signed_video_compare_versions(kVer1, kVer1);
+  ck_assert_int_eq(check, 0);
+  check = signed_video_compare_versions(kVer1, kVer4);
   ck_assert_int_eq(check, 0);
   check = signed_video_compare_versions(kVer2, kVer1);
   ck_assert_int_eq(check, 1);


### PR DESCRIPTION
There is a check for version mismatch between signing and
validation. If the stream has been signed with a newer version
than what is used when validating the validation result cannot
be guaranteed. The reason is that it is not possible to be
forward compatible.
However, if the change is minor, like when the patch number
only has changed, it should still be possible to trust the
result.

This commit checks only major and minor for version mismatch.
