### PR TITLE
Move computing pending BUs into while loop

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -1283,6 +1283,8 @@ maybe_validate_gop(signed_video_t *self, bu_info_t *bu)
       if (!validation_flags->waiting_for_signature) {
         self->gop_info->verified_signature_hash = -1;
         validation_flags->has_auth_result = true;
+        // All statistics but pending BUs have already been collected.
+        latest->number_of_pending_picture_nalus = bu_list_num_pending_items(bu_list);
       }
       if (latest->authenticity == SV_AUTH_RESULT_NOT_SIGNED) {
         // Only report "stream is unsigned" in the accumulated report.
@@ -1305,11 +1307,12 @@ maybe_validate_gop(signed_video_t *self, bu_info_t *bu)
       update_sei_in_validation(self, false, NULL, &sei_validation_status);
       // Reset any set linked hashes if the session is still waiting for a first validation.
       reset_linked_hash(self);
+      // Re-compute number of pending BUs.
+      latest->number_of_pending_picture_nalus = bu_list_num_pending_items(bu_list);
     }
 
     if (!validation_flags->waiting_for_signature) {
       // All statistics but pending BUs have already been collected.
-      latest->number_of_pending_picture_nalus = bu_list_num_pending_items(bu_list);
       DEBUG_LOG("Validated GOP as %s", kAuthResultValidStr[latest->authenticity]);
       DEBUG_LOG(
           "Expected number of Bitstream Units = %d", latest->number_of_expected_picture_nalus);


### PR DESCRIPTION
The computation should be done when there is a signed SEI. If
the first validation fails due to an outdated SEI pending BUs
have to be re-computed.
