### PR TITLE
Adds a nullptr check

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -667,8 +667,7 @@ verify_hashes_without_sei(signed_video_t *self, int num_skips)
       continue;
     }
 
-    bu_info_t *bu_info = item->bu;
-    if (bu_info->is_sv_sei && bu_info->is_signed) {
+    if (item->bu && item->bu->is_sv_sei && item->bu->is_signed) {
       // Skip marking signed SEIs since they are verified by its signature.
       item = item->next;
       continue;

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -50,7 +50,7 @@
 #define DEFAULT_HASH_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v2.2.0"
+#define SIGNED_VIDEO_VERSION "v2.2.1"
 #define SV_VERSION_MAX_STRLEN 19  // Longest possible string including 'ONVIF' prefix
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '2.2.0',
+  version : '2.2.1',
   meson_version : '>= 0.53.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
This pleases Coverity. It should not be possible to become
a nullptr, but since the validation side code has become
more complex it is not a bad thing to add.

Bumps version to v2.2.1.
