### PR TITLE
Test dummy data now supports FH + TG for AV1

### DIFF
--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -89,6 +89,7 @@ typedef enum {
   BU_TYPE_PS = 4,  // Parameter Set: PPS/SPS/VPS and similar for AV1
   BU_TYPE_AUD = 5,
   BU_TYPE_OTHER = 6,
+  BU_TYPE_TG = 7,
 } SignedVideoFrameType;
 
 typedef enum {

--- a/tests/check/check_signed_video_auth.c
+++ b/tests/check/check_signed_video_auth.c
@@ -249,8 +249,8 @@ START_TEST(invalid_api_inputs)
 
   signed_video_t *sv = signed_video_create(codec);
   ck_assert(sv);
-  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 0, codec);
-  test_stream_item_t *invalid = test_stream_item_create_from_type('X', 0, codec);
+  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 0, codec, false);
+  test_stream_item_t *invalid = test_stream_item_create_from_type('X', 0, codec, false);
 
   // signed_video_add_nalu_and_authenticate()
   // NULL pointers are invalid, as well as zero sized BUs.
@@ -1001,7 +1001,7 @@ START_TEST(add_one_sei_after_signing)
   test_stream_check_types(list, "IPPISPPPISPPISP");
 
   const uint8_t id = 0;
-  test_stream_item_t *sei = test_stream_item_create_from_type('Z', id, codec);
+  test_stream_item_t *sei = test_stream_item_create_from_type('Z', id, codec, false);
 
   // Append the middle 'P' in second GOP: IPPISP P(Z) PISPPISP
   const int append_item_number = 7;
@@ -1463,7 +1463,7 @@ END_TEST
  */
 START_TEST(onvif_seis)
 {
-  test_stream_t *list = test_stream_create("IPIOPIOP", settings[_i].codec);
+  test_stream_t *list = test_stream_create("IPIOPIOP", settings[_i].codec, false);
   if (settings[_i].codec == SV_CODEC_AV1) {
     // ONVIF Media Signing is not supported for AV1.
     test_stream_check_types(list, "IPIPIP");
@@ -1499,7 +1499,7 @@ END_TEST
  */
 START_TEST(no_signature)
 {
-  test_stream_t *list = test_stream_create("IPPIPPIPPIPPI", settings[_i].codec);
+  test_stream_t *list = test_stream_create("IPPIPPIPPIPPI", settings[_i].codec, false);
   test_stream_check_types(list, "IPPIPPIPPIPPI");
 
   // Video is not signed, hence all Bitstream Units are pending.
@@ -1519,7 +1519,7 @@ START_TEST(multislice_no_signature)
 {
   // For AV1, multi-slices are covered in one single OBU (OBU Frame).
   if (settings[_i].codec == SV_CODEC_AV1) return;
-  test_stream_t *list = test_stream_create("IiPpPpIiPpPpIiPpPpIiPpPpIi", settings[_i].codec);
+  test_stream_t *list = test_stream_create("IiPpPpIiPpPpIiPpPpIiPpPpIi", settings[_i].codec, false);
   test_stream_check_types(list, "IiPpPpIiPpPpIiPpPpIiPpPpIi");
 
   // Video is not signed, hence all Bitstream Units are pending.
@@ -1576,9 +1576,9 @@ START_TEST(vendor_axis_communications_operation)
   SignedVideoReturnCode sv_rc;
   struct sv_setting setting = settings[_i];
   SignedVideoCodec codec = settings[_i].codec;
-  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec);
-  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 1, codec);
-  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 2, codec);
+  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec, false);
+  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 1, codec, false);
+  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 2, codec, false);
   test_stream_item_t *sei_item = NULL;
   uint8_t *sei = NULL;
   size_t sei_size = 0;
@@ -1691,9 +1691,9 @@ START_TEST(factory_provisioned_key)
 #ifndef NO_ONVIF_MEDIA_SIGNING
   if (codec != SV_CODEC_AV1) return;
 #endif
-  test_stream_item_t *i_item = test_stream_item_create_from_type('I', 0, codec);
-  test_stream_item_t *p_item = test_stream_item_create_from_type('P', 1, codec);
-  test_stream_item_t *i_item_2 = test_stream_item_create_from_type('I', 2, codec);
+  test_stream_item_t *i_item = test_stream_item_create_from_type('I', 0, codec, false);
+  test_stream_item_t *p_item = test_stream_item_create_from_type('P', 1, codec, false);
+  test_stream_item_t *i_item_2 = test_stream_item_create_from_type('I', 2, codec, false);
   test_stream_item_t *sei_item = NULL;
   uint8_t *sei = NULL;
   size_t sei_size = 0;
@@ -1844,8 +1844,8 @@ generate_and_set_private_key_on_camera_side(struct sv_setting setting,
   SignedVideoReturnCode sv_rc;
   char *private_key = NULL;
   size_t private_key_size = 0;
-  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, setting.codec);
-  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, setting.codec);
+  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, setting.codec, false);
+  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, setting.codec, false);
   signed_video_t *sv = signed_video_create(setting.codec);
   ck_assert(sv);
   // Read and set content of private_key.
@@ -1894,7 +1894,7 @@ validate_public_key_scenario(signed_video_t *sv,
   signed_video_authenticity_t *auth_report = NULL;
   signed_video_latest_validation_t *latest = NULL;
 
-  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec);
+  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec, false);
   sv_rc =
       signed_video_add_nalu_and_authenticate(sv, i_frame->data, i_frame->data_size, &auth_report);
   ck_assert(!auth_report);
@@ -2028,8 +2028,8 @@ START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
 {
   SignedVideoReturnCode sv_rc;
   SignedVideoCodec codec = settings[_i].codec;
-  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec);
-  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, codec);
+  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec, false);
+  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, codec, false);
   test_stream_item_t *sei = NULL;
   signed_video_t *sv_camera = NULL;
   char *tmp_private_key = NULL;
@@ -2098,8 +2098,8 @@ START_TEST(no_emulation_prevention_bytes)
   SignedVideoReturnCode sv_rc;
 
   // Create a video with a single I-frame, and a SEI (to be created later).
-  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec);
-  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, codec);
+  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec, false);
+  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, codec, false);
 
   test_stream_item_t *sei_item = NULL;
   uint8_t *sei = NULL;
@@ -2561,7 +2561,7 @@ START_TEST(add_one_p_frame_partial_gops)
   test_stream_check_types(list, "IPPPPSPISPPISPPPPSPISP");
 
   // Add a middle 'P' in third GOP: IPPPPSPISPPISP P PPPSPISP
-  test_stream_item_t *p = test_stream_item_create_from_type('P', 100, settings[_i].codec);
+  test_stream_item_t *p = test_stream_item_create_from_type('P', 100, settings[_i].codec, false);
   const int append_item_number = 14;
   test_stream_append_item(list, p, append_item_number);
   test_stream_check_types(list, "IPPPPSPISPPISPPPPPSPISP");
@@ -3018,7 +3018,7 @@ START_TEST(add_one_p_frame_multiple_gops)
   test_stream_check_types(list, "IPPIsPPIsPPISPPIsPPIsPPISP");
 
   // Add a middle 'P' in second GOP: IPPIsP P PIsPPISPPIsPPIsPPISP
-  test_stream_item_t *p = test_stream_item_create_from_type('P', 100, settings[_i].codec);
+  test_stream_item_t *p = test_stream_item_create_from_type('P', 100, settings[_i].codec, false);
   const int append_nalu_number = 6;
   test_stream_append_item(list, p, append_nalu_number);
   test_stream_check_types(list, "IPPIsPPPIsPPISPPIsPPIsPPISP");

--- a/tests/check/check_signed_video_sign.c
+++ b/tests/check/check_signed_video_sign.c
@@ -176,8 +176,8 @@ START_TEST(api_inputs)
 {
   SignedVideoReturnCode sv_rc;
   SignedVideoCodec codec = settings[_i].codec;
-  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 0, codec);
-  test_stream_item_t *invalid = test_stream_item_create_from_type('X', 0, codec);
+  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 0, codec, false);
+  test_stream_item_t *invalid = test_stream_item_create_from_type('X', 0, codec, false);
   char *private_key = NULL;
   size_t private_key_size = 0;
   uint8_t *sei = NULL;
@@ -357,8 +357,8 @@ START_TEST(incorrect_operation)
   ck_assert(sv);
   char *private_key = NULL;
   size_t private_key_size = 0;
-  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 0, codec);
-  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec);
+  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 0, codec, false);
+  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec, false);
   // The path to openssl keys has to be set before start of signing.
   SignedVideoReturnCode sv_rc =
       signed_video_add_nalu_for_signing_with_timestamp(sv, i_frame->data, i_frame->data_size, NULL);
@@ -685,11 +685,11 @@ START_TEST(two_completed_seis_pending)
   signed_video_t *sv = get_initialized_signed_video(settings[_i], false);
   ck_assert(sv);
 
-  test_stream_item_t *i_frame_1 = test_stream_item_create_from_type('I', 0, codec);
-  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, codec);
-  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 2, codec);
-  test_stream_item_t *i_frame_3 = test_stream_item_create_from_type('I', 3, codec);
-  test_stream_item_t *i_frame_4 = test_stream_item_create_from_type('i', 4, codec);
+  test_stream_item_t *i_frame_1 = test_stream_item_create_from_type('I', 0, codec, false);
+  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, codec, false);
+  test_stream_item_t *p_frame = test_stream_item_create_from_type('P', 2, codec, false);
+  test_stream_item_t *i_frame_3 = test_stream_item_create_from_type('I', 3, codec, false);
+  test_stream_item_t *i_frame_4 = test_stream_item_create_from_type('i', 4, codec, false);
 
   sv_rc = signed_video_add_nalu_for_signing_with_timestamp(
       sv, i_frame_1->data, i_frame_1->data_size, NULL);
@@ -808,8 +808,8 @@ START_TEST(w_wo_emulation_prevention_bytes)
   uint8_t *seis[NUM_EPB_CASES] = {NULL, NULL};
   size_t sei_sizes[NUM_EPB_CASES] = {0, 0};
   bool with_emulation_prevention[NUM_EPB_CASES] = {true, false};
-  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec);
-  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, codec);
+  test_stream_item_t *i_frame = test_stream_item_create_from_type('I', 0, codec, false);
+  test_stream_item_t *i_frame_2 = test_stream_item_create_from_type('I', 1, codec, false);
 
   size_t sei_size = 0;
   unsigned num_pending_seis = 0;

--- a/tests/check/legacy_test_data.c
+++ b/tests/check/legacy_test_data.c
@@ -1301,7 +1301,7 @@ get_legacy_stream(int idx, SignedVideoCodec codec)
   // Check if this test case is valid.
   if (!legacy_data[idx][0].data || (legacy_data[idx][0].data_size == 0)) return NULL;
 
-  test_stream_t *list = test_stream_create("", codec);
+  test_stream_t *list = test_stream_create("", codec, false);
   for (int ii = 0; ii < LEGACY_STREAM_LENGTH; ii++) {
     uint8_t *data = malloc(legacy_data[idx][ii].data_size);
     memcpy(data, legacy_data[idx][ii].data, legacy_data[idx][ii].data_size);

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -369,7 +369,7 @@ create_signed_stream_with_sv(signed_video_t *sv, const char *str, bool split_bu,
   const bool apply_ep = false;  // Apply emulation prevention on generated SEI afterwards.
   const bool get_seis_at_end = false;  // Fetch all SEIs at once at the end of the stream.
   // Create a test stream given the input string.
-  test_stream_t *list = test_stream_create(str, sv->codec);
+  test_stream_t *list = test_stream_create(str, sv->codec, false);
   test_stream_item_t *item = list->first_item;
   int64_t timestamp = g_testTimestamp;
   num_gops_until_signing = sv->signing_frequency - 1;

--- a/tests/check/test_stream.h
+++ b/tests/check/test_stream.h
@@ -57,9 +57,10 @@ typedef struct _test_stream_st {
  **/
 
 /* Creates a test stream with test stream items based on the input string. The string is
- * converted to test stream items. */
+ * converted to test stream items. For AV1, one can select representing frames with
+ * OBU_FRAME or OBU_FRAME_HEADER + OBU_TILE_GROUP, the latter if |with_fh| is 'true'. */
 test_stream_t *
-test_stream_create(const char *str, SignedVideoCodec codec);
+test_stream_create(const char *str, SignedVideoCodec codec, bool with_fh);
 
 /* Frees all the items in the list and the list itself. */
 void
@@ -112,9 +113,11 @@ test_stream_print(test_stream_t *list);
  * test_stream_item_t functions
  **/
 
-/* Creates a test_stream_item_t from a |type| and |codec|. Then sets the |id|. */
+/* Creates a test_stream_item_t from a |type| and |codec|. Then sets the |id|.  For AV1,
+ * one can select representing frames with OBU_FRAME or OBU_FRAME_HEADER + OBU_TILE_GROUP,
+ * the latter if |with_fh| is 'true'.*/
 test_stream_item_t *
-test_stream_item_create_from_type(char type, uint8_t id, SignedVideoCodec codec);
+test_stream_item_create_from_type(char type, uint8_t id, SignedVideoCodec codec, bool with_fh);
 
 /* Creates a new test stream item. Takes pointers to the Bitstream Unit data, the bu data
  * size. Memory ownership is transferred. */


### PR DESCRIPTION
A test stream can now be created with FH and following TG. The
TG is represented by 't'. That is, a GOP with frame header is
written as "ItPtPtPt".
