### PR TITLE
Removes the used_for_linked_hash flag

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -178,7 +178,6 @@ struct _bu_list_item_t {
   // Flags
   bool has_been_decoded;  // Marks a SEI as decoded. Decoding it twice might overwrite
   // vital information.
-  bool used_for_linked_hash;
 
   // Members used when there are unsigned SEIs involved. The content of a SEI can only be
   // trusted once the signed SEI has been verified.


### PR DESCRIPTION
There is a more efficient way of detecting the BU hash that
also represents a linked hash. The first pending item should
by design be the linked hash.
