### PR TITLE
Enables remaining signed multiple gops tests

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -641,7 +641,7 @@ verify_hashes_without_sei(signed_video_t *self, int num_skips)
   bu_list_item_t *item = bu_list->first_item;
   while (item) {
     // Skip non-pending items
-    if (item->tmp_validation_status != 'P') {
+    if (item->tmp_validation_status != 'P' || item->associated_sei) {
       item = item->next;
       continue;
     }
@@ -649,7 +649,7 @@ verify_hashes_without_sei(signed_video_t *self, int num_skips)
     bu_info_t *bu_info = item->bu;
     // Only (added) items marked as 'missing' ('M') have no |bu_info|.
     assert(bu_info);
-    if (bu_info->is_sv_sei) {
+    if (bu_info->is_sv_sei && bu_info->is_signed) {
       // Skip counting signed SEIs since they are verified by its signature.
       item = item->next;
       continue;
@@ -685,13 +685,13 @@ verify_hashes_without_sei(signed_video_t *self, int num_skips)
   item = bu_list->first_item;
   while (item && (num_marked_items < max_marked_items)) {
     // Skip non-pending items and items already associated with a SEI.
-    if (item->tmp_validation_status != 'P') {
+    if (item->tmp_validation_status != 'P' || item->associated_sei) {
       item = item->next;
       continue;
     }
 
     bu_info_t *bu_info = item->bu;
-    if (bu_info->is_sv_sei) {
+    if (bu_info->is_sv_sei && bu_info->is_signed) {
       // Skip marking signed SEIs since they are verified by its signature.
       item = item->next;
       continue;

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -3038,8 +3038,6 @@ END_TEST
 
 START_TEST(modify_one_i_frame_multiple_gops)
 {
-  // Enable when validation can be made without dead lock.
-  return;
   // Device side
   struct sv_setting setting = settings[_i];
   const unsigned signing_frequency = 3;
@@ -3075,8 +3073,6 @@ END_TEST
 
 START_TEST(remove_one_i_frame_multiple_gops)
 {
-  // Enable when validation can be made without dead lock.
-  return;
   // Device side
   struct sv_setting setting = settings[_i];
   const unsigned signing_frequency = 3;
@@ -3116,8 +3112,6 @@ END_TEST
 
 START_TEST(modify_sei_frames_multiple_gops)
 {
-  // Enable when validation can be made without dead lock.
-  return;
   // Device side
   struct sv_setting setting = settings[_i];
   const unsigned signing_frequency = 3;
@@ -3166,8 +3160,6 @@ END_TEST
 
 START_TEST(remove_sei_frames_multiple_gops)
 {
-  // Enable when validation can be made without dead lock.
-  return;
   // Device side
   struct sv_setting setting = settings[_i];
   const unsigned signing_frequency = 3;


### PR DESCRIPTION
The function verify_hashes_without_sei has been updated to handle
unsigned SEIs.
