### PR TITLE
Adds validation flag waiting_for_signature

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -210,6 +210,7 @@ typedef struct {
   bool hash_algo_known;  // Information on what hash algorithm to use has been received.
 
   // GOP-related flags.
+  bool waiting_for_signature;  // Validating a GOP with a SEI without signature.
   bool has_lost_sei;  // Has detected a lost SEI since last validation.
 } validation_flags_t;
 


### PR DESCRIPTION
This flag makes sure to avoid updating authenticity reports
upon unsigned SEIs.

Further, a counter has been added to avoid running into a
deadlock.
