### PR TITLE
Make current_partial_gop int64_t

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -89,7 +89,7 @@ decode_sei_data(signed_video_t *self, const uint8_t *payload, size_t payload_siz
 {
   assert(self && payload && (payload_size > 0));
   gop_info_t *gop_info = self->gop_info;
-  int64_t partial_gop_number = (int64_t)gop_info->current_partial_gop;
+  int64_t partial_gop_number = gop_info->current_partial_gop;
   DEBUG_LOG("SEI payload size = %zu, exp (partial) gop number = %ld", payload_size,
       gop_info->latest_validated_gop + 1);
 
@@ -100,7 +100,7 @@ decode_sei_data(signed_video_t *self, const uint8_t *payload, size_t payload_siz
   }
 
   // Compare new with last number of GOPs to detect potential wraparound.
-  int64_t new_partial_gop_number = (int64_t)gop_info->current_partial_gop;
+  int64_t new_partial_gop_number = gop_info->current_partial_gop;
   if (new_partial_gop_number < partial_gop_number) {
     // There is a potential wraparound, but it could also be due to re-ordering of SEIs.
     // Use the distance to determine which of these options is the most likely one.
@@ -122,7 +122,7 @@ detect_lost_sei(signed_video_t *self)
   // Get the last GOP counter.
   int64_t exp_partial_gop_number = gop_info->latest_validated_gop + 1;
   // Compare new with last number of GOPs to detect potentially lost SEIs.
-  int64_t new_partial_gop_number = (int64_t)gop_info->current_partial_gop;
+  int64_t new_partial_gop_number = gop_info->current_partial_gop;
   // Compensate for counter wraparounds.
   new_partial_gop_number += (int64_t)gop_info->num_partial_gop_wraparounds << 32;
   int64_t potentially_lost_seis = new_partial_gop_number - exp_partial_gop_number;

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -255,7 +255,7 @@ typedef struct {
   // |gop_hash|.
   uint16_t num_frames_in_partial_gop;  // Counted number of frames in the current partial
   // GOP.
-  uint32_t current_partial_gop;  // The index of the current GOP, incremented when encoded in the
+  int64_t current_partial_gop;  // The index of the current GOP, incremented when encoded in the
   // TLV.
   int64_t latest_validated_gop;  // The index of latest validated GOP.
   int num_partial_gop_wraparounds;  // Tracks number of times the |current_partial_gop|

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -218,7 +218,7 @@ encode_general(signed_video_t *self, uint8_t *data)
 {
   gop_info_t *gop_info = self->gop_info;
   size_t data_size = 0;
-  uint32_t gop_counter = gop_info->current_partial_gop + 1;
+  uint32_t gop_counter = (uint32_t)(gop_info->current_partial_gop + 1);
   uint16_t num_in_partial_gop = gop_info->num_in_partial_gop;
   const uint8_t version = 4;
   int64_t start_ts = gop_info->start_timestamp;
@@ -332,8 +332,10 @@ decode_general(signed_video_t *self, const uint8_t *data, size_t data_size)
   SV_TRY()
     SV_THROW_IF(version < 1 || version > 4, SV_INCOMPATIBLE_VERSION);
 
-    data_ptr += sv_read_32bits(data_ptr, &gop_info->current_partial_gop);
-    DEBUG_LOG("Found GOP counter = %u", gop_info->current_partial_gop);
+    uint32_t gop_counter = 0;
+    data_ptr += sv_read_32bits(data_ptr, &gop_counter);
+    gop_info->current_partial_gop = gop_counter;
+    DEBUG_LOG("Found GOP counter = %ld", gop_info->current_partial_gop);
     data_ptr += sv_read_16bits(data_ptr, &gop_info->num_sent);
     DEBUG_LOG("Number of sent Bitstream Units = %u", gop_info->num_sent);
 
@@ -380,7 +382,7 @@ decode_general(signed_video_t *self, const uint8_t *data, size_t data_size)
     printf("\nGeneral Information Tag\n");
     printf("             tag version: %u\n", version);
     printf("                   flags: %u\n", flags);
-    printf("           partial GOP #: %u\n", gop_info->current_partial_gop);
+    printf("           partial GOP #: %ld\n", gop_info->current_partial_gop);
     printf("triggered by partial GOP: %s\n", gop_info->triggered_partial_gop ? "true" : "false");
     printf("# hashed Bitstream Units: %u\n", gop_info->num_sent);
     printf("              SW version: %s\n", code_version_str);


### PR DESCRIPTION
This makes it easier to track wraparounds etc. Note that the
value is still stored as an uint32_t in the TLV.
