### PR TITLE
Updates ONVIF Media Signing to r25.12.1

### DIFF
--- a/lib/src/sv_authenticity.c
+++ b/lib/src/sv_authenticity.c
@@ -464,9 +464,8 @@ transfer_onvif_latest(signed_video_latest_validation_t *latest,
       break;
   }
   latest->has_timestamp = true;
-  latest->start_timestamp = convert_1601_to_unix_us(onvif_latest->timestamp);
-  // ONVIF Media Signing currently only has one timestamp.
-  latest->end_timestamp = latest->start_timestamp;
+  latest->start_timestamp = convert_1601_to_unix_us(onvif_latest->start_timestamp);
+  latest->end_timestamp = convert_1601_to_unix_us(onvif_latest->end_timestamp);
 }
 
 static void

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -50,7 +50,7 @@
 #define DEFAULT_HASH_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v2.3.1"
+#define SIGNED_VIDEO_VERSION "v2.3.2"
 #define SV_VERSION_MAX_STRLEN 19  // Longest possible string including 'ONVIF' prefix
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME

--- a/lib/src/sv_onvif.h
+++ b/lib/src/sv_onvif.h
@@ -79,7 +79,8 @@ typedef struct {
   int number_of_pending_hashable_nalus;
   char *validation_str;
   char *nalu_str;
-  int64_t timestamp;
+  int64_t start_timestamp;
+  int64_t end_timestamp;
 } onvif_media_signing_latest_validation_t;
 // Defines onvif_media_signing_accumulated_validation_t
 typedef struct {

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '2.3.1',
+  version : '2.3.2',
   meson_version : '>= 0.53.0',
   default_options : [ 'warning_level=2',
                       'werror=true',

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -680,8 +680,8 @@ validate_stream(signed_video_t *sv,
       public_key_has_changed |= latest->public_key_has_changed;
 
       if (latest->has_timestamp) {
-        if (sv->onvif || sv->legacy_sv) {
-          // Media Signing and Legacy code only have one timestamp
+        if (sv->legacy_sv) {
+          // Legacy code only have one timestamp
           ck_assert_int_eq(latest->start_timestamp, latest->end_timestamp);
         } else {
           if (has_timestamp) {


### PR DESCRIPTION
ONVIF Media Signing has changed version numbering system.
In addition, two reported timestamps is now used.

Version bumped to v2.3.2.
