### PR TITLE
Completes some struct resets

### DIFF
--- a/lib/src/sv_authenticity.c
+++ b/lib/src/sv_authenticity.c
@@ -194,7 +194,9 @@ sv_accumulated_validation_init(signed_video_accumulated_validation_t *self)
   // after creating a session, or done on the signing side.
   if (!self) return;
 
-  self->authenticity = SV_AUTH_RESULT_NOT_SIGNED;
+  if (self->authenticity != SV_AUTH_RESULT_NOT_SIGNED) {
+    self->authenticity = SV_AUTH_RESULT_SIGNATURE_PRESENT;
+  }
   self->public_key_has_changed = false;
   self->number_of_received_nalus = 0;
   self->number_of_validated_nalus = 0;

--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -280,6 +280,9 @@ gop_info_reset(gop_info_t *gop_info)
   gop_info->list_idx = 0;
   gop_info->num_partial_gop_wraparounds = 0;
   gop_info->partial_gop_is_synced = false;
+  gop_info->current_partial_gop = 0;
+  gop_info->latest_validated_gop = 0;
+  memset(gop_info->linked_hashes, 0, MAX_HASH_SIZE * 2);
 }
 
 svrc_t
@@ -648,8 +651,13 @@ validation_flags_init(validation_flags_t *validation_flags)
 {
   if (!validation_flags) return;
 
+  bool signing_present = validation_flags->signing_present;
+  bool hash_algo_known = validation_flags->hash_algo_known;
   memset(validation_flags, 0, sizeof(validation_flags_t));
   validation_flags->is_first_validation = true;
+  validation_flags->is_first_sei = true;
+  validation_flags->signing_present = signing_present;
+  validation_flags->hash_algo_known = hash_algo_known;
 }
 
 void


### PR DESCRIPTION
Affects accumulated auth report, gop_info and validation flags.
The authenticity report "Signature present" is now only shown
once, which affects for example file scrubbing. Tests have been
updated accordingly.
