### PR TITLE
Fixes tests to pass if Media Signing code is present

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -1273,7 +1273,6 @@ static svrc_t
 reregister_bu(signed_video_t *self)
 {
   assert(self);
-  assert(self->validation_flags.hash_algo_known);
 
   bu_list_t *bu_list = self->bu_list;
   bu_list_item_t *item = bu_list->first_item;

--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -1051,8 +1051,6 @@ signed_video_free(signed_video_t *self)
   onvif_media_signing_free(self->onvif);
   // Free the legacy validation if present.
   legacy_sv_free(self->legacy_sv);
-  // Free the onvif object if present.
-  onvif_media_signing_free(self->onvif);
 
   // Teardown the plugin before closing.
   sv_signing_plugin_session_teardown(self->plugin_handle);

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1451,9 +1451,13 @@ START_TEST(onvif_seis)
   while (item) {
     SignedVideoReturnCode sv_rc =
         signed_video_add_nalu_and_authenticate(sv, item->data, item->data_size, NULL);
-    // If the current item's type corresponds to 'O', expect SV_EXTERNAL_ERROR
+#ifdef NO_ONVIF_MEDIA_SIGNING
+    // If the current item's type corresponds to 'O', expect SV_EXTERNAL_ERROR.
     ck_assert_int_eq(sv_rc, item->type == 'O' ? SV_EXTERNAL_ERROR : SV_OK);
-
+#else
+    // If ONVIF Media Signing code is present there should not be any errors.
+    ck_assert_int_eq(sv_rc, SV_OK);
+#endif
     // Move to the next item in the list
     item = item->next;
   }


### PR DESCRIPTION
Removes an assert, since hash algo will never be known if the
stream was signed with ONVIF Media Signing.

Removes a double free of the ONVIF Media Signing session.

Updates a validation test w.r.t. presence of ONVIF Media Signing
code.
