### PR TITLE
Adds private key members signed_video_t struct

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -304,6 +304,8 @@ struct _signed_video_t {
   // For signing plugin
   void *plugin_handle;
   sign_or_verify_data_t *sign_data;  // Pointer to all necessary information to sign in a plugin.
+  // Placeholder for the private key used during ONVIF initialization.  
+  // This will not exist after the session ends.
   const char *private_key;
   size_t private_key_size;
 

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -304,6 +304,8 @@ struct _signed_video_t {
   // For signing plugin
   void *plugin_handle;
   sign_or_verify_data_t *sign_data;  // Pointer to all necessary information to sign in a plugin.
+  const char *private_key;
+  size_t private_key_size;
 
   // Frame counter and flag to handle recurrence
   bool has_recurrent_data;

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -305,7 +305,7 @@ struct _signed_video_t {
   void *plugin_handle;
   sign_or_verify_data_t *sign_data;  // Pointer to all necessary information to sign in a plugin.
   // Placeholder for the private key used during ONVIF initialization.  
-  // This will not exist after the session ends.
+  // This will cease to exist when the session starts.
   const char *private_key;
   size_t private_key_size;
 

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -878,6 +878,8 @@ signed_video_set_private_key(signed_video_t *self, const char *private_key, size
     // Temporally turn the PEM |private_key| into an EVP_PKEY and allocate memory for signatures.
     SV_THROW(openssl_private_key_malloc(self->sign_data, private_key, private_key_size));
     SV_THROW(openssl_read_pubkey_from_private_key(self->sign_data, &self->pem_public_key));
+    self->private_key = private_key;
+    self->private_key_size = private_key_size;
 
     self->plugin_handle = sv_signing_plugin_session_setup(private_key, private_key_size);
     SV_THROW_IF(!self->plugin_handle, SV_EXTERNAL_ERROR);

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -555,6 +555,8 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
     DEBUG_LOG("Invalid input parameters: (%p, %p, %zu)", self, bu_data, bu_data_size);
     return SV_INVALID_PARAMETER;
   }
+  // The placeholder for the |private_key| is no longer valid.
+  self->private_key = NULL;
 
   if (self->onvif && timestamp) {
     int64_t onvif_timestamp = convert_unix_us_to_1601(*timestamp);


### PR DESCRIPTION
Adds private key members signed_video_t struct to use  in ONVIF
initialization.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
