### PR TITLE
Bumps version to v2.1.0

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -50,7 +50,7 @@
 #define DEFAULT_HASH_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v2.0.4"
+#define SIGNED_VIDEO_VERSION "v2.1.0"
 #define SV_VERSION_MAX_STRLEN 19  // Longest possible string including 'ONVIF' prefix
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '2.0.4',
+  version : '2.1.0',
   meson_version : '>= 0.53.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
Includes ONVIF Media Signing support (v1.0.0).
