### PR TITLE
Adds sanity check on TLV length

### DIFF
--- a/lib/src/sv_common.c
+++ b/lib/src/sv_common.c
@@ -429,7 +429,9 @@ remove_epb_from_sei_payload(bu_info_t *bu)
       // If the SEI was hashed before applying emulation prevention, update |hashable_data|.
       bu->hashable_data = bu->nalu_data_wo_epb;
       bu->tlv_start_in_bu_data = bu->tlv_data;
-      if (bu->is_signed) {
+      if (bu->is_signed && !signature_ptr) {
+        bu->is_valid = -1;  // Something went wrong when finding the signature tag.
+      } else if (bu->is_signed) {
         bu->hashable_data_size = signature_ptr - bu->hashable_data;
       } else {
         bu->hashable_data_size = data_size;

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -50,7 +50,7 @@
 #define DEFAULT_HASH_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v2.2.3"
+#define SIGNED_VIDEO_VERSION "v2.2.4"
 #define SV_VERSION_MAX_STRLEN 19  // Longest possible string including 'ONVIF' prefix
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -1221,6 +1221,10 @@ sv_tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, sv_tlv_tag_t tag,
       length <<= 8;
       length |= sv_read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);
     }
+    if (tlv_data_ptr + length > tlv_data + tlv_data_size) {
+      DEBUG_LOG("TLV length (%u) too large", length);
+      return NULL;
+    }
     // Scan past the data
     for (int i = 0; i < length; i++) {
       sv_read_byte(&last_two_bytes, &tlv_data_ptr, with_ep);

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '2.2.3',
+  version : '2.2.4',
   meson_version : '>= 0.53.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
If the read TLV length parameter is too large, i.e., will make
reading outside memory, when finding a tag no tag is returned.
Further, when finding the signature tag a second time fails
the SEI is put in an error state with member is_valid.
