### PR TITLE
Removes possibility to add arbitrary data

### DIFF
--- a/lib/src/legacy/legacy_internal.h
+++ b/lib/src/legacy/legacy_internal.h
@@ -218,11 +218,6 @@ struct _legacy_sv_t {
   // Handle for vendor specific data. Only works with one vendor.
   void *vendor_handle;  // Borrowed from |parent|
 
-  // Arbitrary data
-  uint8_t *arbitrary_data;  // Enables the user to transmit user specific data and is automatically
-  // sent through the ARBITRARY_DATA_TAG.
-  size_t arbitrary_data_size;  // Size of |arbitrary_data|.
-
   // Status and authentication
   // Linked list to track the validation status of each added BU. Items are appended to the list
   // when added, that is, in signed_video_add_nalu_and_authenticate(). Items are removed when

--- a/lib/src/legacy/legacy_tlv.c
+++ b/lib/src/legacy/legacy_tlv.c
@@ -302,6 +302,9 @@ legacy_decode_product_info(legacy_sv_t *self, const uint8_t *data, size_t data_s
 
 /**
  * @brief Decodes the ARBITRARY_DATA_TAG from data
+ *
+ * This tag is deprecated and should not be used for new implementations. If it
+ * is present, it will not be decoded, and an error is thrown.
  */
 static svrc_t
 legacy_decode_arbitrary_data(legacy_sv_t *self, const uint8_t *data, size_t data_size)
@@ -314,25 +317,17 @@ legacy_decode_arbitrary_data(legacy_sv_t *self, const uint8_t *data, size_t data
   SV_TRY()
     SV_THROW_IF(version == 0, SV_INCOMPATIBLE_VERSION);
     SV_THROW_IF(arbdata_size == 0, SV_AUTHENTICATION_ERROR);
-    uint8_t *arbdata = realloc(self->arbitrary_data, arbdata_size);
-    SV_THROW_IF(!arbdata, SV_MEMORY);
-    memcpy(arbdata, data_ptr, arbdata_size);
-    self->arbitrary_data = arbdata;
-    self->arbitrary_data_size = arbdata_size;
-    data_ptr += arbdata_size;
-    SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
+    /* Do not decode the data, but throw an error if this is used on v2.3.4 or later. */
+    SV_THROW_IF(!is_older_than_v2_3_4(self->code_version), SV_INCOMPATIBLE_VERSION);
 #ifdef PRINT_DECODED_SEI
     printf("\nArbitrary Data Tag\n");
     printf("             tag version: %u\n", version);
     printf("     arbitrary data size: %u\n", arbdata_size);
-    sv_print_hex_data(arbdata, arbdata_size, "          arbitrary data: ");
+    sv_print_hex_data(data_ptr, arbdata_size, "          arbitrary data: ");
 #endif
+    data_ptr += arbdata_size;
+    SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
   SV_CATCH()
-  {
-    free(self->arbitrary_data);
-    self->arbitrary_data = NULL;
-    self->arbitrary_data_size = 0;
-  }
   SV_DONE(status)
 
   return status;

--- a/lib/src/sv_defines.h
+++ b/lib/src/sv_defines.h
@@ -108,8 +108,7 @@ typedef SignedVideoReturnCode svrc_t;
   svrc_t status_; \
   bool status_set_ = false;
 #define SV_CATCH() \
-  catch_error: \
-  if (!status_set_) { \
+  catch_error : if (!status_set_) { \
     DEBUG_LOG("status_ was never set, which means no THROW call was used"); \
     status_ = SV_OK; \
   } \
@@ -162,7 +161,7 @@ typedef enum {
   PRODUCT_INFO_TAG = 3,
   HASH_LIST_TAG = 4,
   SIGNATURE_TAG = 5,
-  ARBITRARY_DATA_TAG = 6,
+  ARBITRARY_DATA_TAG = 6,  // deprecated
   CRYPTO_INFO_TAG = 7,
   NUMBER_OF_TLV_TAGS = 8,
   // Vendor specific TLV tags.

--- a/lib/src/sv_internal.h
+++ b/lib/src/sv_internal.h
@@ -50,7 +50,7 @@
 #define DEFAULT_HASH_SIZE (256 / 8)
 
 #define SV_VERSION_BYTES 3
-#define SIGNED_VIDEO_VERSION "v2.3.4"
+#define SIGNED_VIDEO_VERSION "v2.3.5"
 #define SV_VERSION_MAX_STRLEN 19  // Longest possible string including 'ONVIF' prefix
 
 #define DEFAULT_AUTHENTICITY_LEVEL SV_AUTHENTICITY_LEVEL_FRAME
@@ -283,11 +283,6 @@ struct _signed_video_t {
 
   // Handle for vendor specific data. Only works with one vendor.
   void *vendor_handle;
-
-  // Arbitrary data
-  uint8_t *arbitrary_data;  // Enables the user to transmit user specific data and is automatically
-  // sent through the ARBITRARY_DATA_TAG.
-  size_t arbitrary_data_size;  // Size of |arbitrary_data|.
 
   // Members only used for signing
 

--- a/lib/src/sv_tlv.c
+++ b/lib/src/sv_tlv.c
@@ -28,6 +28,7 @@
 #include "includes/signed_video_openssl.h"  // pem_pkey_t, sign_or_verify_data_t
 #include "sv_authenticity.h"  // transfer_product_info()
 #include "sv_axis_communications.h"
+#include "sv_defines_general.h"  // ATTR_UNUSED
 #include "sv_openssl_internal.h"  // openssl_public_key_malloc()
 
 /**
@@ -149,7 +150,6 @@ static const sv_tlv_tag_t optional_tags[] = {
 static const sv_tlv_tag_t mandatory_tags[] = {
     GENERAL_TAG,
     HASH_LIST_TAG,
-    ARBITRARY_DATA_TAG,
 };
 
 /**
@@ -556,37 +556,21 @@ decode_product_info(signed_video_t *self, const uint8_t *data, size_t data_size)
 
 /**
  * @brief Encodes the ARBITRARY_DATA_TAG into data
+ *
+ * This tag is deprecated and should not be used for new implementations. Always
+ * returns 0 and does not write anything to |data|.
  */
 static size_t
-encode_arbitrary_data(signed_video_t *self, uint8_t *data)
+encode_arbitrary_data(ATTR_UNUSED signed_video_t *self, ATTR_UNUSED uint8_t *data)
 {
-  size_t data_size = 0;
-  const uint8_t version = 1;
-
-  if (!self->arbitrary_data || self->arbitrary_data_size == 0) return 0;
-
-  data_size += sizeof(version);
-
-  // Size of arbitrary_data
-  data_size += self->arbitrary_data_size;
-
-  if (!data) return data_size;
-
-  uint8_t *data_ptr = data;
-  uint16_t *last_two_bytes = &self->last_two_bytes;
-  bool epb = self->sei_epb;
-  // Version
-  sv_write_byte(last_two_bytes, &data_ptr, version, epb);
-
-  for (size_t ii = 0; ii < self->arbitrary_data_size; ++ii) {
-    sv_write_byte(last_two_bytes, &data_ptr, self->arbitrary_data[ii], epb);
-  }
-
-  return (data_ptr - data);
+  return 0;
 }
 
 /**
  * @brief Decodes the ARBITRARY_DATA_TAG from data
+ *
+ * This tag is deprecated and should not be used for new implementations. If it
+ * is present, it will not be decoded, and an error is thrown.
  */
 static svrc_t
 decode_arbitrary_data(signed_video_t *self, const uint8_t *data, size_t data_size)
@@ -599,25 +583,17 @@ decode_arbitrary_data(signed_video_t *self, const uint8_t *data, size_t data_siz
   SV_TRY()
     SV_THROW_IF(version != 1, SV_INCOMPATIBLE_VERSION);
     SV_THROW_IF(arbdata_size == 0, SV_AUTHENTICATION_ERROR);
-    uint8_t *arbdata = realloc(self->arbitrary_data, arbdata_size);
-    SV_THROW_IF(!arbdata, SV_MEMORY);
-    memcpy(arbdata, data_ptr, arbdata_size);
-    self->arbitrary_data = arbdata;
-    self->arbitrary_data_size = arbdata_size;
-    data_ptr += arbdata_size;
-    SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
+    /* Do not decode the data, but throw an error if this is used on v2.3.4 or later. */
+    SV_THROW_IF(!is_older_than_v2_3_4(self->code_version), SV_INCOMPATIBLE_VERSION);
 #ifdef PRINT_DECODED_SEI
     printf("\nArbitrary Data Tag\n");
     printf("             tag version: %u\n", version);
     printf("     arbitrary data size: %u\n", arbdata_size);
-    sv_print_hex_data(arbdata, arbdata_size, "          arbitrary data: ");
+    sv_print_hex_data(data_ptr, arbdata_size, "          arbitrary data: ");
 #endif
+    data_ptr += arbdata_size;
+    SV_THROW_IF(data_ptr != data + data_size, SV_AUTHENTICATION_ERROR);
   SV_CATCH()
-  {
-    free(self->arbitrary_data);
-    self->arbitrary_data = NULL;
-    self->arbitrary_data_size = 0;
-  }
   SV_DONE(status)
 
   return status;
@@ -1393,4 +1369,21 @@ sv_write_byte_many(uint8_t **dst,
     uint8_t ch = src[ii];
     sv_write_byte(last_two_bytes, dst, ch, do_emulation_prevention);
   }
+}
+
+bool
+is_older_than_v2_3_4(const int *code_version)
+{
+  if (code_version[0] < 2) {
+    return true;
+  } else if (code_version[0] == 2) {
+    if (code_version[1] < 3) {
+      return true;
+    } else if (code_version[1] == 3) {
+      if (code_version[2] < 4) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/lib/src/sv_tlv.h
+++ b/lib/src/sv_tlv.h
@@ -181,4 +181,14 @@ sv_get_mandatory_tags(size_t *num_of_mandatory_tags);
 sv_tlv_tag_t
 sv_get_signature_tag();
 
+/**
+ * @brief Check of version is older than v2.3.4
+ *
+ * @param code_version A pointer to an array of version numbers.
+ *
+ * @return True if the version is older than v2.3.4, false otherwise.
+ */
+bool
+is_older_than_v2_3_4(const int *code_version);
+
 #endif  // __SV_TLV_H__

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('signed-video-framework', 'c',
-  version : '2.3.4',
+  version : '2.3.5',
   meson_version : '>= 0.53.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
The arbitrary data tag is a potential attack vector. It is not
needed by Axis, hence removed. If present in a SEI, the data is
not decoded into the session. For backward compatibility,
versions older than v2.3.4, will silently continue, but newer
will throw an error.

In addition, the ONVIF Media Signing has been updated with
r25.12.2.

The version is bumped to v2.3.5.
