### PR TITLE
Use generic sv_tlv_find_and_decode_tags()

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -1022,7 +1022,10 @@ is_recurrent_data_decoded(signed_video_t *self)
     if (item->bu && item->bu->is_sv_sei && item->tmp_validation_status == 'P') {
       const uint8_t *tlv_data = item->bu->tlv_data;
       size_t tlv_size = item->bu->tlv_size;
-      recurrent_data_decoded = sv_tlv_find_and_decode_optional_tags(self, tlv_data, tlv_size);
+      size_t num_of_tags = 0;
+      const sv_tlv_tag_t *optional_tags = sv_get_optional_tags(&num_of_tags);
+      recurrent_data_decoded =
+          sv_tlv_find_and_decode_tags(self, tlv_data, tlv_size, optional_tags, num_of_tags);
     }
     item = item->next;
   }

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -1240,7 +1240,7 @@ tag_is_present(sv_tlv_tag_t tag, const sv_tlv_tag_t *tags, size_t num_of_tags)
   return false;
 }
 
-static bool
+bool
 sv_tlv_find_and_decode_tags(signed_video_t *self,
     const uint8_t *tlv_data,
     size_t tlv_data_size,
@@ -1276,17 +1276,6 @@ sv_tlv_find_and_decode_tags(signed_video_t *self,
   }
 
   return decoded_tags > 0;
-}
-
-bool
-sv_tlv_find_and_decode_optional_tags(signed_video_t *self,
-    const uint8_t *tlv_data,
-    size_t tlv_data_size)
-{
-  size_t num_of_tags = 0;
-  const sv_tlv_tag_t *optional_tags = sv_get_optional_tags(&num_of_tags);
-
-  return sv_tlv_find_and_decode_tags(self, tlv_data, tlv_data_size, optional_tags, num_of_tags);
 }
 
 const sv_tlv_tag_t *

--- a/lib/src/sv_tlv.h
+++ b/lib/src/sv_tlv.h
@@ -133,21 +133,25 @@ uint8_t
 sv_read_byte(uint16_t *last_two_bytes, const uint8_t **payload, bool do_emulation_prevention);
 
 /**
- * @brief Scans the TLV part of a SEI payload and decodes all recurrent tags
+ * @brief Scans the TLV part of a SEI payload and decodes tags
  *
  * The data is assumed to have been written in a TLV format. This function parses data and
- * finds all tags dependent on recurrency (marked not |is_always_present|) and decodes them.
+ * finds all |tags| and decodes them.
  *
  * @param self Pointer to the signed_video_t session.
  * @param tlv_data Pointer to the TLV data to scan.
  * @param tlv_data_size Size of the TLV data.
+ * @param tags An array of the TLV tags to decode.
+ * @param num_of_tags Size of the array of TLV tags.
  *
  * @return True if find and decoding tag was successful.
  */
 bool
-sv_tlv_find_and_decode_optional_tags(signed_video_t *self,
+sv_tlv_find_and_decode_tags(signed_video_t *self,
     const uint8_t *tlv_data,
-    size_t tlv_data_size);
+    size_t tlv_data_size,
+    const sv_tlv_tag_t *tags,
+    size_t num_of_tags);
 
 /**
  * @brief Helper to get only the optional tags as an array


### PR DESCRIPTION
instead of explicit function for optional tags.
