### PR TITLE
Allows for unsigned SEIs

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -440,6 +440,8 @@ sv_print_hex_data(const uint8_t *data, size_t data_size, const char *fmt, ...);
 #ifdef SIGNED_VIDEO_DEBUG
 char *
 bu_type_to_str(const bu_info_t *bu);
+svrc_t
+sv_simply_hash(signed_video_t *self, const bu_info_t *bu, uint8_t *hash, size_t hash_size);
 #endif
 
 char


### PR DESCRIPTION
To be able to support signing multiple GOPs the library
has to manage unsigned SEIs. This means that the queue
of SEIs can have some already completed SEIs as well as
SEIs waiting for the signature to be completed.

This commit changes the behavior slightly when getting
SEIs.
