### PR TITLE
Moves sv_update_hashable_data() into BU parser

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -398,9 +398,6 @@ void
 copy_bu_except_pointers(bu_info_t *dst_bu, const bu_info_t *src_bu);
 
 void
-sv_update_hashable_data(bu_info_t *bu);
-
-void
 sv_bytes_to_version_str(const int *arr, char *str);
 
 int64_t

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -445,7 +445,6 @@ complete_sei(signed_video_t *self)
     uint8_t test_hash[MAX_HASH_SIZE];
     bu_info_t test_bu_info =
         parse_bu_info(sei, sei_data->completed_sei_size, self->codec, false, true);
-    sv_update_hashable_data(&test_bu_info);
     SV_THROW(sv_simply_hash(self, &test_bu_info, test_hash, self->sign_data->hash_size));
     free(test_bu_info.nalu_data_wo_epb);
     // Borrow hash and signature from |sign_data|.

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -849,7 +849,6 @@ START_TEST(w_wo_emulation_prevention_bytes)
     ck_assert(seis[ii]);
     sei_sizes[ii] = sei_size;
     bu[ii] = parse_bu_info(seis[ii], sei_sizes[ii], codec, false, true);
-    sv_update_hashable_data(&bu[ii]);
     signed_video_free(sv);
     sv = NULL;
   }


### PR DESCRIPTION
Previously SEIs were postprocessed to update the
hashable_data_size after parsing the BU. This is now done as
part of the parsing.

The function sv_update_hashable_data() has been removed.
