### PR TITLE
Removes lost_start_of_gop

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -320,10 +320,6 @@ compute_gop_hash(signed_video_t *self, bu_list_item_t *sei)
       item = item->next;
     }
     assert(item);  // Should have stopped latest at |sei|.
-    if (!gop_info->triggered_partial_gop && !item->bu->is_first_bu_in_gop) {
-      DEBUG_LOG("Lost an I-frame");
-      self->validation_flags.lost_start_of_gop = true;
-    }
     SV_THROW(sv_openssl_finalize_hash(self->crypto_handle, gop_info->computed_gop_hash, true));
     // Store number of BUs used in |computed_gop_hash|.
     self->tmp_num_in_partial_gop = num_in_partial_gop;
@@ -1211,7 +1207,6 @@ maybe_validate_gop(signed_video_t *self, bu_info_t *bu)
         latest->number_of_pending_picture_nalus = -1;
         latest->public_key_has_changed = public_key_has_changed;
         validation_flags->num_invalid = 0;
-        validation_flags->lost_start_of_gop = false;
         // Reset |in_validation|.
         update_sei_in_validation(self, true, NULL, NULL);
       }

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -213,8 +213,6 @@ typedef struct {
   int num_lost_seis;  // Indicates how many SEIs has been lost since last the session got
   // the latest SEI. Note that this value can become negative if SEIs have changed order.
   int num_invalid;  // Tracks invalid GOPs across multiple GOP validation.
-  bool lost_start_of_gop;  // Tracks if an I-frame has been lost, which needs to be
-  // handled as a special case if it happens for the first validation.
 } validation_flags_t;
 
 // Buffer of |last_two_bytes| and pointers to |sei| memory and current |write_position|.


### PR DESCRIPTION
It is not needed since there is a separate mechanism
to synchronize the first SEI.
