### PR TITLE
Fixes a bug in validating legacy recordings

### DIFF
--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -1489,6 +1489,8 @@ add_bitstream_unit(signed_video_t *self, const uint8_t *bu_data, size_t bu_data_
       self->legacy_sv = legacy_sv_create(self);
       SV_THROW_IF(!self->legacy_sv, SV_MEMORY);
       sv_accumulated_validation_init(self->accumulated_validation);
+      // Hash algorithm is by definition known.
+      validation_flags->hash_algo_known = true;
     }
     if (nalus_pending_registration && validation_flags->hash_algo_known) {
       SV_THROW(reregister_bu(self));

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -50,7 +50,7 @@
 #define DEFAULT_HASH_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v2.2.2"
+#define SIGNED_VIDEO_VERSION "v2.2.3"
 #define SV_VERSION_MAX_STRLEN 19  // Longest possible string including 'ONVIF' prefix
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '2.2.2',
+  version : '2.2.3',
   meson_version : '>= 0.53.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
Hashing algorithm is by definition known is therefore set when
creating a legacy object.

Version is bumped to v2.2.3
