### PR TITLE
Decodes SEIs at registration

### DIFF
--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1155,12 +1155,12 @@ START_TEST(detect_change_of_public_key)
   //
   // IPPIS            ...P.                ->  (   valid)
   //    ISPPIS           ....P.            ->  (   valid)
-  //        ISPIS*           N.NP.         ->  ( invalid, key has changed, wrong link)
-  //           IS*PIS*          ...P.      ->  (   valid)
+  //        ISPIS*           N.NPN         ->  ( invalid, key has changed, wrong link)
+  //           IS*PIS*          NNNPN      ->  ( invalid)
   signed_video_accumulated_validation_t final_validation = {
       SV_AUTH_RESULT_NOT_OK, true, 16, 13, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
-  const struct validation_stats expected = {.valid_gops = 3,
-      .invalid_gops = 1,
+  const struct validation_stats expected = {.valid_gops = 2,
+      .invalid_gops = 2,
       .pending_bu = 4,
       .public_key_has_changed = true,
       .final_validation = &final_validation};


### PR DESCRIPTION
This commit change the behavior to decode the optional tags in
a SEI when being registered. After that, the signature is
verified.

Further, to avoid the risk of reading the same Public key twice
the Public key is not updated if it has changed. This is a
security precaution since change of key should never be allowed.
