### PR TITLE
Fixes forward scrubbing

### DIFF
--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -664,7 +664,6 @@ update_validation_flags(validation_flags_t *validation_flags, bu_info_t *bu)
 {
   if (!validation_flags || !bu) return;
 
-  validation_flags->is_first_sei = !validation_flags->signing_present && bu->is_sv_sei;
   // As soon as we receive a SEI, Signed Video is present.
   validation_flags->signing_present |= bu->is_sv_sei;
 }

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -212,6 +212,7 @@ typedef struct {
   bool sei_in_sync;  // The SEIs are correctly associated with a (partial) GOP
   int num_lost_seis;  // Indicates how many SEIs has been lost since last the session got
   // the latest SEI. Note that this value can become negative if SEIs have changed order.
+  int num_invalid;  // Tracks invalid GOPs across multiple GOP validation.
   bool lost_start_of_gop;  // Tracks if an I-frame has been lost, which needs to be
   // handled as a special case if it happens for the first validation.
 } validation_flags_t;

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1220,10 +1220,6 @@ mimic_au_fast_forward_and_get_list(signed_video_t *sv, struct sv_setting setting
 
 START_TEST(fast_forward_stream_with_reset)
 {
-  // TODO: Remove when scrubbing forward works. Currently, the first SEI after a "fast
-  // forward" operation is validated as 'invalid' when it should not be validated at all.
-  // Disabling the test until it has been solved.
-  return;
   // Create a session.
   signed_video_t *sv = get_initialized_signed_video(settings[_i], false);
   ck_assert(sv);
@@ -1319,10 +1315,6 @@ mimic_au_fast_forward_on_late_seis_and_get_list(signed_video_t *sv, struct sv_se
 
 START_TEST(fast_forward_stream_with_delayed_seis)
 {
-  // TODO: Remove when scrubbing forward works. Currently, the first SEI after a "fast
-  // forward" operation is validated as 'invalid' when it should not be validated at all.
-  // Disabling the test until it has been solved.
-  return;
   // Create a new session.
   signed_video_t *sv = get_initialized_signed_video(settings[_i], false);
   ck_assert(sv);
@@ -2388,10 +2380,6 @@ END_TEST
 
 START_TEST(file_export_and_scrubbing_partial_gops)
 {
-  // TODO: Remove when scrubbing forward works. Currently, the first SEI after a "fast
-  // forward" operation is validated as 'invalid' when it should not be validated at all.
-  // Disabling the test until it has been solved.
-  return;
   // Device side
   struct sv_setting setting = settings[_i];
   const unsigned max_signing_frames = 4;


### PR DESCRIPTION
The root cause was among the validation flags, where is_first_sei
was not updated correctly.
