### PR TITLE
Updates unsigned SEIs properly

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -889,13 +889,19 @@ update_sei_in_validation(signed_video_t *self,
       // Fetch the validation status, if not pending, before resetting tmp variable.
       if (sei->tmp_validation_status != 'P') {
         *get_validation_status = sei->tmp_validation_status;
+      } else if (!sei->bu->is_signed && sei->validation_status_if_sei_ok != ' ') {
+        *get_validation_status = sei->validation_status_if_sei_ok;
       }
       sei->tmp_validation_status = sei->validation_status;
     }
     // Set the |validation_status| unless it has been set before.
     if (set_validation_status && sei->validation_status == 'P') {
-      sei->validation_status = *set_validation_status;
-      sei->tmp_validation_status = *set_validation_status;
+      if (!sei->bu->is_signed) {
+        sei->validation_status_if_sei_ok = *set_validation_status;
+      } else {
+        sei->validation_status = *set_validation_status;
+        sei->tmp_validation_status = *set_validation_status;
+      }
     }
   }
 }


### PR DESCRIPTION
When in validation and the algorithm tries to synchronize
the SEI, reverse actions are done if syncing fails. For
unsigned SEIs the temporary operations are NOT done on
tmp_validation_status, but on validation_status_if_sei_ok.

This commit applies SEI update operations correctly for
unsigned SEIs.
