### PR TITLE
Adds next_partial_gop counter

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -100,7 +100,7 @@ decode_sei_data(signed_video_t *self, const uint8_t *payload, size_t payload_siz
   }
 
   // Compare new with last number of GOPs to detect potential wraparound.
-  int64_t new_partial_gop_number = gop_info->current_partial_gop;
+  int64_t new_partial_gop_number = gop_info->next_partial_gop;
   if (new_partial_gop_number < partial_gop_number) {
     // There is a potential wraparound, but it could also be due to re-ordering of SEIs.
     // Use the distance to determine which of these options is the most likely one.
@@ -108,6 +108,7 @@ decode_sei_data(signed_video_t *self, const uint8_t *payload, size_t payload_siz
       gop_info->num_partial_gop_wraparounds++;
     }
   }
+  gop_info->current_partial_gop = gop_info->next_partial_gop;
 
   return status;
 }

--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -280,6 +280,7 @@ gop_info_reset(gop_info_t *gop_info)
   gop_info->list_idx = 0;
   gop_info->num_partial_gop_wraparounds = 0;
   gop_info->current_partial_gop = 0;
+  gop_info->next_partial_gop = 0;
   gop_info->latest_validated_gop = 0;
   memset(gop_info->linked_hashes, 0, MAX_HASH_SIZE * 2);
 }

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -257,6 +257,7 @@ typedef struct {
   // GOP.
   int64_t current_partial_gop;  // The index of the current GOP, incremented when encoded in the
   // TLV.
+  uint32_t next_partial_gop;  // The index of the next partial GOP (when decoding SEI).
   int64_t latest_validated_gop;  // The index of latest validated GOP.
   int num_partial_gop_wraparounds;  // Tracks number of times the |current_partial_gop|
   // has wrapped around.

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -332,10 +332,8 @@ decode_general(signed_video_t *self, const uint8_t *data, size_t data_size)
   SV_TRY()
     SV_THROW_IF(version < 1 || version > 4, SV_INCOMPATIBLE_VERSION);
 
-    uint32_t gop_counter = 0;
-    data_ptr += sv_read_32bits(data_ptr, &gop_counter);
-    gop_info->current_partial_gop = gop_counter;
-    DEBUG_LOG("Found GOP counter = %ld", gop_info->current_partial_gop);
+    data_ptr += sv_read_32bits(data_ptr, &gop_info->next_partial_gop);
+    DEBUG_LOG("Found GOP counter = %u", gop_info->next_partial_gop);
     data_ptr += sv_read_16bits(data_ptr, &gop_info->num_sent);
     DEBUG_LOG("Number of sent Bitstream Units = %u", gop_info->num_sent);
 
@@ -382,7 +380,7 @@ decode_general(signed_video_t *self, const uint8_t *data, size_t data_size)
     printf("\nGeneral Information Tag\n");
     printf("             tag version: %u\n", version);
     printf("                   flags: %u\n", flags);
-    printf("           partial GOP #: %ld\n", gop_info->current_partial_gop);
+    printf("           partial GOP #: %u\n", gop_info->next_partial_gop);
     printf("triggered by partial GOP: %s\n", gop_info->triggered_partial_gop ? "true" : "false");
     printf("# hashed Bitstream Units: %u\n", gop_info->num_sent);
     printf("              SW version: %s\n", code_version_str);


### PR DESCRIPTION
The decoded partial GOP counter is stored for later use.
Currently current_partial_gop is updated right after decode,
but later it will be updated after validation based on the
result. There could for example be missing SEIs or the SEIs
might not be synchronized.
