### PR TITLE
Adds a new validation flag: num_lost_seis

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -123,6 +123,11 @@ detect_lost_sei(signed_video_t *self)
   bool is_wraparound = (potentially_missed_gops + INT64_MAX) < (INT64_MAX / 2);
   if (is_wraparound) potentially_missed_gops += INT64_MAX;
 
+  // Check if any SEIs have been lost. Wraparound of 64 bits is not feasible in practice.
+  // Hence, a negative value means that an older SEI has been received.
+  // NOTE: It should not be necessary to check if |potentially_missed_gops| is outside
+  // range, since if that many GOPs has been lost that is a much more serious issue.
+  self->validation_flags.num_lost_seis = (int)potentially_missed_gops;
   // It is only possible to know if a SEI has been lost if the |current_partial_gop| is in sync.
   // Otherwise, the counter cannot be trusted.
   self->validation_flags.has_lost_sei =

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -210,6 +210,8 @@ typedef struct {
   // GOP-related flags.
   bool waiting_for_signature;  // Validating a GOP with a SEI without signature.
   bool has_lost_sei;  // Has detected a lost SEI since last validation.
+  int num_lost_seis;  // Indicates how many SEIs has been lost since last the session got
+  // the latest SEI. Note that this value can become negative if SEIs have changed order.
 } validation_flags_t;
 
 // Buffer of |last_two_bytes| and pointers to |sei| memory and current |write_position|.


### PR DESCRIPTION
This will replace the boolean has_lost_sei to be able to
handle SEIs that are in the wrong order.
