### PR TITLE
Removes latest_validated_gop

### DIFF
--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -281,7 +281,6 @@ gop_info_reset(gop_info_t *gop_info)
   gop_info->num_partial_gop_wraparounds = 0;
   gop_info->current_partial_gop = 0;
   gop_info->next_partial_gop = 0;
-  gop_info->latest_validated_gop = 0;
   memset(gop_info->linked_hashes, 0, MAX_HASH_SIZE * 2);
 }
 

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -258,7 +258,6 @@ typedef struct {
   int64_t current_partial_gop;  // The index of the current GOP, incremented when encoded in the
   // TLV.
   uint32_t next_partial_gop;  // The index of the next partial GOP (when decoding SEI).
-  int64_t latest_validated_gop;  // The index of latest validated GOP.
   int num_partial_gop_wraparounds;  // Tracks number of times the |current_partial_gop|
   // has wrapped around.
   int verified_signature_hash;  // Status of last hash-signature-pair verification. Has 1 for


### PR DESCRIPTION
When validating and decoding the procedure has now
changed to look forward rather than backward. The
member current_partial_gop now reflects the GOP
number that currently has been validated. It is
updated after a validation has been performed,
either with next_partial_gop or incremented if
a GOP has been lost.

The member latest_validated_gop is no longer
used, and therefore removed.
