### PR TITLE
Passes on threaded signing plugin if Media Signing is known

### DIFF
--- a/lib/plugins/threaded-signing/plugin.c
+++ b/lib/plugins/threaded-signing/plugin.c
@@ -47,7 +47,7 @@
 // ONVIF Media Signing is installed separately; Camera
 #include <media-signing-framework/onvif_media_signing_common.h>
 #include <media-signing-framework/onvif_media_signing_plugin.h>
-#else
+#elif !defined(NO_ONVIF_MEDIA_SIGNING)
 // ONVIF Media Signing is dragged in as a submodule; FilePlayer
 #include "includes/onvif_media_signing_common.h"
 #include "includes/onvif_media_signing_plugin.h"


### PR DESCRIPTION
If ONVIF Media Signing is known (installed or present in the submodule)
the threaded signing plugin should pass on all operations to the
threaded plugin in media-signing-framework. This ensures that only one
thread for signing is setup, and that thread is "controlled" from
media-signing-framework.
NOTE: that using the plugin in media-signing-framework has nothing to
do whether the stream has been signed with ONVIF Media Signing format
or not.
