### PR TITLE
Implements support for signing multiple GOPs

### DIFF
--- a/lib/src/includes/signed_video_sign.h
+++ b/lib/src/includes/signed_video_sign.h
@@ -333,6 +333,25 @@ signed_video_set_authenticity_level(signed_video_t *self,
     SignedVideoAuthenticityLevel authenticity_level);
 
 /**
+ * @brief Sets the signing frequency for this Signed Video session
+ *
+ * The default behavior of the Signed Video library is to sign and generate a SEI/OBU
+ * Metadata every GOP (Group Of Pictures). Due to hardware resource limitations and GOP
+ * length settings, signing every GOP can become infeasible in real-time. For example,
+ * when multiple streams are signed or if the GOP length is very short.
+ *
+ * This API allows the user to change the signing frequency at anytime during a session.
+ * The signing frequency is measured in number of GOPs.
+ *
+ * @param self              Pointer to the Signed Video session.
+ * @param signing_frequency Number of GOPs between signatures (default 1)
+ *
+ * @returns A Signed Video Return Code.
+ */
+SignedVideoReturnCode
+signed_video_set_signing_frequency(signed_video_t *self, unsigned signing_frequency);
+
+/**
  * @brief Sets the average recurrence interval for the signed video session in frames
  *
  * Metadata that is only needed once when validating the authenticity can be transmitted

--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -560,9 +560,10 @@ parse_bu_info(const uint8_t *bu_data,
     }
 
     remove_epb_from_sei_payload(&bu);
-    if (bu.emulation_prevention_bytes >= 0) {
+    if (bu.emulation_prevention_bytes >= 0 && (bu.hashable_data_size > bu.tlv_size)) {
       // Check if a signature TLV tag exists. If number of computed emulation prevention
-      // bytes is negative, either the SEI is currupt or incomplete.
+      // bytes is negative, either the SEI is currupt or incomplete. Or if there is enough
+      // TLV data.
       const uint8_t *signature_tag =
           sv_tlv_find_tag(bu.tlv_data, bu.tlv_size, SIGNATURE_TAG, false);
       bu.is_signed = (signature_tag != NULL);

--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -563,7 +563,9 @@ parse_bu_info(const uint8_t *bu_data,
     if (bu.emulation_prevention_bytes >= 0) {
       // Check if a signature TLV tag exists. If number of computed emulation prevention
       // bytes is negative, either the SEI is currupt or incomplete.
-      bu.is_signed = !!sv_tlv_find_tag(bu.tlv_data, bu.tlv_size, SIGNATURE_TAG, false);
+      const uint8_t *signature_tag =
+          sv_tlv_find_tag(bu.tlv_data, bu.tlv_size, SIGNATURE_TAG, false);
+      bu.is_signed = (signature_tag != NULL);
     }
     // Update |is_hashable| w.r.t. signed or not.
     bu.is_hashable |= bu.is_sv_sei && !bu.is_signed;

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -147,6 +147,7 @@ typedef struct {
   bool is_last_bu_part;  // True if the |bu_data| includes the last part
   bool with_epb;  // Hashable data may include emulation prevention bytes
   bool is_golden_sei;
+  bool is_signed;  // True if the SEI is signed, i.e., has a signature
 } bu_info_t;
 
 /**
@@ -285,6 +286,7 @@ struct _signed_video_t {
   SignedVideoAuthenticityLevel authenticity_level;
   size_t max_sei_payload_size;  // Default 0 = unlimited
   unsigned signing_frequency;  // Number of GOPs per signature (default 1)
+  unsigned num_gops_until_signing;  // Counter to track |signing_frequency|
   unsigned recurrence;
   unsigned max_signing_frames;
 

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -506,6 +506,7 @@ get_initialized_signed_video(struct sv_setting settings, bool new_private_key)
   ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings.auth_level), SV_OK);
   ck_assert_int_eq(signed_video_set_max_sei_payload_size(sv, settings.max_sei_payload_size), SV_OK);
   ck_assert_int_eq(signed_viedo_set_max_signing_frames(sv, settings.max_signing_frames), SV_OK);
+  ck_assert_int_eq(signed_video_set_signing_frequency(sv, settings.signing_frequency), SV_OK);
   ck_assert_int_eq(signed_video_set_hash_algo(sv, settings.hash_algo_name), SV_OK);
   if (settings.codec != SV_CODEC_AV1) {
     ck_assert_int_eq(signed_video_set_sei_epb(sv, settings.ep_before_signing), SV_OK);

--- a/tests/check/test_stream.c
+++ b/tests/check/test_stream.c
@@ -127,8 +127,10 @@ get_type_char(const uint8_t *data, size_t data_size, SignedVideoCodec codec)
         type = 'Z';
       else if (bu.is_golden_sei)
         type = 'G';
-      else
+      else if (bu.is_signed)
         type = 'S';
+      else
+        type = 's';
       break;
     }
     default:


### PR DESCRIPTION
Through the API signed_video_set_signing_frequency(...) the user
can specify how often GOPs should be signed. Unsigned GOPs will
still produce SEIs, but without signatures. These SEIs are
hashed like normal frames and eventually signed with the final
SEI.

A test has been added for signing multiple GOPs.
