### PR TITLE
Makes a second (final) validation stats update

### DIFF
--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -524,14 +524,9 @@ START_TEST(modify_one_p_frame)
     //         ISPPIS                      ....P.      (  valid, 1 pending)
     //                                                           6 pending
     //             ISP                         P.P     (invalid, 3 pending)
-    expected.valid_gops = 2;  // 1;
-    expected.invalid_gops = 0;
+    expected.valid_gops = 1;
     expected.pending_bu = 6;
     expected.has_signature = 1;
-    // Temporary stats
-    expected.valid_gops_with_missing_info = 0;
-    expected.missed_bu = 0;
-    final_validation.authenticity = SV_AUTH_RESULT_OK;
   }
   validate_stream(NULL, list, expected, true);
 


### PR DESCRIPTION
If multiple GOPs are validated and the validation started
being out of sync, but sync was established, the first GOP
should no longer be ignored. Therefore, perform a final
stats update after having looped through the GOPs.
