### PR TITLE
Starts using associated_sei instead of used_in_gop_hash

### DIFF
--- a/lib/src/sv_bu_list.c
+++ b/lib/src/sv_bu_list.c
@@ -174,9 +174,9 @@ bu_list_item_print(const bu_list_item_t *item)
   memcpy(validation_status_str, &item->tmp_validation_status, 1);
 
   printf("BU type = %s\n", bu_type_str);
-  printf("validation_status = %s%s%s\n", validation_status_str,
+  printf("validation_status = %s%s%s%p\n", validation_status_str,
       (item->has_been_decoded ? ", has_been_decoded" : ""),
-      (item->used_in_gop_hash ? ", used_in_gop_hash" : ""));
+      (item->used_in_gop_hash ? ", used_in_gop_hash" : ""), item->associated_sei);
   sv_print_hex_data(item->hash, item->hash_size, "item->hash     ");
 }
 #endif
@@ -420,6 +420,7 @@ bu_list_add_missing(bu_list_t *list, int num_missing, bool append, bu_list_item_
       missing_bu->tmp_validation_status = 'M';
       missing_bu->in_validation = true;
       missing_bu->used_in_gop_hash = true;  // Belongs to the same GOP it is added to.
+      // TODO: Associate with a SEI
       if (append) {
         bu_list_item_append_item(item, missing_bu);
       } else {


### PR DESCRIPTION
When dealing with unsigned SEIs it will become important to which
SEI a frame belongs, since the final validation can only be made
once the signed SEI has been received. Therefore, a boolean is
not enough to handle signing multiple GOPs.

This commits replaces the boolean flag in associated places.
When for example removing items or adding missing items the code
still relies on the flag. These will be changed in later commits.
