### PR TITLE
Correctly copies bu_info_t after processing at validation

### DIFF
--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -413,6 +413,7 @@ remove_epb_from_sei_payload(bu_info_t *bu)
     DEBUG_LOG("Failed allocating |nalu_data_wo_epb|");
     bu->is_valid = -1;
   } else {
+    bu->nalu_data_wo_epb_size = data_size;
     // Copy everything from the BU header to stop bit (byte) inclusive, but with the emulation
     // prevention bytes removed.
     const uint8_t *hashable_data_ptr = bu->hashable_data;

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -138,6 +138,7 @@ typedef struct {
   const uint8_t *tlv_data;  // Points to the TLV data after removing emulation prevention bytes
   size_t tlv_size;  // Total size of the |tlv_data|
   uint8_t *nalu_data_wo_epb;  // Temporary memory used if there are emulation prevention bytes
+  size_t nalu_data_wo_epb_size;  // Size of |nalu_data_wo_epb|
   uint32_t start_code;  // Start code or replaced by BU data size
   int emulation_prevention_bytes;  // Computed emulation prevention bytes
   bool is_primary_slice;  // The first slice in the BU or not


### PR DESCRIPTION
If hashing of a Bitstream Unit is done on data without emulation
prevention bytes, that is, after them being removed, that data
is stored in a separate memory. This memory has to be copied as
well. This is critical for signing multiple GOPs to work on the
unsigned SEIs in the beginning of a session.
