### PR TITLE
Increment of current_partial_gop done outside TLV

### DIFF
--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -253,7 +253,7 @@ gop_info_create(void)
   gop_info_t *gop_info = (gop_info_t *)calloc(1, sizeof(gop_info_t));
   if (!gop_info) return NULL;
 
-  gop_info->current_partial_gop = 0;
+  gop_info->current_partial_gop = -1;
   // Initialize |verified_signature_hash| as 'error', since we lack data.
   gop_info->verified_signature_hash = -1;
 
@@ -279,7 +279,7 @@ gop_info_reset(gop_info_t *gop_info)
   // If a reset is forced, the stored hashes in |hash_list| have no meaning anymore.
   gop_info->list_idx = 0;
   gop_info->num_partial_gop_wraparounds = 0;
-  gop_info->current_partial_gop = 0;
+  gop_info->current_partial_gop = -1;
   gop_info->next_partial_gop = 0;
   memset(gop_info->linked_hashes, 0, MAX_HASH_SIZE * 2);
 }

--- a/lib/src/sv_sign.c
+++ b/lib/src/sv_sign.c
@@ -671,6 +671,11 @@ signed_video_add_nalu_part_for_signing_with_timestamp(signed_video_t *self,
           self->num_gops_until_signing = self->signing_frequency;
         }
       }
+      // Increment GOP counter since a new (partial) GOP is detected.
+      if (gop_info->current_partial_gop < 0) {
+        gop_info->current_partial_gop = 0;
+      }
+      gop_info->current_partial_gop++;
       if (new_gop) {
         self->num_gops_until_signing--;
       }

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -218,7 +218,7 @@ encode_general(signed_video_t *self, uint8_t *data)
 {
   gop_info_t *gop_info = self->gop_info;
   size_t data_size = 0;
-  uint32_t gop_counter = (uint32_t)(gop_info->current_partial_gop + 1);
+  uint32_t gop_counter = (uint32_t)(gop_info->current_partial_gop & 0xffffffff);
   uint16_t num_in_partial_gop = gop_info->num_in_partial_gop;
   const uint8_t version = 4;
   int64_t start_ts = gop_info->start_timestamp;
@@ -306,8 +306,6 @@ encode_general(signed_video_t *self, uint8_t *data)
   for (size_t i = 0; i < self->sign_data->hash_size; i++) {
     sv_write_byte(last_two_bytes, &data_ptr, gop_info->computed_gop_hash[i], epb);
   }
-
-  gop_info->current_partial_gop = gop_counter;
 
   return (data_ptr - data);
 }


### PR DESCRIPTION
On the signing side, the current_partial_gop was updated
when encoding the TLVs. The TLV encoding process should
not take any actions. It should solely write the current
state into the SEI.

The update is now done outside encoding. Further, the
counter is initialized to -1 instead of 0. This makes
it more clear on the validation side when the first SEI
is to be used.
