### PR TITLE
Instead of setting the same timestamp all the time

### DIFF
--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -165,8 +165,12 @@ validate_stream(signed_video_t *sv,
       has_timestamp |= latest->has_timestamp;
 
       if (latest->has_timestamp) {
-        ck_assert_int_eq(latest->start_timestamp, g_testTimestamp);
-        ck_assert_int_eq(latest->end_timestamp, g_testTimestamp);
+        if (sv->onvif || sv->legacy_sv) {
+          // Media Signing and Legacy code only have one timestamp
+          ck_assert_int_eq(latest->start_timestamp, latest->end_timestamp);
+        } else {
+          ck_assert_int_lt(latest->start_timestamp, latest->end_timestamp);
+        }
       }
 
       // Check if product_info has been received and set correctly.

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -377,16 +377,15 @@ create_signed_stream_with_sv(signed_video_t *sv, const char *str, bool split_bu,
 
   // Loop through the Bitstream Units and add for signing.
   while (item) {
+    if (item->type == 'I' || item->type == 'P') {
+      // Increment timestamp when there is a new primary slice. Prepended SEIs will get
+      // same timestamp as the primary slice.
+      timestamp += 400000;  // One frame if 25 fps.
+    }
     int pulled_seis = 0;
     // Pull all SEIs and add them into the test stream.
     if (!get_seis_at_end || (get_seis_at_end && item->next == NULL)) {
       pulled_seis = pull_seis(sv, &item, apply_ep, delay);
-    }
-    if (item->type == 'I' || item->type == 'P') {
-      // Increment timestamp when there is a new primary slice. This is not truly correct,
-      // for example, a (prepended) SEI will now get a different timestamp as the slice.
-      // For tests though, it serves its purpose.
-      timestamp += 400000;  // One frame if 25 fps.
     }
     // If the test uses Golden SEIs, they are currently present as the first item in the stream.
     if (!(!item->prev && sv->using_golden_sei)) {

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -382,6 +382,12 @@ create_signed_stream_with_sv(signed_video_t *sv, const char *str, bool split_bu,
     if (!get_seis_at_end || (get_seis_at_end && item->next == NULL)) {
       pulled_seis = pull_seis(sv, &item, apply_ep, delay);
     }
+    if (item->type == 'I' || item->type == 'P') {
+      // Increment timestamp when there is a new primary slice. This is not truly correct,
+      // for example, a (prepended) SEI will now get a different timestamp as the slice.
+      // For tests though, it serves its purpose.
+      timestamp += 400000;  // One frame if 25 fps.
+    }
     // If the test uses Golden SEIs, they are currently present as the first item in the stream.
     if (!(!item->prev && sv->using_golden_sei)) {
       ck_assert(!signed_video_is_golden_sei(sv, item->data, item->data_size));
@@ -401,8 +407,6 @@ create_signed_stream_with_sv(signed_video_t *sv, const char *str, bool split_bu,
     }
     ck_assert_int_eq(rc, SV_OK);
     pulled_seis -= pulled_seis ? 1 : 0;
-    // TODO: Activate timestamps in tests
-    // timestamp += 400000;  // One frame if 25 fps.
 
     if (item->next == NULL) {
       if (sei) {


### PR DESCRIPTION
this commit increments the timestamp for primary slices.
Tests now verify that the end_timestamp is larger than the
start_timestamp.
