### PR TITLE
Changes the order of tests in test_checks.sh

### DIFF
--- a/tests/test_checks.sh
+++ b/tests/test_checks.sh
@@ -15,17 +15,11 @@ echo ""
 meson setup -Dbuildtype=debug . build
 ninja -C build test
 
-echo "=== Run check tests without any vendors ==="
+echo ""
+echo "=== Run with threaded signing plugin (should not do anything) ==="
 echo ""
 
-meson setup -Dbuildtype=debug -Dvendors= --reconfigure . build
-ninja -C build test
-
-echo ""
-echo "=== Run check tests with all vendors and SIGNED_VIDEO_DEBUG ==="
-echo ""
-
-meson setup -Ddebugprints=true -Dbuildtype=debug -Dvendors=all --reconfigure . build
+meson setup -Dbuildtype=debug -Dsigningplugin=threaded --reconfigure . build
 ninja -C build test
 
 echo ""
@@ -35,9 +29,15 @@ echo ""
 meson setup -Ddebugprints=false -Dbuildtype=debug -Dsigningplugin=threaded_unless_check_dep --reconfigure . build
 ninja -C build test
 
-echo ""
-echo "=== Run with threaded signing plugin (should not do anything) ==="
+echo "=== Run check tests without any vendors ==="
 echo ""
 
-meson setup -Dbuildtype=debug -Dsigningplugin=threaded --reconfigure . build
+meson setup -Dbuildtype=debug -Dsigningplugin=unthreaded -Dvendors= --reconfigure . build
+ninja -C build test
+
+echo ""
+echo "=== Run check tests with all vendors and SIGNED_VIDEO_DEBUG ==="
+echo ""
+
+meson setup -Ddebugprints=true -Dbuildtype=debug -Dvendors=all --reconfigure . build
 ninja -C build test


### PR DESCRIPTION
Now the last test is a normal test with debugprints on. This
simplifies life a little bit since one can keep using ninja
and get tests run properly.
Before this change, the last setup was to use the threaded
plugin, which made no tests to run at all.
