### PR TITLE
Fixes bug if lib is not built with a vendor

### DIFF
--- a/lib/plugins/README.md
+++ b/lib/plugins/README.md
@@ -25,7 +25,7 @@ initialized using `sv_signing_plugin_init_new(user_data)` a central thread is sp
 [signed_video_openssl.h](../src/includes/signed_video_openssl.h)) and should include the signing key
 to use. If the user runs multiple sessions they share the same input and output buffers.
 If the plugin is not initialized signing is done from a local thread in each session. This can cause
-quite some threads if multiple streams are signed. The implementation requires glib-2.0.
+quite some threads if multiple streams are signed. The implementation requires GLib 2.0.
 
 ## Selecting a plugin
 Through the meson option `signingplugin`, one of them can be selected and the source file is added

--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -1329,7 +1329,7 @@ detect_onvif_media_signing(signed_video_t *self, const bu_info_t *bu)
   // Create an ONVIF Media Signing session for validation if and only if a SEI of type
   // ONVIF Media Signing has been detected AND the library has been build for Axis
   // Communications (|vendor_handle| exists).
-  if (bu->uuid_type != UUID_TYPE_ONVIF_MEDIA_SIGNING && self->vendor_handle) {
+  if (bu->uuid_type != UUID_TYPE_ONVIF_MEDIA_SIGNING || !self->vendor_handle) {
     return SV_OK;
   }
 

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -50,7 +50,7 @@
 #define DEFAULT_HASH_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v2.1.0"
+#define SIGNED_VIDEO_VERSION "v2.1.1"
 #define SV_VERSION_MAX_STRLEN 19  // Longest possible string including 'ONVIF' prefix
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '2.1.0',
+  version : '2.1.1',
   meson_version : '>= 0.53.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
If the library was built without any vendor (Axis) the
authentication side tried to create an ONVIF Media Signing
session when it should not. This commit fixes that.

In addition a minor spell change of GLib has been made.

The version has been changed to v2.1.1.
