### PR TITLE
Handles reset on camera

### DIFF
--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -1093,8 +1093,6 @@ END_TEST
  */
 START_TEST(camera_reset_on_signing_side)
 {
-  // TODO: Enable when solved
-  return;
   // Generate 2 GOPs
   test_stream_t *list = create_signed_stream("IPPIPPIP", settings[_i]);
   test_stream_check_types(list, "IPPISPPISP");


### PR DESCRIPTION
A reset made on the camera will rewind the GOP counter
which on the validation side will be detected as an
old SEI. If an old SEI is detected, but the GOP hash
is correct return success.
