### PR TITLE
Hashes FH+TGs together

### DIFF
--- a/.github/workflows/meson-build.yml
+++ b/.github/workflows/meson-build.yml
@@ -37,3 +37,5 @@ jobs:
       run: CK_FORK=no valgrind $GITHUB_WORKSPACE/build_lib/tests/check/unittest_sign
     - name: Run valgrind on unittest_auth
       run: CK_FORK=no valgrind $GITHUB_WORKSPACE/build_lib/tests/check/unittest_auth
+    - name: Run valgrind on unittest_av1
+      run: CK_FORK=no valgrind $GITHUB_WORKSPACE/build_lib/tests/check/unittest_av1

--- a/.github/workflows/meson-full-build.yml
+++ b/.github/workflows/meson-full-build.yml
@@ -41,3 +41,5 @@ jobs:
       run: CK_FORK=no valgrind --leak-check=full $GITHUB_WORKSPACE/build_lib/tests/check/unittest_sign
     - name: Run valgrind on unittest_auth
       run: CK_FORK=no valgrind --leak-check=full $GITHUB_WORKSPACE/build_lib/tests/check/unittest_auth
+    - name: Run valgrind on unittest_av1
+      run: CK_FORK=no valgrind $GITHUB_WORKSPACE/build_lib/tests/check/unittest_av1

--- a/lib/src/includes/signed_video_auth.h
+++ b/lib/src/includes/signed_video_auth.h
@@ -137,6 +137,7 @@ typedef struct {
   // 'v' : Parameter Set, i.e., SPS/PPS/VPS, SH
   // '_' : AUD/TD
   // 'o' : Other valid type of Bitstream Unit
+  // 't' : OBU Tile Group
   // 'U' : Undefined Bitstream Unit
   // ' ' : No Bitstream Unit present, e.g., when missing Bitstream Units are detected
 

--- a/lib/src/sv_auth.c
+++ b/lib/src/sv_auth.c
@@ -278,9 +278,12 @@ compute_gop_hash(signed_video_t *self, bu_list_item_t *sei)
       if (gop_info->triggered_partial_gop && (num_in_partial_gop >= gop_info->num_sent)) {
         break;
       }
-      // Since the GOP hash is initialized, it can be updated with each incoming BU hash.
-      SV_THROW(sv_openssl_update_hash(self->crypto_handle, item->hash, hash_size, true));
-      num_in_partial_gop++;
+      // Skip TGs since they do not have their own hash.
+      if (item->bu->bu_type != BU_TYPE_TG) {
+        // Since the GOP hash is initialized, it can be updated with each incoming BU hash.
+        SV_THROW(sv_openssl_update_hash(self->crypto_handle, item->hash, hash_size, true));
+        num_in_partial_gop++;
+      }
 
       // Mark the item and move to next.
       item->associated_sei = sei;

--- a/lib/src/sv_codec_av1.c
+++ b/lib/src/sv_codec_av1.c
@@ -79,6 +79,8 @@ parse_av1_obu_header(bu_info_t *obu)
     case 3:  // 3 OBU_FRAME_HEADER
       obu->bu_type = ((*obu_ptr & 0x60) >> 5) == 0 ? BU_TYPE_I : BU_TYPE_P;
       obu->is_primary_slice = true;
+      obu->ongoing_hash = obu->bu_type == BU_TYPE_I ? 2 : 1;
+      obu->is_fh = true;
       break;
     case 4:  // 4 OBU_TILE_GROUP
       obu->bu_type = BU_TYPE_TG;

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -150,6 +150,8 @@ typedef struct {
   bool with_epb;  // Hashable data may include emulation prevention bytes
   bool is_golden_sei;
   bool is_signed;  // True if the SEI is signed, i.e., has a signature
+  int ongoing_hash;  // Type of ongoing hash this BU is part of; 0: None, 1: P-frame, 2: I-frame
+  bool is_fh;  // True if this BU is an OBU_FRAME_HEADER. The |bu_type| indicates I- or P-frame
 } bu_info_t;
 
 /**
@@ -382,6 +384,12 @@ void
 check_and_copy_hash_to_hash_list(signed_video_t *signed_video,
     const uint8_t *hash,
     size_t hash_size);
+
+svrc_t
+sv_add_ongoing_hash(signed_video_t *self,
+    const bu_info_t *bu,
+    const bu_info_t *prev_bu,
+    uint8_t *bu_hash);
 
 svrc_t
 sv_hash_and_add(signed_video_t *self, const bu_info_t *bu);


### PR DESCRIPTION
For efficiency when transmitting the hash list hashing both the
FH and all TGs becomes quite costly. Therefore, one single hash
for the entire frame (FH+TGs) is generated.
The logic is similar to hashing when a NALU is split into
several parts. There is one major difference though, and that is
that for FH+TGs it is not known when to complete the ongoing
hash until the next frame has been detected.

Therefore, a helper function sv_add_ongoing_hash() that handles
frame transitions has been added.

The commit updates both the signing and the validation side
which keeps the test intact.
