### PR TITLE
Adds tests for signing multiple GOPs

### DIFF
--- a/tests/check/test_stream.c
+++ b/tests/check/test_stream.c
@@ -481,6 +481,40 @@ test_stream_pop(test_stream_t *list, int number_of_items)
   return new_list;
 }
 
+/* Pops |number_of_gops| from a |list| and returns a new list with these items. If there
+ * is not at least |number_of_gops| in the list NULL is returned. */
+test_stream_t *
+test_stream_pop_gops(test_stream_t *list, int number_of_gops)
+{
+  if (!list) {
+    return NULL;
+  }
+
+  // Count number of I-frames, which equals number of GOPs.
+  int num_gops_in_list = 0;
+  test_stream_item_t *item = list->first_item;
+  while (item) {
+    num_gops_in_list += item->type == 'I';
+    item = item->next;
+  }
+
+  if (num_gops_in_list < number_of_gops) {
+    return NULL;
+  }
+
+  // Create an empty list.
+  test_stream_t *new_list = test_stream_create("", list->codec);
+  ck_assert(new_list);
+  // Pop items from list and append to the new_list.
+  while (number_of_gops) {
+    test_stream_item_t *item = test_stream_pop_first_item(list);
+    test_stream_append_last_item(new_list, item);
+    number_of_gops -= list->first_item->type == 'I';  // Reached end of GOP
+  }
+
+  return new_list;
+}
+
 /* Appends a test stream to a |list|. The |list_to_append| is freed after the operation. */
 void
 test_stream_append(test_stream_t *list, test_stream_t *list_to_append)

--- a/tests/check/test_stream.h
+++ b/tests/check/test_stream.h
@@ -70,6 +70,11 @@ test_stream_free(test_stream_t *list);
 test_stream_t *
 test_stream_pop(test_stream_t *list, int number_of_items);
 
+/* Pops |number_of_gops| from a |list| and returns a new list with these items. If there
+ * is not at least |number_of_gops| in the list NULL is returned. */
+test_stream_t *
+test_stream_pop_gops(test_stream_t *list, int number_of_gops);
+
 /* Appends a list to a list. The |list_to_append| is freed after the operation. */
 void
 test_stream_append(test_stream_t *list, test_stream_t *list_to_append);


### PR DESCRIPTION
Currently all tests are disabled since validation has not yet
been implemented and the code ends up in a dead lock.

A new test function to pop complete GOPs instead of counting
items has been added.
