### PR TITLE
Validates intact stream signed with multiple GOPs

### DIFF
--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -668,7 +668,7 @@ update_num_bu_in_gop_hash(signed_video_t *self, const bu_info_t *bu)
 {
   if (!self || !bu) return;
 
-  if (!bu->is_sv_sei) {
+  if (!(bu->is_sv_sei && bu->is_signed)) {
     self->gop_info->num_in_partial_gop++;
     if (self->gop_info->num_in_partial_gop == 0) {
       DEBUG_LOG("Wraparound in |num_in_partial_gop|");

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -2752,8 +2752,6 @@ END_TEST
  * Verifies intact and tampered streams when the device signs multiple GOPs. */
 START_TEST(sign_multiple_gops)
 {
-  // Enable when validation can be made without dead lock.
-  return;
   // Device side
   struct sv_setting setting = settings[_i];
   const unsigned signing_frequency = 3;  // Sign every third GOP.


### PR DESCRIPTION
The signing side has been updated to send correct number of hashed
BUs. Also, SEI association on the validation side is removed if
a lost SEI was detected, or if the first validation failed.
