### PR TITLE
Add getter for certificate chain for ONVIF initialization

### DIFF
--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -827,7 +827,7 @@ get_axis_communications_certificate_chain(void *handle)
 
   sv_vendor_axis_communications_t *self = (sv_vendor_axis_communications_t *)handle;
 
-  return self->certificate_chain;
+  return (const char *)self->certificate_chain;
 }
 
 // Definitions of public APIs declared in sv_vendor_axis_communications.h.

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -818,6 +818,19 @@ get_axis_communications_supplemental_authenticity(void *handle,
   return status;
 }
 
+/**
+ * Retrieves the certificate chain from the vendor handle. */
+const char *
+get_axis_communications_certificate_chain(void *handle)
+{
+  if (!handle) return NULL;
+
+  sv_vendor_axis_communications_t *self = (sv_vendor_axis_communications_t *)handle;
+
+  // Return the certificate chain
+  return self->certificate_chain;
+}
+
 // Definitions of public APIs declared in sv_vendor_axis_communications.h.
 
 SignedVideoReturnCode

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications.c
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications.c
@@ -827,7 +827,6 @@ get_axis_communications_certificate_chain(void *handle)
 
   sv_vendor_axis_communications_t *self = (sv_vendor_axis_communications_t *)handle;
 
-  // Return the certificate chain
   return self->certificate_chain;
 }
 

--- a/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
+++ b/lib/vendors/axis-communications/sv_vendor_axis_communications_internal.h
@@ -150,4 +150,15 @@ get_axis_communications_supplemental_authenticity(void *handle,
 const char *
 get_axis_communications_trusted_certificate(void);
 
+/**
+ * @brief Retrieves the certificate chain from the vendor handle.
+ *
+ * This function returns a pointer to an internally managed certificate chain.
+ *
+ * @param handle The handle to Axis Communications specific information.
+ * @return The certificate chain as a null-terminated string, or NULL on failure.
+ */
+const char *
+get_axis_communications_certificate_chain(void *handle);
+
 #endif  // __SV_VENDOR_AXIS_COMMUNICATIONS_INTERNAL_H__


### PR DESCRIPTION
Adds a function to retrieve the certificate chain during ONVIF setup.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
