### PR TITLE
Adds a timestamp to the SEI TLV

### DIFF
--- a/lib/src/includes/signed_video_auth.h
+++ b/lib/src/includes/signed_video_auth.h
@@ -154,8 +154,13 @@ typedef struct {
   SignedVideoPublicKeyValidation public_key_validation;
   // True if the timestamp member is valid to look at, false otherwise.
   bool has_timestamp;
-  // Unix epoch UTC timestamp in microseconds of the latest signed Bitstream Unit.
-  int64_t timestamp;
+  // Unix epoch UTC timestamp in microseconds of the first signed Bitstream Unit.
+  int64_t start_timestamp;
+  // Unix epoch UTC timestamp in microseconds of the last signed Bitstream Unit (exclusive).
+  // The total duration this validation span is |end_timestamp| - |start_timestamp|.
+  // For older recordings, only one timestamp is present which represents the entire GOP. In that
+  // case |end_timestamp| = |start_timestamp|.
+  int64_t end_timestamp;
 } signed_video_latest_validation_t;
 
 /**

--- a/lib/src/legacy/legacy_tlv.c
+++ b/lib/src/legacy/legacy_tlv.c
@@ -209,7 +209,8 @@ legacy_decode_general(legacy_sv_t *self, const uint8_t *data, size_t data_size)
       if (self->latest_validation) {
         self->latest_validation->has_timestamp = gop_info->has_timestamp;
         if (gop_info->has_timestamp) {
-          self->latest_validation->timestamp = gop_info->timestamp;
+          self->latest_validation->start_timestamp = gop_info->timestamp;
+          self->latest_validation->end_timestamp = gop_info->timestamp;
         }
       }
     }

--- a/lib/src/sv_authenticity.c
+++ b/lib/src/sv_authenticity.c
@@ -117,7 +117,8 @@ transfer_latest_validation(signed_video_latest_validation_t *dst,
     dst->number_of_pending_picture_nalus = src->number_of_pending_picture_nalus;
     dst->public_key_validation = src->public_key_validation;
     dst->has_timestamp = src->has_timestamp;
-    dst->timestamp = src->timestamp;
+    dst->start_timestamp = src->start_timestamp;
+    dst->end_timestamp = src->end_timestamp;
   SV_CATCH()
   SV_DONE(status)
 
@@ -177,7 +178,8 @@ sv_latest_validation_init(signed_video_latest_validation_t *self)
   self->number_of_pending_picture_nalus = 0;
   self->public_key_validation = SV_PUBKEY_VALIDATION_NOT_FEASIBLE;
   self->has_timestamp = false;
-  self->timestamp = 0;
+  self->start_timestamp = -1;
+  self->end_timestamp = -1;
 
   free(self->nalu_str);
   self->nalu_str = NULL;
@@ -241,9 +243,9 @@ update_accumulated_validation(const signed_video_latest_validation_t *latest,
   if (latest->has_timestamp) {
     if (!accumulated->has_timestamp) {
       // No previous timestamp has been set.
-      accumulated->first_timestamp = latest->timestamp;
+      accumulated->first_timestamp = latest->start_timestamp;
     }
-    accumulated->last_timestamp = latest->timestamp;
+    accumulated->last_timestamp = latest->end_timestamp;
     accumulated->has_timestamp = true;
   }
 }
@@ -460,7 +462,9 @@ transfer_onvif_latest(signed_video_latest_validation_t *latest,
       break;
   }
   latest->has_timestamp = true;
-  latest->timestamp = convert_1601_to_unix_us(onvif_latest->timestamp);
+  latest->start_timestamp = convert_1601_to_unix_us(onvif_latest->timestamp);
+  // ONVIF Media Signing currently only has one timestamp.
+  latest->end_timestamp = latest->start_timestamp;
 }
 
 static void

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -256,7 +256,8 @@ typedef struct {
   int verified_signature_hash;  // Status of last hash-signature-pair verification. Has 1 for
   // success, 0 for fail, and -1 for error.
   bool has_timestamp;  // True if timestamp exists and has not yet been written to SEI.
-  int64_t timestamp;  // Unix epoch UTC timestamp of the first Bitstream Unit in GOP
+  int64_t start_timestamp;  // Unix epoch UTC timestamp of the first Bitstream Unit in (partial) GOP
+  int64_t end_timestamp;  // Unix epoch UTC timestamp of the (partial) GOP
 } gop_info_t;
 
 struct _signed_video_t {

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -620,12 +620,13 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
     // buffer. For all other valid Bitstream Units, simply hash and proceed.
     if (new_gop || trigger_signing) {
       gop_info->triggered_partial_gop = !new_gop;
-      if (self->sei_generation_enabled) {
-        if (timestamp) {
-          self->gop_info->timestamp = *timestamp;
-          self->gop_info->has_timestamp = true;
-        }
+      if (timestamp) {
+        gop_info->start_timestamp = gop_info->end_timestamp;
+        gop_info->end_timestamp = *timestamp;
+        gop_info->has_timestamp = true;
+      }
 
+      if (self->sei_generation_enabled) {
         uint8_t *payload = NULL;
         uint8_t *payload_signature_ptr = NULL;
 

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -165,7 +165,8 @@ validate_stream(signed_video_t *sv,
       has_timestamp |= latest->has_timestamp;
 
       if (latest->has_timestamp) {
-        ck_assert_int_eq(latest->timestamp, g_testTimestamp);
+        ck_assert_int_eq(latest->start_timestamp, g_testTimestamp);
+        ck_assert_int_eq(latest->end_timestamp, g_testTimestamp);
       }
 
       // Check if product_info has been received and set correctly.


### PR DESCRIPTION
Currently the SEI is associated with only one timestamp which
is the first Bitstream Unit of the (partial) GOP. In normal case
the I-frame. This means that, in neither the latest nor the
accumulated validation results, a correct time span for the
validated video can be displayed. By adding also an end timestamp
this can be achieved.
